### PR TITLE
Validation error when updating DB-Connected service

### DIFF
--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -18,7 +18,7 @@ class PatchInputFilter extends PostInputFilter
         $this->add(array(
             'name' => 'resource_class',
             'required' => true,
-            'allow_empty' => false,
+            'allow_empty' => true,
             'error_message' => 'The Resource Class must be a valid class name',
         ));
         $this->add(array(

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -135,7 +135,7 @@ class PatchInputFilterTest extends TestCase
                 'collection_name',
                 'entity_class',
                 'entity_identifier_name',
-                'resource_class',
+                // 'resource_class', // Resource class is allowed to be empty
                 'route_identifier_name',
                 'route_match',
             )),


### PR DESCRIPTION
Starting with beta3, and due to changes introduced for #149, updating a DB-Connected service results in a validation error due to the `resource_class` field being empty. This field should be marked `allow_empty`.
