### PR TITLE
Adding required attribute to API Name, REST Service Name and RPC Service...

### DIFF
--- a/asset/zf-apigility-admin/partials/api/rest-services.html
+++ b/asset/zf-apigility-admin/partials/api/rest-services.html
@@ -19,7 +19,7 @@
             <div class="form-group">
               <label class="col-lg-2 control-label">REST Service Name</label>
               <div class="col-lg-10">
-                <input class="form-control" type="text" ng-model="$parent.restServiceName" placeholder="REST Service Name ...">
+                <input class="form-control" type="text" ng-model="$parent.restServiceName" placeholder="REST Service Name ..." required="">
               </div>
             </div>
           </fieldset>

--- a/asset/zf-apigility-admin/partials/api/rpc-services.html
+++ b/asset/zf-apigility-admin/partials/api/rpc-services.html
@@ -11,7 +11,7 @@
         <div class="form-group">
           <label class="col-lg-2 control-label">RPC Service Name</label>
           <div class="col-lg-10">
-            <input type="text" class="form-control" ng-model="$parent.rpcServiceName" placeholder="RPC Service Name ...">
+            <input type="text" class="form-control" ng-model="$parent.rpcServiceName" placeholder="RPC Service Name ..." required="">
           </div>
         </div>
 

--- a/view/app.phtml
+++ b/view/app.phtml
@@ -53,7 +53,7 @@
             <div class="panel-heading">Create New API</div>
             <div class="panel-body">
                 <form ng-submit="createNewApi()">
-                    <input type="text" ng-model="apiName" placeholder="API Name ...">
+                    <input type="text" ng-model="apiName" placeholder="API Name ..." required="">
                     <button type="submit" class="btn btn-sm btn-success">Create API</button>
                     <button ng-click="resetForm()" type="button" class="btn btn-sm btn-warning">Cancel</button>
                 </form>


### PR DESCRIPTION
... Name

Weird things happen if the REST Service Name input element is left blank. Added a required attribute to it and also Service Name and RPC Service Name so that the user can get some visual feedback before unwittingly sending blank data for these required fields.
