### PR TITLE
Throw exception on blank/empty resource name.

### DIFF
--- a/src/ZF/Apigility/Admin/Model/RestServiceResource.php
+++ b/src/ZF/Apigility/Admin/Model/RestServiceResource.php
@@ -85,7 +85,7 @@ class RestServiceResource extends AbstractResourceListener
         }
 
         if (empty($data['resource_name'])) {
-            throw new CreationException('Unable to create resource; resource name not provided.');
+            throw new CreationException('Unable to create REST service; resource name not provided.');
         }
 
         $type = RestServiceModelFactory::TYPE_DEFAULT;


### PR DESCRIPTION
Without this, submitting the form with just a space tries to create a
blank resource and completely breaks apigility (all API requests return
500 errors, etc because the config is corrupt with bad values).

This is really just a temporary shim for usability, but ultimately we
should do some real validation here.
