### PR TITLE
Feature request: Ability to disable pagination from admin ui

### DIFF
--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -6,6 +6,8 @@
 
 namespace ZF\Apigility\Admin\InputFilter\RestService;
 
+use Zend\Validator\Callback as CallbackValidator;
+
 class PatchInputFilter extends PostInputFilter
 {
     protected $isUpdate = true;
@@ -68,9 +70,22 @@ class PatchInputFilter extends PostInputFilter
             'allow_empty' => true,
             'continue_if_empty' => true,
             'validators' => array(
-                array('name' => 'Zend\Validator\Digits')
+                new CallbackValidator(function ($value) {
+                    if (intval($value) != $value) {
+                        return false;
+                    }
+
+                    $value = intval($value);
+                    if ($value === -1
+                        || $value > 0
+                    ) {
+                        return true;
+                    }
+
+                    return false;
+                }),
             ),
-            'error_message' => 'The Page Size must be an integer',
+            'error_message' => 'The Page Size must be either a positive integer or the value "-1" (disabling pagination)',
         ));
         $this->add(array(
             'name' => 'collection_http_methods',

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -57,6 +57,41 @@ class PatchInputFilterTest extends TestCase
                 'selector' => 'HalJson',
                 'service_name' => 'Baz_Bat',
             )),
+            'page_size-negative' => array(array(
+                'accept_whitelist' => array (
+                    0 => 'application/vnd.foo_bar.v1+json',
+                    1 => 'application/hal+json',
+                    2 => 'application/json',
+                ),
+                'collection_class' => 'Zend\Paginator\Paginator',
+                'collection_http_methods' => array (
+                    0 => 'GET',
+                    1 => 'POST',
+                ),
+                'collection_name' => 'foo_bar',
+                'collection_query_whitelist' => array (
+                ),
+                'content_type_whitelist' => array (
+                    0 => 'application/vnd.foo_bar.v1+json',
+                    1 => 'application/json',
+                ),
+                'entity_class' => 'StdClass',
+                'entity_http_methods' => array (
+                    0 => 'GET',
+                    1 => 'PATCH',
+                    2 => 'PUT',
+                    3 => 'DELETE',
+                ),
+                'entity_identifier_name' => 'id',
+                'hydrator_name' => 'Zend\\Stdlib\\Hydrator\\ArraySerializable',
+                'page_size' => -1,
+                'page_size_param' => NULL,
+                'resource_class' => 'Foo_Bar\\V1\\Rest\\Baz_Bat\\Baz_BatResource',
+                'route_identifier_name' => 'foo_bar_id',
+                'route_match' => '/foo_bar[/:foo_bar_id]',
+                'selector' => 'HalJson',
+                'service_name' => 'Baz_Bat',
+            )),
         );
     }
 


### PR DESCRIPTION
Pagination can be disabled by setting the page_size parameter to -1, but the UI does not allow this. If you put in -1 it says the input must be an integer. If you put in 0, it doesn't save.

If you've manually entered -1, it's no longer possible to save changes via the admin UI because the page_size field doesn't validate.
