### PR TITLE
Default ArraySerializable hydrator for a new REST entity

### DIFF
--- a/src/ZF/Apigility/Admin/Model/RestServiceModel.php
+++ b/src/ZF/Apigility/Admin/Model/RestServiceModel.php
@@ -626,6 +626,7 @@ class RestServiceModel implements EventManagerAwareInterface
             $entityClass => array(
                 'identifier_name' => $details->identifierName,
                 'route_name'      => $routeName,
+                'hydrator'        => 'Zend\Stdlib\Hydrator\ArraySerializable',
             ),
             $collectionClass => array(
                 'identifier_name' => $details->identifierName,

--- a/view/code-connected/rest-entity.phtml
+++ b/view/code-connected/rest-entity.phtml
@@ -3,4 +3,23 @@ namespace <?php echo $module ?>\V<?php echo $version ?>\Rest\<?php echo $resourc
 
 class <?php echo $classname ?>
 {
+    /**
+     * Export this entity to an array
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+
+    }
+
+    /**
+     * Populate this entity with data from an array
+     *
+     * @return void
+     */
+    public function exchangeArray($input)
+    {
+
+    }
 }


### PR DESCRIPTION
Add the ArraySerializable hydrator to the zf-hal config for the entity.
Add stubs for getArrayCopy and exchangeArray to the entity skeleton.

This PR addresses issue #23.
