### PR TITLE
Cannot edit DSN of database adapters

### DIFF
--- a/src/InputFilter/DbAdapterInputFilter.php
+++ b/src/InputFilter/DbAdapterInputFilter.php
@@ -29,6 +29,11 @@ class DbAdapterInputFilter extends InputFilter
             'error_message' => 'Please provide a Database Adapter driver name available to Zend Framework',
         ));
         $this->add(array(
+            'name' => 'dsn',
+            'required' => false,
+            'allow_empty' => true,
+        ));
+        $this->add(array(
             'name' => 'username',
             'required' => false,
             'allow_empty' => true,


### PR DESCRIPTION
When editing an existing database adapter, that contains data in the DSN-field, you cannot save it. 
A response of:
{"type":"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html","title":"Bad Request","status":400,"detail":"Unrecognized field \"dsn\""} 
is returned.

Creating a new adapter, with data in DSN works as expected.
