### PR TITLE
zf-hal option 'render_collections' can break Apigility admin

### DIFF
--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Admin;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\RouteMatch;
+use Zend\ServiceManager\ServiceManager;
+use Zend\View\HelperPluginManager;
+use ZF\Apigility\Admin\Module;
+use ZF\Hal\Plugin\Hal;
+
+class ModuleTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->services = new ServiceManager();
+        $this->module = new Module();
+    }
+
+    public function setupServiceChain()
+    {
+        $this->hal = new Hal();
+        $this->helpers = new HelperPluginManager();
+        $this->helpers->setService('Hal', $this->hal);
+        $this->helpers->setServiceLocator($this->services);
+        $this->services->setService('ViewHelperManager', $this->helpers);
+        $this->application = new TestAsset\Application();
+        $this->application->setServiceManager($this->services);
+    }
+
+    public function testRouteListenerDoesNothingIfNoRouteMatches()
+    {
+        $event = new MvcEvent();
+        $this->assertNull($this->module->onRoute($event));
+    }
+
+    public function testRouteListenerDoesNothingIfRouteMatchesDoNotContainController()
+    {
+        $matches = new RouteMatch(array());
+        $event = new MvcEvent();
+        $event->setRouteMatch($matches);
+        $this->assertNull($this->module->onRoute($event));
+    }
+
+    public function testRouteListenerDoesNothingIfRouteMatchControllerIsNotRelevant()
+    {
+        $matches = new RouteMatch(array(
+            'controller' => 'Foo\Bar',
+        ));
+        $event = new MvcEvent();
+        $event->setRouteMatch($matches);
+        $this->assertNull($this->module->onRoute($event));
+    }
+
+    public function testRouteListenerModifiesHalPluginToRenderCollectionsIfControllerIsRelevant()
+    {
+        $this->setupServiceChain();
+        $this->hal->setRenderCollections(false);
+
+        $matches = new RouteMatch(array(
+            'controller' => 'ZF\Apigility\Admin\Foo\Controller',
+        ));
+        $event = new MvcEvent();
+        $event->setRouteMatch($matches);
+        $event->setTarget($this->application);
+
+        $this->assertNull($this->module->onRoute($event));
+        $this->assertTrue($this->hal->getRenderCollections());
+    }
+}

--- a/test/TestAsset/Application.php
+++ b/test/TestAsset/Application.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Admin\TestAsset;
+
+class Application
+{
+    protected $services;
+
+    public function setServiceManager($services)
+    {
+        $this->services = $services;
+    }
+
+    public function getServiceManager()
+    {
+        return $this->services;
+    }
+}


### PR DESCRIPTION
Not sure if this is a bug or more of a "gotcha" but if in the course of setting up an API you switch the default behavior of `zf-hal` to not render collections:

```
'zf-hal' => array(
    'renderer' => array(
        'render_collections' => false,
    ),
),
```

The Apigility admin panel's APIs tab will die with this javascript error:

![apigility_error](https://cloud.githubusercontent.com/assets/527329/3305050/5c3ae894-f651-11e3-8fc8-827f3ef64ca4.png)

as Apigility's admin panel relies on the `GET /apigility/api/module` call to return the collection of versions for each API, but with `render_collections` off that data isn't included in the response
