### PR TITLE
Update AbstractPluginManagerModel.php

### DIFF
--- a/src/ZF/Apigility/Admin/Model/AbstractPluginManagerModel.php
+++ b/src/ZF/Apigility/Admin/Model/AbstractPluginManagerModel.php
@@ -50,10 +50,18 @@ class AbstractPluginManagerModel
             return $this->plugins;
         }
 
-        $this->plugins  = [];
-        foreach ($this->pluginManager->getCanonicalNames() as $name => $canonical) {
+        // Add invokableClasses via reflection
+        $reflClass = new \ReflectionClass($this->pluginManager);
+        $reflProp  = $reflClass->getProperty('invokableClasses');
+        $reflProp->setAccessible(true);
+
+        $invokables = array_flip($reflProp->getValue($this->pluginManager));
+        $plugins    = array_merge($invokables, $this->pluginManager->getCanonicalNames());
+
+        foreach ($plugins as $name => $canonical) {
             $this->plugins[] = $name;
         }
+
         sort($this->plugins, SORT_STRING);
         return $this->plugins;
     }


### PR DESCRIPTION
This fixes two issues:
1. The previous behavior would overwrite keys because of the array addition which could potentially cause less hydrators to show than really available.
2. It uses the getCanonicalNames() method of the service manager to return the full display name which makes it a lot easier to view in the dropdown.
