### PR TITLE
Fresh install fails to load admin ui with JS errors

### DIFF
--- a/asset/Gruntfile.js
+++ b/asset/Gruntfile.js
@@ -209,6 +209,18 @@ module.exports = function(grunt) {
         }
     });
 
+    grunt.registerTask('monkeyPatches', function () {
+        // monkeypatch FileProcessor to include utf-8
+        var FileProcessor = require('grunt-usemin/lib/fileprocessor');
+        FileProcessor.prototype.replaceWithOld = FileProcessor.prototype.replaceWith;
+        FileProcessor.prototype.replaceWith = function replaceWith(block) {
+            var script = FileProcessor.prototype.replaceWithOld(block);
+            if (script.match(/<script src/)) {
+                script = script.replace('></script>', ' charset="utf-8"></script>');
+            }
+            return script;
+        };
+    });
 
     grunt.registerTask('serve', function(target) {
         grunt.task.run([
@@ -233,6 +245,7 @@ module.exports = function(grunt) {
         'copy:dist',
         'cssmin',
         'uglify',
+        'monkeyPatches',
         'usemin'
     ]);
 


### PR DESCRIPTION
Uncaught SyntaxError: Unexpected token ILLEGAL /zf-apigility-admin/js/vendor-ui.js:11

Uncaught Error: [$injector:modulerr] Failed to instantiate module ag-admin due to:
Error: [jqLite:nosel] Looking up elements via selectors is not supported by jqLite! See: http://docs.angularjs.org/api/angular.element
http://errors.angularjs.org/1....<omitted>...5) vendor-angular.js:1

Tried fresh install via composer, tar, curl, and git clone all produce same result.  I'm running Zend Server 6.3.0, Apache 2.2.26 with PHP 5.3.28. Browser Chrome 33 and Safari 7.0.3.
