### PR TITLE
Fix an issue observed in Eclipse / Studio

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -778,7 +778,7 @@ class Module
     protected function disableHttpCache($headers)
     {
         $headers->addHeader(new GenericHeader('Expires', '0'));
-        $headers->addHeaderLine('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
+        // $headers->addHeaderLine('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
         $headers->addHeader(new GenericMultiHeader('Cache-Control', 'no-store, no-cache, must-revalidate'));
         $headers->addHeader(new GenericMultiHeader('Cache-Control', 'post-check=0, pre-check=0'));
         $headers->addHeaderLine('Pragma', 'no-cache');


### PR DESCRIPTION
With the 1.0.4 release of Apigility, you are no longer able to create a new
API via the Apigility interface in Eclipse. It fails silently.

On inspection, we determined that the POST request to create an API was being 
sent as a GET request, for no apparent reason. We then started stepping
through commits from zf-apigility-admin's 1.0.2 tag up to the 1.0.3 tag to
determine when this behavior began. The commit that broke was 5c4087c, which
was when cache-control headers were committed. In examining the
implementation, commenting out the Last-Modified header resolved the issues
observed in Studio.

Since Last-Modified is the weakest indicator in the set of cache control
headers used, we can safely remove it and still have reasonable expectations
that the cache control requests will be honored.
