### PR TITLE
Introduced timeouts to API create/delete actions

### DIFF
--- a/asset/src/zf-apigility-admin/js/controllers/api-create.js
+++ b/asset/src/zf-apigility-admin/js/controllers/api-create.js
@@ -3,7 +3,7 @@
 
 angular.module('ag-admin').controller(
   'CreateApiController',
-  function($scope, $modalInstance, $rootScope, $state, flash, ApiRepository, agFormHandler) {
+  function($scope, $modalInstance, $rootScope, $state, $timeout, flash, ApiRepository, agFormHandler) {
     $scope.apiName = '';
 
     var resetForm = function () {
@@ -26,13 +26,15 @@ angular.module('ag-admin').controller(
           $modalInstance.close(newApi);
           resetForm();
 
-          flash.success = 'New API Created';
+          flash.success = 'New API created; redirecting momentarily';
 
           /* Angular has no way to emit to sibling controllers; use the
            * $rootScope to broadcast downwards instead.
            */
-          $rootScope.$broadcast('api.updateList');
-          $state.go('ag.api.version', {apiName: newApi.name, version: 1});
+          $timeout(function () {
+            $rootScope.$broadcast('api.updateList');
+            $state.go('ag.api.version', {apiName: newApi.name, version: 1});
+          }, 500);
         }
       ).catch(
         function (error) {

--- a/asset/src/zf-apigility-admin/js/controllers/api-overview.js
+++ b/asset/src/zf-apigility-admin/js/controllers/api-overview.js
@@ -1,7 +1,9 @@
 (function() {
     'use strict';
 
-angular.module('ag-admin').controller('ApiOverviewController', function ($scope, $state, flash, ApiRepository) {
+angular.module('ag-admin').controller(
+    'ApiOverviewController',
+    function ($scope, $state, $timeout, flash, ApiRepository) {
     $scope.api = {};
     $scope.defaultApiVersion = 1;
     $scope.deleteApiPanelIsCollapsed = true;
@@ -33,8 +35,10 @@ angular.module('ag-admin').controller('ApiOverviewController', function ($scope,
         var name = $state.params.apiName;
         ApiRepository.removeApi($state.params.apiName, !!recursive).then(
             function () {
-                flash.success = 'Deleted API "' + name + '"';
-                $state.go('^');
+                flash.success = 'Deleted API "' + name + '"; redirecting to API overview momentarily';
+                $timeout(function () {
+                    $state.go('^');
+                }, 500);
             }
         );
     };


### PR DESCRIPTION
- Introduced 500ms timeout between receiving successful response from
  create/delete actions and when the state change happens. Potential fix for
  #175.
