### PR TITLE
Undefined index: input_filter_specs

### DIFF
--- a/src/Model/InputFilterModel.php
+++ b/src/Model/InputFilterModel.php
@@ -86,7 +86,10 @@ class InputFilterModel
         }
 
         $validator = $config['zf-content-validation'][$controller]['input_filter'];
-        if (!array_key_exists($validator, $config['input_filter_specs'])) {
+        if (! isset($config['input_filter_specs'])
+            || ! is_array($config['input_filter_specs'])
+            || ! array_key_exists($validator, $config['input_filter_specs'])
+        ) {
             return false;
         }
 


### PR DESCRIPTION
As reported in [this thread](https://groups.google.com/a/zend.com/d/msgid/apigility-users/10e4e018-b4af-441b-836f-5e34701aefb4%40zend.com?utm_medium=email&utm_source=footer), a notice can pop up indicating that an index, `input_filter_specs`, does not exist on line 89 of `ZF\Apigility\Admin\Model\InputFilterModel`.

Solution: check for existence of that key before checking if a key exists in that array.
