### PR TITLE
Creating new API fails on IE

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -69,7 +69,8 @@ return array(
                         'options' => array(
                             'route' => '/api',
                             'defaults' => array(
-                                'action' => false,
+                                'is_apigility_admin_api' => true,
+                                'action'                 => false,
                             ),
                         ),
                         'may_terminate' => false,


### PR DESCRIPTION
Creating new API fails when using Internet Explorer. I get an red error message at the bottom: "API <name> not found". 

I can successfully create APIs when using Chrome on the very same Apigility skeleton running on the same PHP built-in server instance.

However, the it seems that the API is created on the file system, but Apigility Admin running in IE cannot read it back. If I load/refresh Apigility Admin in Chrome then the API created in IE appears.

IE version is: 10.0.9200.16576
