### PR TITLE
Switch from `input_filters` to `input_filter_specs`

### DIFF
--- a/src/ZF/Apigility/Admin/Model/InputFilterModel.php
+++ b/src/ZF/Apigility/Admin/Model/InputFilterModel.php
@@ -86,7 +86,7 @@ class InputFilterModel
         }
 
         $validator = $config['zf-content-validation'][$controller]['input_filter'];
-        if (!array_key_exists($validator, $config['input_filters'])) {
+        if (!array_key_exists($validator, $config['input_filter_specs'])) {
             return false;
         }
 
@@ -96,14 +96,14 @@ class InputFilterModel
 
         // Retrieving the input filter by name
         if ($inputFilterName && $inputFilterName === $validator) {
-            $inputFilter = new $entityType($config['input_filters'][$inputFilterName]);
+            $inputFilter = new $entityType($config['input_filter_specs'][$inputFilterName]);
             $inputFilter['input_filter_name'] = $inputFilterName;
             return $inputFilter;
         }
 
         // Retrieving a collection
         $collection  = new $collectionType();
-        $inputFilter = new $entityType($config['input_filters'][$validator]);
+        $inputFilter = new $entityType($config['input_filter_specs'][$validator]);
         $inputFilter['input_filter_name'] = $validator;
         $collection->enqueue($inputFilter);
         return $collection;
@@ -134,23 +134,23 @@ class InputFilterModel
 
         $validator = $config['zf-content-validation'][$controller]['input_filter'];
 
-        if (!isset($config['input_filters'])) {
-            $config['input_filters'] = array();
+        if (!isset($config['input_filter_specs'])) {
+            $config['input_filter_specs'] = array();
         }
 
-        if (!isset($config['input_filters'][$validator])) {
-            $config['input_filters'][$validator] = array();
+        if (!isset($config['input_filter_specs'][$validator])) {
+            $config['input_filter_specs'][$validator] = array();
         }
 
-        $config['input_filters'][$validator] = $inputFilter;
+        $config['input_filter_specs'][$validator] = $inputFilter;
 
-        $updated = $configModule->patchKey(array('input_filters', $validator), $inputFilter);
+        $updated = $configModule->patchKey(array('input_filter_specs', $validator), $inputFilter);
         if (!is_array($updated)) {
             return false;
         }
 
         $entityType = $this->getEntityType($controller);
-        $return = new $entityType($updated['input_filters'][$validator]);
+        $return = new $entityType($updated['input_filter_specs'][$validator]);
         $return['input_filter_name'] = $validator;
         return $return;
     }
@@ -173,7 +173,7 @@ class InputFilterModel
         $config       = $configModule->fetch(true);
         $validator    = $config['zf-content-validation'][$controller]['input_filter'];
 
-        if (!isset($config['input_filters'][$validator])) {
+        if (!isset($config['input_filter_specs'][$validator])) {
             return false;
         }
 
@@ -181,11 +181,11 @@ class InputFilterModel
             return false;
         }
 
-        unset($config['input_filters'][$validator]);
+        unset($config['input_filter_specs'][$validator]);
         unset($config['zf-content-validation'][$controller]['input_filter']);
 
-        if (empty($config['input_filters'])) {
-            unset($config['input_filters']);
+        if (empty($config['input_filter_specs'])) {
+            unset($config['input_filter_specs']);
         }
 
         if (empty($config['zf-content-validation'][$controller])) {

--- a/src/ZF/Apigility/Admin/Model/VersioningModel.php
+++ b/src/ZF/Apigility/Admin/Model/VersioningModel.php
@@ -238,7 +238,7 @@ class VersioningModel
             ), true);
         }
 
-        // update zf-content-validation and input_filters
+        // update zf-content-validation and input_filter_specs
         if (isset($config['zf-content-validation'])) {
             $newValues = $this->changeVersionArray($config['zf-content-validation'], $previous, $version);
             $this->configResource->patch(array(
@@ -246,10 +246,10 @@ class VersioningModel
             ), true);
         }
 
-        if (isset($config['input_filters'])) {
-            $newValues = $this->changeVersionArray($config['input_filters'], $previous, $version);
+        if (isset($config['input_filter_specs'])) {
+            $newValues = $this->changeVersionArray($config['input_filter_specs'], $previous, $version);
             $this->configResource->patch(array(
-                'input_filters' => $newValues
+                'input_filter_specs' => $newValues
             ), true);
         }
 
@@ -395,8 +395,8 @@ class VersioningModel
 
     /**
      * Update the documentation to add a new $version based on the $previous
-     * 
-     * @param  string $module 
+     *
+     * @param  string $module
      * @param  integer $previous Previous version
      * @param  integer $version New version
      * @return true

--- a/test/ZFTest/Apigility/Admin/Controller/InputFilterControllerTest.php
+++ b/test/ZFTest/Apigility/Admin/Controller/InputFilterControllerTest.php
@@ -83,7 +83,7 @@ class InputFilterControllerTest extends TestCase
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\InputFilterEntity', $inputFilter);
 
         $inputFilterKey = $this->config['zf-content-validation'][$controller]['input_filter'];
-        $expected = $this->config['input_filters'][$inputFilterKey];
+        $expected = $this->config['input_filter_specs'][$inputFilterKey];
         $expected['input_filter_name'] = $inputFilterKey;
         $this->assertEquals($expected, $inputFilter->getArrayCopy());
     }
@@ -118,7 +118,7 @@ class InputFilterControllerTest extends TestCase
         $entity = $payload->entity;
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\InputFilterEntity', $entity);
 
-        $expected = $this->config['input_filters'][$validator];
+        $expected = $this->config['input_filter_specs'][$validator];
         $expected['input_filter_name'] = $validator;
         $this->assertEquals($expected, $entity->getArrayCopy());
     }
@@ -179,7 +179,7 @@ class InputFilterControllerTest extends TestCase
 
         $config    = include $this->basePath . '/module.config.php';
         $validator = $config['zf-content-validation'][$controller]['input_filter'];
-        $expected  = $config['input_filters'][$validator];
+        $expected  = $config['input_filter_specs'][$validator];
         $expected['input_filter_name'] = $validator;
         $this->assertEquals($expected, $entity->getArrayCopy());
     }

--- a/test/ZFTest/Apigility/Admin/Model/InputFilterModelTest.php
+++ b/test/ZFTest/Apigility/Admin/Model/InputFilterModelTest.php
@@ -55,7 +55,7 @@ class InputFilterModelTest extends TestCase
         $this->assertEquals(1, count($result));
         $inputFilter = $result->dequeue();
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\InputFilterEntity', $inputFilter);
-        $this->assertEquals($this->config['input_filters']['InputFilter\V1\Rest\Foo\Validator']['foo'], $inputFilter['foo']);
+        $this->assertEquals($this->config['input_filter_specs']['InputFilter\V1\Rest\Foo\Validator']['foo'], $inputFilter['foo']);
     }
 
     public function testAddInputFilterExistingController()

--- a/test/ZFTest/Apigility/Admin/Model/TestAsset/module/InputFilter/config/module.config.php
+++ b/test/ZFTest/Apigility/Admin/Model/TestAsset/module/InputFilter/config/module.config.php
@@ -1,6 +1,6 @@
 <?php
 return array(
-    'input_filters' => array(
+    'input_filter_specs' => array(
         'InputFilter\V1\Rest\Foo\Validator' => array(
             'foo' => array(
                 'name' => 'foo',

--- a/test/ZFTest/Apigility/Admin/Model/TestAsset/module/Version/config/module.config.php.dist
+++ b/test/ZFTest/Apigility/Admin/Model/TestAsset/module/Version/config/module.config.php.dist
@@ -22,7 +22,7 @@ return array (
             ),
         ),
     ),
-    'input_filters' => array(
+    'input_filter_specs' => array(
         'Version\\V1\\Rest\\Message\\Validator' => array(
             array(
                 'name' => 'email',

--- a/test/ZFTest/Apigility/Admin/Model/VersioningModelTest.php
+++ b/test/ZFTest/Apigility/Admin/Model/VersioningModelTest.php
@@ -197,8 +197,8 @@ class VersioningModelTest extends TestCase
         $this->assertArrayHasKey('zf-content-validation', $originalConfig);
         $this->assertArrayHasKey('Version\V1\Rest\Message\Controller', $originalConfig['zf-content-validation']);
         $this->assertArrayHasKey('input_filter', $originalConfig['zf-content-validation']['Version\V1\Rest\Message\Controller']);
-        $this->assertArrayHasKey('input_filters', $originalConfig);
-        $this->assertArrayHasKey('Version\V1\Rest\Message\Validator', $originalConfig['input_filters']);
+        $this->assertArrayHasKey('input_filter_specs', $originalConfig);
+        $this->assertArrayHasKey('Version\V1\Rest\Message\Validator', $originalConfig['input_filter_specs']);
 
         $result = $this->model->createVersion('Version', 2, __DIR__ . '/TestAsset/module/Version/src/Version');
 
@@ -213,10 +213,10 @@ class VersioningModelTest extends TestCase
         $this->assertArrayHasKey('input_filter', $updatedConfig['zf-content-validation']['Version\V2\Rest\Message\Controller']);
         $this->assertEquals('Version\V2\Rest\Message\Validator', $updatedConfig['zf-content-validation']['Version\V2\Rest\Message\Controller']['input_filter']);
 
-        $this->assertArrayHasKey('input_filters', $updatedConfig);
-        $this->assertArrayHasKey('Version\V1\Rest\Message\Validator', $updatedConfig['input_filters']);
-        $this->assertArrayHasKey('Version\V2\Rest\Message\Validator', $updatedConfig['input_filters']);
-        $this->assertEquals($updatedConfig['input_filters']['Version\V1\Rest\Message\Validator'], $updatedConfig['input_filters']['Version\V2\Rest\Message\Validator']);
+        $this->assertArrayHasKey('input_filter_specs', $updatedConfig);
+        $this->assertArrayHasKey('Version\V1\Rest\Message\Validator', $updatedConfig['input_filter_specs']);
+        $this->assertArrayHasKey('Version\V2\Rest\Message\Validator', $updatedConfig['input_filter_specs']);
+        $this->assertEquals($updatedConfig['input_filter_specs']['Version\V1\Rest\Message\Validator'], $updatedConfig['input_filter_specs']['Version\V2\Rest\Message\Validator']);
     }
 
     public function testSettingTheApiDefaultVersion()


### PR DESCRIPTION
Follows on zfcampus/zf-content-validation#10 - which moves the configuration
for the input filter abstract factory to the key `input_filter_specs`. All
changes happen at the domain model layer, requiring no changes to the API or
UI.
