### PR TITLE
Convert string ‘false’ and ‘true’ to booleans before it’s sent into the ...

### DIFF
--- a/asset/zf-apigility-admin/js/app.js
+++ b/asset/zf-apigility-admin/js/app.js
@@ -610,6 +610,9 @@ module.controller('ApiServiceInputController', ['$scope', function ($scope) {
     };
 
     $scope.addOption = function (validator) {
+        if (typeof validator._newOptionValue == 'string' && (validator._newOptionValue === 'true' || validator._newOptionValue === 'false')) {
+            validator._newOptionValue = (validator._newOptionValue === 'true');
+        }
         validator.options[validator._newOptionName] = validator._newOptionValue;
         validator._newOptionName = '';
         validator._newOptionValue = '';


### PR DESCRIPTION
...API to allow boolean options on validators to work properly.

This is another approach to fix issue #44, but arguably a more elegant one since this doesn't prevent the API from ever receiving and using strings of 'true' and 'false' for option values, it just makes it so the apigility admin ui can't do it.
