### PR TITLE
Enable endpoints with or without an ending /

### DIFF
--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -598,7 +598,7 @@ class RestServiceModel implements EventManagerAwareInterface
                     $routeName => array(
                         'type' => 'Segment',
                         'options' => array(
-                            'route' => sprintf('%s[/:%s]', $route, $routeIdentifier),
+                            'route' => sprintf('%s[/:%s[/]]', $route, $routeIdentifier),
                             'defaults' => array(
                                 'controller' => $controllerService,
                             ),


### PR DESCRIPTION
I'm not sure if this would cause issues elsewhere but I've been modifying my routes after creating endpoints to allow for a trailing slash.  If not allowed, requesting an endpoint with a trailing slash yields a 404.
