### PR TITLE
Fix for the Zend\Filter\Encrypt and Zend\Filter\Compress adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ vendor/sebastian/
 vendor/symfony/
 vendor/zendframework/
 vendor/zfcampus/
+.project
+.buildpath
+.settings


### PR DESCRIPTION
This PR fix the issue https://github.com/zfcampus/zf-apigility-admin/issues/163 and also the `Zend\Filter\Compress\*` adapters. I attached a new event in `Module.php` during the `EVENT_ROUTE` that transform a `Zend\Filter\[Encrypt|Compress]\x` adapter in `Zend\Filter\[Encrypt|Compress]` with the option `'adapters' -> 'x'`.
