### PR TITLE
OAuth2 Mongo Adapter cannot be created successfully

### DIFF
--- a/src/Model/AuthenticationEntity.php
+++ b/src/Model/AuthenticationEntity.php
@@ -181,7 +181,7 @@ class AuthenticationEntity
                     $this->database = $value;
                     break;
                 case 'dsn':
-                    $this->dsn = $value;
+                    $this->dsn = $value ?: 'mongodb://localhost:27017';
                     break;
                 case 'htdigest':
                     $this->htdigest = $value;

--- a/src/Model/AuthenticationModel.php
+++ b/src/Model/AuthenticationModel.php
@@ -165,7 +165,7 @@ class AuthenticationModel
                 $type   = array_shift($config['accept_schemes']);
                 $realm  = isset($config['realm']) ? $config['realm'] : 'api';
                 return new AuthenticationEntity($type, $realm, $config);
-            case (isset($config['dsn'])):
+            case (isset($config['dsn']) || isset($config['dsn_type'])):
                 return new AuthenticationEntity(AuthenticationEntity::TYPE_OAUTH2, $config);
         }
     }


### PR DESCRIPTION
According to this [thread](https://groups.google.com/a/zend.com/d/msgid/apigility-users/23703bf6-1ada-4085-8e24-a09aa66fc3d8%40zend.com?utm_medium=email&utm_source=footer), when creating a Mongo adapter for OAuth2, no DSN is sent -- which means that `ZF\Apigility\Admin\Model\AuthenticationModel::createAuthenticationEntityFromConfig()` returns a `null` value, causing a later method call to raise a fatal error.
