### PR TITLE
Skip cache reset if built-in webserver

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -527,6 +527,12 @@ class Module
      */
     protected function resetCache()
     {
+        $phpServerString = 'PHP ' . PHP_VERSION . ' Development Server';
+        if (isset($_SERVER['SERVER_SOFTWARE']) && $_SERVER['SERVER_SOFTWARE'] == $phpServerString) {
+            // skip the built-in PHP webserver (OPcache reset is not needed + it crashes the server in PHP 5.4 with ZendOptimizer+)
+            return;
+        }
+        
         if (function_exists('opcache_reset')) {
             // >= PHP 5.5.0
             opcache_reset();


### PR DESCRIPTION
in PHP 5.4 with ZendOptimizer+ the built-in webserver crashes.

So now the reset is skipped, if the built-in webserver is present.
