### PR TITLE
Documentation API - Save Bug

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -752,7 +752,9 @@ class Module
 
     protected function getServiceType($service)
     {
-        if (strstr($service, '\\Rest\\')) {
+        if (strstr($service, '\\Rest\\')
+            || strstr($service, '-Rest-')
+        ) {
             return 'rest';
         }
         return 'rpc';


### PR DESCRIPTION
I encounter this bug (on DB-connected service) :

The API documentation does not record, only the general description is recorded, collection entity, GET, POST, etc ... they are not recorded. 
I have to write to the hands the file documentation.config.php but reading documentation its works. 

If i change documentation with the admin interface, i lost the documentation, persists only the general description. This suggests to error when saving but no error in the logs files. 

After looking at the source code and make some testing, the problem would be the parameter "$controllerType" in method "storeDocumentation" because "controllerType" take the value "RPC" while I save documention a "REST" service. So the method "getSchemaTemplate" does not return the correct documentation template and the method "storeDocumentation" does not correctly recorded documentation see "storeDocumentation" (array_intersect_key) 

I guess the problem just webapp (js/controllers/api-documentation.js) 
Afer some testing I arrive on file (js/services/api.js) on method "saveDocumentation" and two paramters :
- Paramter 1 "url" : in my case : http://{domaine}/apigility/api/module/{API name}/rpc/{Controller Name}/doc

The problem is in url "RPC"  while I work on "REST" service, if I replace "RPC" by "REST"  its works, the documentation is correctly recorded but only for services "REST" because I just quickly test with : url = url.replace('rpc', 'rest');
- Parameter 2 "api.documentation" : documentation send is clean.

I work on debian 7 - Apache 2.2.22 - PHP (mod) 5.4.4 - browser: Chrome and Iceweasel
