### PR TITLE
Enabling adapter literal definition in Db Validators

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -935,14 +935,14 @@ return array(
             'format' => 'string',
             'basevalue' => 'string|int',
         ),
-        'ZF\ContentValidation\Validator\Db\NoRecordExists' => array(
+        'ZF\ContentValidation\Validator\DbNoRecordExists' => array(
         	'adapter' => 'string',
             'table' => 'string',
             'schema' => 'string',
             'field' => 'string',
             'exclude' => 'string',
         ),
-        'ZF\ContentValidation\Validator\Db\RecordExists' => array(
+        'ZF\ContentValidation\Validator\DbRecordExists' => array(
         	'adapter' => 'string',
             'table' => 'string',
             'schema' => 'string',


### PR DESCRIPTION
Changed the  Zend\Validator\Db\RecordExists and Zend\Validator\Db\NoRecordExists with the ones implemented in my PR in zf-content-validation.
Added a text input for setting the adapter in the validator definition
![capture decran 2014-02-27 a 16 16 44](https://f.cloud.github.com/assets/5320213/2283838/5579af6c-9fc2-11e3-9361-192b84fb82ef.png)
