### PR TITLE
Make source path dynamic

### DIFF
--- a/src/ZF/Apigility/Admin/Model/RestServiceModel.php
+++ b/src/ZF/Apigility/Admin/Model/RestServiceModel.php
@@ -84,11 +84,6 @@ class RestServiceModel implements EventManagerAwareInterface
     protected $routeNameFilter;
 
     /**
-     * @var string
-     */
-    protected $sourcePath;
-
-    /**
      * @param  ModuleEntity $moduleEntity
      * @param  ModuleUtils $modules
      * @param  ConfigResource $config
@@ -830,10 +825,6 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     protected function getSourcePath($resourceName)
     {
-        if ($this->sourcePath) {
-            return $this->sourcePath;
-        }
-
         $sourcePath = sprintf(
             '%s/src/%s/V%s/Rest/%s',
             $this->modulePath,
@@ -846,7 +837,6 @@ class RestServiceModel implements EventManagerAwareInterface
             mkdir($sourcePath, 0777, true);
         }
 
-        $this->sourcePath = $sourcePath;
         return $sourcePath;
     }
 


### PR DESCRIPTION
When the ZF\Apigility\Model\RestServiceResource is reused the sourcePath of the object is cached thereby putting all generated classes in the first sourcePath created.  There is no benefit to caching the sourcePath so the property has been removed and will be generated every time it is required.
