### PR TITLE
Allow defining DB adapter driver options

### DIFF
--- a/asset/src/zf-apigility-admin/html/settings/db-adapters/edit.html
+++ b/asset/src/zf-apigility-admin/html/settings/db-adapters/edit.html
@@ -84,6 +84,55 @@
         </div>
     </fieldset>
 
+    <ag-collapse class="panel-default">
+        <collapse-header>
+            <h4 class="panel-title">Driver Options</h4>
+        </collapse-header>
+
+        <collapse-body>
+            <li
+                class="list-group-item"
+                ng-repeat="(optionKey, optionValue) in dbAdapter.driver_options">
+
+                <div class="form-group">
+                    <label>Option:</label>
+                    <input type="text" class="form-control input-xlarge" ng-model="optionKey">
+                </div>
+
+                <div class="form-group">
+                    <label>Value:</label>
+                    <input type="text" class="form-control input-xlarge" ng-model="optionValue">
+                </div>
+
+                <div class="btn-group ag-new-input pull-right">
+                    <button type="button" class="btn btn-sm btn-danger"
+                        ng-click="removeDriverOption(dbAdapter, optionKey)">Remove Option</button>
+                </div>
+
+                <div class="clearfix"></div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="form-group">
+                    <label>Option:</label>
+                    <input type="text" class="form-control input-xlarge" ng-model="dbAdapter._newOptionKey">
+                </div>
+
+                <div class="form-group">
+                    <label>Value:</label>
+                    <input type="text" class="form-control input-xlarge" ng-model="dbAdapter._newOptionValue">
+                </div>
+
+                <div class="btn-group ag-new-input pull-right">
+                    <button type="button" class="btn btn-sm btn-primary"
+                        ng-click="addDriverOption(dbAdapter)">Add Option</button>
+                </div>
+
+                <div class="clearfix"></div>
+            </li>
+        </collapse-body>
+    </ag-collapse>
+
     <div class="btn-group pull-right">
         <button type="button" class="btn btn-sm btn-default" ag-cancel-edit>Cancel</a>
         <button type="submit" class="btn btn-sm btn-success">Save</button>

--- a/asset/src/zf-apigility-admin/html/settings/db-adapters/new-adapter-form.html
+++ b/asset/src/zf-apigility-admin/html/settings/db-adapters/new-adapter-form.html
@@ -98,6 +98,55 @@
                 </div>
             </fieldset>
 
+            <ag-collapse class="panel-default">
+                <collapse-header>
+                    <h4 class="panel-title">Driver Options</h4>
+                </collapse-header>
+
+                <collapse-body>
+                    <li
+                        class="list-group-item"
+                        ng-repeat="(optionKey, optionValue) in driver_options">
+
+                        <div class="form-group">
+                            <label>Option:</label>
+                            <input type="text" class="form-control input-xlarge" ng-model="optionKey">
+                        </div>
+
+                        <div class="form-group">
+                            <label>Value:</label>
+                            <input type="text" class="form-control input-xlarge" ng-model="optionValue">
+                        </div>
+
+                        <div class="btn-group ag-new-input pull-right">
+                            <button type="button" class="btn btn-sm btn-danger"
+                                ng-click="removeNewDriverOption(driver_options, optionKey)">Remove Option</button>
+                        </div>
+
+                        <div class="clearfix"></div>
+                    </li>
+
+                    <li class="list-group-item">
+                        <div class="form-group">
+                            <label>Option:</label>
+                            <input type="text" class="form-control input-xlarge" ng-model="newOptionKey">
+                        </div>
+
+                        <div class="form-group">
+                            <label>Value:</label>
+                            <input type="text" class="form-control input-xlarge" ng-model="newOptionValue">
+                        </div>
+
+                        <div class="btn-group ag-new-input pull-right">
+                            <button type="button" class="btn btn-sm btn-primary"
+                                ng-click="addNewDriverOption(driver_options)">Add Option</button>
+                        </div>
+
+                        <div class="clearfix"></div>
+                    </li>
+                </collapse-body>
+            </ag-collapse>
+
             <div class="btn-group pull-right">
                 <a ng-click="resetForm()&&(showNewDbAdapterForm = false)" class="btn btn-sm btn-default">Cancel</a>
                 <button type="submit" class="btn btn-sm btn-primary">Create DB Adapter</button>

--- a/asset/src/zf-apigility-admin/html/settings/db-adapters/view.html
+++ b/asset/src/zf-apigility-admin/html/settings/db-adapters/view.html
@@ -38,5 +38,24 @@
         <td>Charset</td>
         <td>{{ dbAdapter.charset }}</td>
     </tr>
+
+    <tr ng-show="dbAdapter.driver_options">
+        <td colspan="2">
+        <ag-collapse class="panel-default">
+            <collapse-header>
+                <h4 class="panel-title">Driver Options</h4>
+            </collapse-header>
+
+            <collapse-body>
+                <table class="table table-striped">
+                    <tr ng-repeat="(optionKey, optionValue) in dbAdapter.driver_options">
+                        <td>{{ optionKey }}</td>
+                        <td>{{ optionValue }}</td>
+                    </tr>
+                </table>
+            </collapse-body>
+        </ag-collapse>
+        </td>
+    </tr>
 </table>
 

--- a/asset/src/zf-apigility-admin/js/controllers/db-adapter.js
+++ b/asset/src/zf-apigility-admin/js/controllers/db-adapter.js
@@ -11,15 +11,18 @@ angular.module('ag-admin').controller(
         $scope.resetForm = function () {
             agFormHandler.resetForm($scope);
             $scope.showNewDbAdapterForm = false;
-            $scope.adapterName = '';
-            $scope.driver      = '';
-            $scope.database    = '';
-            $scope.dsn         = '';
-            $scope.username    = '';
-            $scope.password    = '';
-            $scope.hostname    = '';
-            $scope.port        = '';
-            $scope.charset     = '';
+            $scope.adapterName          = '';
+            $scope.driver               = '';
+            $scope.database             = '';
+            $scope.dsn                  = '';
+            $scope.username             = '';
+            $scope.password             = '';
+            $scope.hostname             = '';
+            $scope.port                 = '';
+            $scope.charset              = '';
+            $scope.driver_options       = {};
+            $scope.newOptionKey         = '';
+            $scope.newOptionValue       = '';
             return true;
         };
 
@@ -34,6 +37,54 @@ angular.module('ag-admin').controller(
             });
         };
 
+        $scope.addNewDriverOption = function (options) {
+            var key   = $scope.newOptionKey;
+            var value = $scope.newOptionValue;
+
+            if (key.length === 0 || value.length === 0) {
+                return;
+            }
+
+            if (! $scope.driver_options) {
+                $scope.driver_options = {};
+            }
+
+            $scope.driver_options[key] = value;
+            $scope.newOptionKey   = '';
+            $scope.newOptionValue = '';
+        };
+
+        $scope.addDriverOption = function (dbAdapter) {
+            var key   = dbAdapter._newOptionKey;
+            var value = dbAdapter._newOptionValue;
+
+            if (key.length === 0 || value.length === 0) {
+                return;
+            }
+
+            if (! dbAdapter.driver_options) {
+                dbAdapter.driver_options = {};
+            }
+
+            dbAdapter.driver_options[key]    = value;
+            dbAdapter._newOptionKey   = '';
+            dbAdapter._newOptionValue = '';
+        };
+
+        $scope.removeNewDriverOption = function (driver_options, optionKey) {
+            if (! $scope.driver_options || ! $scope.driver_options[optionKey]) {
+                return;
+            }
+            delete $scope.driver_options[optionKey];
+        };
+
+        $scope.removeDriverOption = function (dbAdapter, optionKey) {
+            if (! dbAdapter.driver_options || ! dbAdapter.driver_options[optionKey]) {
+                return;
+            }
+            delete dbAdapter.driver_options[optionKey];
+        };
+
         $scope.createNewDbAdapter = function () {
             var options = {
                 adapter_name :  $scope.adapter_name,
@@ -45,14 +96,21 @@ angular.module('ag-admin').controller(
                 port         :  $scope.port,
                 charset      :  $scope.charset
             };
+
             if ($scope.dsn) {
                 options.dsn = $scope.dsn;
             }
+
+            if ($scope.driver_options && Object.keys($scope.driver_options).length > 0) {
+                options.driver_options = $scope.driver_options;
+            }
+
             DbAdapterResource.createNewAdapter(options).then(
                 function (dbAdapter) {
                     updateDbAdapters(true, 'Database adapter created');
                     $scope.resetForm();
-                },
+                }
+            ).catch(
                 function (error) {
                     agFormHandler.reportError(error, $scope);
                 }
@@ -70,14 +128,21 @@ angular.module('ag-admin').controller(
                 port     :  dbAdapter.port,
                 charset  :  dbAdapter.charset
             };
+
             if (dbAdapter.dsn) {
                 options.dsn = dbAdapter.dsn;
             }
+
+            if (dbAdapter.driver_options && Object.keys(dbAdapter.driver_options).length > 0) {
+                options.driver_options = dbAdapter.driver_options;
+            }
+
             DbAdapterResource.saveAdapter(dbAdapter.adapter_name, options).then(
                 function (dbAdapter) {
                     agFormHandler.resetForm($scope);
                     updateDbAdapters(true, 'Database adapter ' + dbAdapter.adapter_name + ' updated');
-                },
+                }
+            ).catch(
                 function (error) {
                     agFormHandler.reportError(error, $scope);
                 }

--- a/asset/src/zf-apigility-admin/js/templates.js
+++ b/asset/src/zf-apigility-admin/js/templates.js
@@ -3700,6 +3700,55 @@ angular.module("html/settings/db-adapters/edit.html", []).run(["$templateCache",
     "        </div>\n" +
     "    </fieldset>\n" +
     "\n" +
+    "    <ag-collapse class=\"panel-default\">\n" +
+    "        <collapse-header>\n" +
+    "            <h4 class=\"panel-title\">Driver Options</h4>\n" +
+    "        </collapse-header>\n" +
+    "\n" +
+    "        <collapse-body>\n" +
+    "            <li\n" +
+    "                class=\"list-group-item\"\n" +
+    "                ng-repeat=\"(optionKey, optionValue) in dbAdapter.driver_options\">\n" +
+    "\n" +
+    "                <div class=\"form-group\">\n" +
+    "                    <label>Option:</label>\n" +
+    "                    <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"optionKey\">\n" +
+    "                </div>\n" +
+    "\n" +
+    "                <div class=\"form-group\">\n" +
+    "                    <label>Value:</label>\n" +
+    "                    <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"optionValue\">\n" +
+    "                </div>\n" +
+    "\n" +
+    "                <div class=\"btn-group ag-new-input pull-right\">\n" +
+    "                    <button type=\"button\" class=\"btn btn-sm btn-danger\"\n" +
+    "                        ng-click=\"removeDriverOption(dbAdapter, optionKey)\">Remove Option</button>\n" +
+    "                </div>\n" +
+    "\n" +
+    "                <div class=\"clearfix\"></div>\n" +
+    "            </li>\n" +
+    "\n" +
+    "            <li class=\"list-group-item\">\n" +
+    "                <div class=\"form-group\">\n" +
+    "                    <label>Option:</label>\n" +
+    "                    <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"dbAdapter._newOptionKey\">\n" +
+    "                </div>\n" +
+    "\n" +
+    "                <div class=\"form-group\">\n" +
+    "                    <label>Value:</label>\n" +
+    "                    <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"dbAdapter._newOptionValue\">\n" +
+    "                </div>\n" +
+    "\n" +
+    "                <div class=\"btn-group ag-new-input pull-right\">\n" +
+    "                    <button type=\"button\" class=\"btn btn-sm btn-primary\"\n" +
+    "                        ng-click=\"addDriverOption(dbAdapter)\">Add Option</button>\n" +
+    "                </div>\n" +
+    "\n" +
+    "                <div class=\"clearfix\"></div>\n" +
+    "            </li>\n" +
+    "        </collapse-body>\n" +
+    "    </ag-collapse>\n" +
+    "\n" +
     "    <div class=\"btn-group pull-right\">\n" +
     "        <button type=\"button\" class=\"btn btn-sm btn-default\" ag-cancel-edit>Cancel</a>\n" +
     "        <button type=\"submit\" class=\"btn btn-sm btn-success\">Save</button>\n" +
@@ -3876,6 +3925,55 @@ angular.module("html/settings/db-adapters/new-adapter-form.html", []).run(["$tem
     "                </div>\n" +
     "            </fieldset>\n" +
     "\n" +
+    "            <ag-collapse class=\"panel-default\">\n" +
+    "                <collapse-header>\n" +
+    "                    <h4 class=\"panel-title\">Driver Options</h4>\n" +
+    "                </collapse-header>\n" +
+    "\n" +
+    "                <collapse-body>\n" +
+    "                    <li\n" +
+    "                        class=\"list-group-item\"\n" +
+    "                        ng-repeat=\"(optionKey, optionValue) in driver_options\">\n" +
+    "\n" +
+    "                        <div class=\"form-group\">\n" +
+    "                            <label>Option:</label>\n" +
+    "                            <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"optionKey\">\n" +
+    "                        </div>\n" +
+    "\n" +
+    "                        <div class=\"form-group\">\n" +
+    "                            <label>Value:</label>\n" +
+    "                            <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"optionValue\">\n" +
+    "                        </div>\n" +
+    "\n" +
+    "                        <div class=\"btn-group ag-new-input pull-right\">\n" +
+    "                            <button type=\"button\" class=\"btn btn-sm btn-danger\"\n" +
+    "                                ng-click=\"removeNewDriverOption(driver_options, optionKey)\">Remove Option</button>\n" +
+    "                        </div>\n" +
+    "\n" +
+    "                        <div class=\"clearfix\"></div>\n" +
+    "                    </li>\n" +
+    "\n" +
+    "                    <li class=\"list-group-item\">\n" +
+    "                        <div class=\"form-group\">\n" +
+    "                            <label>Option:</label>\n" +
+    "                            <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"newOptionKey\">\n" +
+    "                        </div>\n" +
+    "\n" +
+    "                        <div class=\"form-group\">\n" +
+    "                            <label>Value:</label>\n" +
+    "                            <input type=\"text\" class=\"form-control input-xlarge\" ng-model=\"newOptionValue\">\n" +
+    "                        </div>\n" +
+    "\n" +
+    "                        <div class=\"btn-group ag-new-input pull-right\">\n" +
+    "                            <button type=\"button\" class=\"btn btn-sm btn-primary\"\n" +
+    "                                ng-click=\"addNewDriverOption(driver_options)\">Add Option</button>\n" +
+    "                        </div>\n" +
+    "\n" +
+    "                        <div class=\"clearfix\"></div>\n" +
+    "                    </li>\n" +
+    "                </collapse-body>\n" +
+    "            </ag-collapse>\n" +
+    "\n" +
     "            <div class=\"btn-group pull-right\">\n" +
     "                <a ng-click=\"resetForm()&&(showNewDbAdapterForm = false)\" class=\"btn btn-sm btn-default\">Cancel</a>\n" +
     "                <button type=\"submit\" class=\"btn btn-sm btn-primary\">Create DB Adapter</button>\n" +
@@ -3952,6 +4050,25 @@ angular.module("html/settings/db-adapters/view.html", []).run(["$templateCache",
     "    <tr ng-show=\"dbAdapter.charset\">\n" +
     "        <td>Charset</td>\n" +
     "        <td>{{ dbAdapter.charset }}</td>\n" +
+    "    </tr>\n" +
+    "\n" +
+    "    <tr ng-show=\"dbAdapter.driver_options\">\n" +
+    "        <td colspan=\"2\">\n" +
+    "        <ag-collapse class=\"panel-default\">\n" +
+    "            <collapse-header>\n" +
+    "                <h4 class=\"panel-title\">Driver Options</h4>\n" +
+    "            </collapse-header>\n" +
+    "\n" +
+    "            <collapse-body>\n" +
+    "                <table class=\"table table-striped\">\n" +
+    "                    <tr ng-repeat=\"(optionKey, optionValue) in dbAdapter.driver_options\">\n" +
+    "                        <td>{{ optionKey }}</td>\n" +
+    "                        <td>{{ optionValue }}</td>\n" +
+    "                    </tr>\n" +
+    "                </table>\n" +
+    "            </collapse-body>\n" +
+    "        </ag-collapse>\n" +
+    "        </td>\n" +
     "    </tr>\n" +
     "</table>\n" +
     "\n" +

--- a/src/InputFilter/DbAdapterInputFilter.php
+++ b/src/InputFilter/DbAdapterInputFilter.php
@@ -7,6 +7,8 @@
 namespace ZF\Apigility\Admin\InputFilter;
 
 use Zend\InputFilter\InputFilter;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Validator\Callback as CallbackValidator;
 
 class DbAdapterInputFilter extends InputFilter
 {
@@ -61,6 +63,17 @@ class DbAdapterInputFilter extends InputFilter
             'name' => 'charset',
             'required' => false,
             'allow_empty' => true,
+        ));
+        $this->add(array(
+            'name' => 'driver_options',
+            'required' => false,
+            'allow_empty' => true,
+            'validators' => array(
+                new CallbackValidator(function ($value) {
+                    return ArrayUtils::isHashTable($value);
+                }),
+            ),
+            'error_message' => 'Driver options must be provided as a set of key/value pairs',
         ));
     }
 }


### PR DESCRIPTION
- Adds to the DB adapter input filter a validator for driver options
- Adds UI elements to the admin:
  - For new/edit screens, a collapse with the ability to add and remove option
    key/value pairs
  - For the view screen, a collapse with the ability to view options

These new UI features are intended to help support DB2 when used on IBM i Series hardware (AS400, etc). In particular, i Series requires options similar to the followign be specified:

``` php
    'DB2' => array(
        'driver' => 'IbmDb2',
        'database' => '*LOCAL',
        'driver_options' => array(
                'i5_lib' => 'ZF2TEST',
                'i5_naming' => DB2_I5_NAMING_OFF
        )
    ),
```

By adding UI elements for specifying driver options, we complete the DB adapter support, making it more robust and flexible.
