### PR TITLE
Disable HTTP caching for Admin API

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -392,7 +392,8 @@ class Module
             return;
         }
 
-        if ($e->getRequest()->isGet()) {
+        $request = $e->getRequest();
+        if ($request->isGet() || $request->isHead()) {
             $this->disableHttpCache($e->getResponse()->getHeaders());
         }
     }


### PR DESCRIPTION
This is a potential fix for #175.

Previously, we were sending a `Cache-Control: no-cache` header. However, to be more thorough and aggressive in cache busting, the following is generally considered necessary:

``` HTTP
Expires: 0
Last-Modified: Tue, 12 Aug 2014 13:30:09 GMT
Cache-Control: no-store, no-cache, must-revalidate
Cache-Control: post-check=0, pre-check=0
Pragma: no-cache
```

This patch fires during the finish event, if the request was a GET or a HEAD request, sending the above headers (with the  Last-Modified header being set to the current timestamp).
