### PR TITLE
db-connected resources created for tables that have an underscore in the name are not being fully created

### DIFF
--- a/src/ZF/Apigility/Admin/Model/DbConnectedRestServiceModel.php
+++ b/src/ZF/Apigility/Admin/Model/DbConnectedRestServiceModel.php
@@ -6,6 +6,8 @@
 
 namespace ZF\Apigility\Admin\Model;
 
+use Zend\Filter\StaticFilter;
+
 class DbConnectedRestServiceModel
 {
     /**
@@ -63,7 +65,7 @@ class DbConnectedRestServiceModel
     public function createService(DbConnectedRestServiceEntity $entity)
     {
         $restModel         = $this->restModel;
-        $resourceName      = ucfirst($entity->tableName);
+        $resourceName      = StaticFilter::execute($entity->tableName, 'WordUnderscoreToCamelCase');
         $resourceClass     = sprintf(
             '%s\\V%s\\Rest\\%s\\%sResource',
             $this->restModel->module,

--- a/test/ZFTest/Apigility/Admin/Model/DbConnectedRestServiceModelTest.php
+++ b/test/ZFTest/Apigility/Admin/Model/DbConnectedRestServiceModelTest.php
@@ -287,4 +287,21 @@ class DbConnectedRestServiceModelTest extends TestCase
         $this->assertArrayHasKey('db-connected', $config['zf-apigility']);
         $this->assertArrayNotHasKey($originalEntity->resourceClass, $config['zf-apigility']['db-connected']);
     }
+
+    public function testCreateServiceWithUnderscoreInNameNormalizesClassNamesToCamelCase()
+    {
+        $originalEntity = $this->getCreationPayload();
+        $originalEntity->exchangeArray(['table_name' => 'bar_baz']);
+
+        $result = $this->model->createService($originalEntity);
+        $this->assertSame($originalEntity, $result);
+
+        $this->assertEquals('BarConf\V1\Rest\BarBaz\Controller', $result->controllerServiceName);
+        $this->assertEquals('BarConf\V1\Rest\BarBaz\BarBazResource', $result->resourceClass);
+        $this->assertEquals('BarConf\V1\Rest\BarBaz\BarBazEntity', $result->entityClass);
+        $this->assertEquals('BarConf\V1\Rest\BarBaz\BarBazCollection', $result->collectionClass);
+        $this->assertEquals('BarConf\V1\Rest\BarBaz\BarBazResource\Table', $result->tableService);
+        $this->assertEquals('bar_baz', $result->tableName);
+        $this->assertEquals('bar-conf.rest.bar-baz', $result->routeName);
+    }
 }


### PR DESCRIPTION
Creating a REST Service with a db adapter named with underscores results in no service listed. Below an example with an API called "FirstAPI" and the following db-adapter (in the databse a table "api_user" exists):

global.php:

``` php
<?php
return array(
    'db' => array(
        'adapters' => array(
            'db_mysql_apigility' => array(),
        ),
    ),
);
```

local.php:

``` php
<?php
return array(
    'db' => array(
        'adapters' => array(
            'db_mysql_apigility' => array(
                'driver' => 'Pdo_Mysql',
                'database' => 'apigility',
                'username' => 'apigility',
                'password' => 'local',
                'hostname' => '127.0.0.1',
                'port' => '3306',
            ),
        ),
    ),
);
```

the command "ll -R module/FirstAPI/" results:

```
module/FirstAPI/:
total 24
drwxr-xr-x 5 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 5 florian florian 4096 Dez 13 16:57 ../
drwxr-xr-x 2 florian florian 4096 Dez 13 16:33 config/
-rw-r--r-- 1 florian florian   51 Dez 13 16:33 Module.php
drwxr-xr-x 3 florian florian 4096 Dez 13 16:33 src/
drwxr-xr-x 2 florian florian 4096 Dez 13 16:33 view/

module/FirstAPI/config:
total 12
drwxr-xr-x 2 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 5 florian florian 4096 Dez 13 16:33 ../
-rw-r--r-- 1 florian florian 3186 Dez 13 16:50 module.config.php

module/FirstAPI/src:
total 12
drwxr-xr-x 3 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 5 florian florian 4096 Dez 13 16:33 ../
drwxr-xr-x 3 florian florian 4096 Dez 13 16:33 FirstAPI/

module/FirstAPI/src/FirstAPI:
total 16
drwxr-xr-x 3 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 3 florian florian 4096 Dez 13 16:33 ../
-rw-r--r-- 1 florian florian  499 Dez 13 16:33 Module.php
drwxr-xr-x 4 florian florian 4096 Dez 13 16:33 V1/

module/FirstAPI/src/FirstAPI/V1:
total 16
drwxr-xr-x 4 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 3 florian florian 4096 Dez 13 16:33 ../
drwxr-xr-x 3 florian florian 4096 Dez 13 16:50 Rest/
drwxr-xr-x 2 florian florian 4096 Dez 13 16:33 Rpc/

module/FirstAPI/src/FirstAPI/V1/Rest:
total 12
drwxr-xr-x 3 florian florian 4096 Dez 13 16:50 ./
drwxr-xr-x 4 florian florian 4096 Dez 13 16:33 ../
drwxr-xr-x 2 florian florian 4096 Dez 13 16:50 Api_user/

module/FirstAPI/src/FirstAPI/V1/Rest/Api_user:
total 16
drwxr-xr-x 2 florian florian 4096 Dez 13 16:50 ./
drwxr-xr-x 3 florian florian 4096 Dez 13 16:50 ../
-rw-r--r-- 1 florian florian  122 Dez 13 16:50 Api_userCollection.php
-rw-r--r-- 1 florian florian  107 Dez 13 16:50 Api_userEntity.php

module/FirstAPI/src/FirstAPI/V1/Rpc:
total 8
drwxr-xr-x 2 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 4 florian florian 4096 Dez 13 16:33 ../

module/FirstAPI/view:
total 8
drwxr-xr-x 2 florian florian 4096 Dez 13 16:33 ./
drwxr-xr-x 5 florian florian 4096 Dez 13 16:33 ../
```

The command "cat module/FirstAPI/config/module.config.php" gives me:

``` php
<?php
return array(
    'zf-mvc-auth' => array(
        'authorization' => array(),
    ),
    'router' => array(
        'routes' => array(
            'first-api.rest.api_user' => array(
                'type' => 'Segment',
                'options' => array(
                    'route' => '/api_user[/:api_user_id]',
                    'defaults' => array(
                        'controller' => 'FirstAPI\\V1\\Rest\\Api_user\\Controller',
                    ),
                ),
            ),
        ),
    ),
    'zf-versioning' => array(
        'uri' => array(
            0 => 'first-api.rest.api_user',
        ),
    ),
    'zf-rest' => array(
        'FirstAPI\\V1\\Rest\\Api_user\\Controller' => array(
            'listener' => 'FirstAPI\\V1\\Rest\\Api_user\\Api_userResource',
            'route_name' => 'first-api.rest.api_user',
            'identifier_name' => 'api_user_id',
            'collection_name' => 'api_user',
            'resource_http_methods' => array(
                0 => 'GET',
                1 => 'PATCH',
                2 => 'PUT',
                3 => 'DELETE',
            ),
            'collection_http_methods' => array(
                0 => 'GET',
                1 => 'POST',
            ),
            'collection_query_whitelist' => array(),
            'page_size' => 25,
            'page_size_param' => null,
            'entity_class' => 'FirstAPI\\V1\\Rest\\Api_user\\Api_userEntity',
            'collection_class' => 'FirstAPI\\V1\\Rest\\Api_user\\Api_userCollection',
        ),
    ),
    'zf-content-negotiation' => array(
        'controllers' => array(
            'FirstAPI\\V1\\Rest\\Api_user\\Controller' => 'HalJson',
        ),
        'accept_whitelist' => array(
            'FirstAPI\\V1\\Rest\\Api_user\\Controller' => array(
                0 => 'application/vnd.first-api.v1+json',
                1 => 'application/hal+json',
                2 => 'application/json',
            ),
        ),
        'content_type_whitelist' => array(
            'FirstAPI\\V1\\Rest\\Api_user\\Controller' => array(
                0 => 'application/vnd.first-api.v1+json',
                1 => 'application/json',
            ),
        ),
    ),
    'zf-hal' => array(
        'metadata_map' => array(
            'FirstAPI\\V1\\Rest\\Api_user\\Api_userEntity' => array(
                'identifier_name' => 'api_user_id',
                'route_name' => 'first-api.rest.api_user',
                'hydrator' => 'ArraySerializable',
            ),
            'FirstAPI\\V1\\Rest\\Api_user\\Api_userCollection' => array(
                'identifier_name' => 'api_user_id',
                'route_name' => 'first-api.rest.api_user',
                'is_collection' => true,
            ),
        ),
    ),
    'zf-apigility' => array(
        'db-connected' => array(
            'FirstAPI\\V1\\Rest\\Api_user\\Api_userResource' => array(
                'adapter_name' => 'db_mysql_apigility',
                'table_name' => 'api_user',
                'hydrator_name' => 'ArraySerializable',
                'controller_service_name' => 'FirstAPI\\V1\\Rest\\Api_user\\Controller',
            ),
        ),
    ),
);
```
