### PR TITLE
[#177] Ensure DB-Connected configuration is properly updated

### DIFF
--- a/src/Model/DbConnectedRestServiceModel.php
+++ b/src/Model/DbConnectedRestServiceModel.php
@@ -123,6 +123,14 @@ class DbConnectedRestServiceModel
     public function updateService(DbConnectedRestServiceEntity $entity)
     {
         $updatedEntity  = $this->restModel->updateService($entity);
+
+        // We need the resource class in order to update db-connected config!
+        if (! $entity->resourceClass && $updatedEntity->resourceClass) {
+            $entity->exchangeArray(array(
+                'resource_class' => $updatedEntity->resourceClass,
+            ));
+        }
+
         $updatedProps   = $this->updateDbConnectedConfig($entity);
         $updatedEntity->exchangeArray($updatedProps);
         $this->updateHalConfig($entity);

--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -320,7 +320,7 @@ class RestServiceModel implements EventManagerAwareInterface
         $controllerService = $update->controllerServiceName;
 
         try {
-            $original = $this->fetch($controllerService);
+            $original = $this->fetch($controllerService, false);
         } catch (Exception\RuntimeException $e) {
             throw new Exception\RuntimeException(sprintf(
                 'Cannot update REST service "%s"; not found',
@@ -333,7 +333,7 @@ class RestServiceModel implements EventManagerAwareInterface
         $this->updateContentNegotiationConfig($original, $update);
         $this->updateHalConfig($original, $update);
 
-        return $this->fetch($controllerService);
+        return $this->fetch($controllerService, false);
     }
 
     /**


### PR DESCRIPTION
The Admin UI sends the entire DB-Connected resource across in every request. 
This raises an issue, because the `resource_class` is always sent as a `null` 
value (as we do not want to reference "virtual" resource classes for purposes
of the source code view modal). Because this is `null`, we end up updating a
null value.

We can get the `resource_class` when fetching the original service data by 
passing a boolean `false` to the `$isAFetchOperation` flag; this forces the 
DB-Connected `onFetch()` listener to include it when returning the entity. 
However... we were not passing that flag when doing `updateService()` 
operations, which meant that updating a DB-Connected service always wrote the 
DB-Connected configuration under a blank key.

This patch does two things:
- It now passes the `$isAFetchOperation` flag for update operations.
- It now pulls the `resource_class` from the updated REST entity prior to
  performing db-connected-specific update oparations.
