### PR TITLE
Potential fix for lack of uniqueness in validator ids

### DIFF
--- a/asset/zf-apigility-admin/js/app.js
+++ b/asset/zf-apigility-admin/js/app.js
@@ -1065,6 +1065,13 @@ module.filter('servicename', function () {
     }
 });
 
+// Used to strip out the backslash characters to use as a part of a class id
+module.filter('namespaceclassid', function () {
+    return function (input) {
+        return input.replace(/\\/g, '');
+    };
+});
+
 module.run(['$rootScope', '$routeParams', '$location', function ($rootScope, $routeParams, $location) {
     $rootScope.routeParams = $routeParams;
 

--- a/asset/zf-apigility-admin/partials/api/services-input.html
+++ b/asset/zf-apigility-admin/partials/api/services-input.html
@@ -14,7 +14,7 @@
         <div class="panel panel-default" ng-repeat="input in service.input_filter">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <button type="button" class="accordion-toggle btn" data-toggle="collapse" data-parent="inputAccordion" data-target="#inputCollapse{{$index}}"><span class="glyphicon glyphicon-wrench"></span></button>
+                    <button type="button" class="accordion-toggle btn" data-toggle="collapse" data-parent="inputAccordion" data-target="#inputCollapse{{ restService.entity_class | namespaceclassid }}{{input.name}}{{$index}}"><span class="glyphicon glyphicon-wrench"></span></button>
                     <a ng-click="input._editNameVisible = true" ng-hide="input._editNameVisible">
                         {{input.name}}
                     </a>
@@ -30,7 +30,7 @@
                 <div class="clearfix"></div>
             </div>
 
-            <div id="inputCollapse{{$index}}" class="panel-collapse collapse">
+            <div id="inputCollapse{{ restService.entity_class | namespaceclassid }}{{input.name}}{{$index}}" class="panel-collapse collapse">
                 <div class="panel-body">
                     <div class="pull-right">
                         <button type="button" class="btn btn-sm btn-success" ng-click="input._newValidatorFormVisible = true">Add Validator</button>


### PR DESCRIPTION
Potential fix for issue #51. I added a custom filter to remove backspaces from the namespaced class name and then use the combination of classname, fieldname and the counter to hopefully ensure uniqueness. Fieldname and counter were close but if two services in the same api used the same field names in the same positions, the second one would not work in the UI. This _should_ be more unique and allow the UI to behave as expected. The input.name part may not even be needed as I expect there's already validation ensuring that you don't enter the same input name more than once per service.

As a side note, I tried replacing \ with : but it seems angular or something didn't like toggling things that had colons in the id, but taking out the namespace separators worked. 
