### PR TITLE
[#22] Return a failure if the module already exists

### DIFF
--- a/src/ZF/Apigility/Admin/Model/ModuleModel.php
+++ b/src/ZF/Apigility/Admin/Model/ModuleModel.php
@@ -115,8 +115,18 @@ class ModuleModel
      */
     public function createModule($module, $path = '.')
     {
+        $application = require "$path/config/application.config.php";
+        if (is_array($application)
+            && isset($application['modules'])
+            && in_array($module, $application['modules'])
+        ) {
+            // Module already exists in configuration
+            return false;
+        }
+
         $modulePath = sprintf('%s/module/%s', $path, $module);
         if (file_exists($modulePath)) {
+            // Module already exists on this path
             return false;
 
         }
@@ -149,7 +159,6 @@ class ModuleModel
         }
 
         // Add the module in application.config.php
-        $application = require "$path/config/application.config.php";
         if (isset($application['modules']) && !in_array($module, $application['modules'])) {
             $application['modules'][] = $module;
             copy ("$path/config/application.config.php", "$path/config/application.config.old");

--- a/test/ZFTest/Apigility/Admin/Model/ModuleModelTest.php
+++ b/test/ZFTest/Apigility/Admin/Model/ModuleModelTest.php
@@ -179,6 +179,21 @@ class ModuleModelTest extends TestCase
         return true;
     }
 
+    /**
+     * @group 22
+     */
+    public function testReturnFalseWhenTryingToCreateAModuleThatAlreadyExistsInConfiguration()
+    {
+        $module     = 'Foo';
+        $modulePath = sys_get_temp_dir() . "/" . uniqid(__NAMESPACE__ . '_');
+
+        mkdir("$modulePath/module", 0777, true);
+        mkdir("$modulePath/config", 0777, true);
+        file_put_contents("$modulePath/config/application.config.php", '<' . "?php return array(\n    'modules' => array(\n        'Foo',\n    )\n);");
+
+        $this->assertFalse($this->model->createModule($module, $modulePath));
+    }
+
     public function testUpdateExistingApiModule()
     {
         $module = 'ZFTest\Apigility\Admin\Model\TestAsset\Bar';


### PR DESCRIPTION
- Previously, it only looked at the module path, not whether the module
  also existed in configuration. This change also looks at the
  application configuration.

Fixes #22
