### PR TITLE
Fix validation of the content-negotiation API

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1282,6 +1282,7 @@ return array(
             'ZF\Apigility\Admin\InputFilter\Authorization' => 'ZF\Apigility\Admin\InputFilter\AuthorizationInputFilter',
             'ZF\Apigility\Admin\InputFilter\DbAdapter' => 'ZF\Apigility\Admin\InputFilter\DbAdapterInputFilter',
             'ZF\Apigility\Admin\InputFilter\ContentNegotiation' => 'ZF\Apigility\Admin\InputFilter\ContentNegotiationInputFilter',
+            'ZF\Apigility\Admin\InputFilter\CreateContentNegotiation' => 'ZF\Apigility\Admin\InputFilter\CreateContentNegotiationInputFilter',
 
             'ZF\Apigility\Admin\InputFilter\Module' => 'ZF\Apigility\Admin\InputFilter\ModuleInputFilter',
             'ZF\Apigility\Admin\InputFilter\Version' => 'ZF\Apigility\Admin\InputFilter\VersionInputFilter',
@@ -1314,6 +1315,7 @@ return array(
 
         'ZF\Apigility\Admin\Controller\ContentNegotiation' => array(
             'input_filter' => 'ZF\Apigility\Admin\InputFilter\ContentNegotiation',
+            'POST' => 'ZF\Apigility\Admin\InputFilter\CreateContentNegotiation',
         ),
 
         'ZF\Apigility\Admin\Controller\Module' => array(

--- a/src/InputFilter/ContentNegotiationInputFilter.php
+++ b/src/InputFilter/ContentNegotiationInputFilter.php
@@ -23,16 +23,6 @@ class ContentNegotiationInputFilter extends InputFilter
         $isValid = true;
 
         foreach ($this->data as $className => $mediaTypes) {
-            if ($className === 'content_name' && is_string($mediaTypes)) {
-                continue;
-            }
-
-            if ($className === 'content_name' && ! is_string($mediaTypes)) {
-                $this->messages[$className][] = 'Content name (' . $className . ') is invalid; must be a string';
-                $isValid = false;
-                continue;
-            }
-
             if (! class_exists($className)) {
                 $this->messages[$className][] = 'Class name (' . $className . ') does not exist';
                 $isValid = false;

--- a/src/InputFilter/ContentNegotiationInputFilter.php
+++ b/src/InputFilter/ContentNegotiationInputFilter.php
@@ -23,6 +23,16 @@ class ContentNegotiationInputFilter extends InputFilter
         $isValid = true;
 
         foreach ($this->data as $className => $mediaTypes) {
+            if ($className === 'content_name' && is_string($mediaTypes)) {
+                continue;
+            }
+
+            if ($className === 'content_name' && ! is_string($mediaTypes)) {
+                $this->messages[$className][] = 'Content name (' . $className . ') is invalid; must be a string';
+                $isValid = false;
+                continue;
+            }
+
             if (! class_exists($className)) {
                 $this->messages[$className][] = 'Class name (' . $className . ') does not exist';
                 $isValid = false;

--- a/src/InputFilter/CreateContentNegotiationInputFilter.php
+++ b/src/InputFilter/CreateContentNegotiationInputFilter.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\InputFilter;
+
+class CreateContentNegotiationInputFilter extends ContentNegotiationInputFilter
+{
+    /**
+     * Is the data set valid?
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        $this->messages = array();
+        $isValid = true;
+
+        if (! array_key_exists('content_name', $this->data)) {
+            $this->messages['content_name'][] = 'No content_name was provided; must be present for new negotiators.';
+            $isValid = false;
+        }
+
+        if (array_key_exists('content_name', $this->data) && ! is_string($this->data['content_name'])) {
+            $this->messages['content_name'][] = 'Content name provided is invalid; must be a string';
+            $isValid = false;
+        }
+
+        if (! $isValid) {
+            return false;
+        }
+
+        $contentName = $this->data['content_name'];
+        unset($this->data['content_name']);
+
+        $isValid = parent::isValid();
+
+        $this->data['content_name'] = $contentName;
+
+        return $isValid;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+}

--- a/test/InputFilter/ContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/ContentNegotiationInputFilterTest.php
@@ -19,12 +19,6 @@ class ContentNegotiationInputFilterTest extends TestCase
                     'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                 ),
             ),
-            'with-content-name' => array(
-                array(
-                    'content_name' => 'test',
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                )
-            ),
         );
     }
 

--- a/test/InputFilter/ContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/ContentNegotiationInputFilterTest.php
@@ -19,6 +19,12 @@ class ContentNegotiationInputFilterTest extends TestCase
                     'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                 ),
             ),
+            'with-content-name' => array(
+                array(
+                    'content_name' => 'test',
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                )
+            ),
         );
     }
 
@@ -63,7 +69,7 @@ class ContentNegotiationInputFilterTest extends TestCase
     {
         $filter = new ContentNegotiationInputFilter;
         $filter->setData($data);
-        $this->assertTrue($filter->isValid());
+        $this->assertTrue($filter->isValid(), var_export($filter->getMessages(), 1));
     }
 
     /**

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Admin\InputFilter;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\Apigility\Admin\InputFilter\CreateContentNegotiationInputFilter;
+
+class CreateContentNegotiationInputFilterTest extends TestCase
+{
+    public function dataProviderIsValid()
+    {
+        return array(
+            'with-content-name' => array(
+                array(
+                    'content_name' => 'test',
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                )
+            ),
+        );
+    }
+
+    public function dataProviderIsInvalid()
+    {
+        return array(
+            'missing-content-name' => array(
+                array(
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('No content_name was provided; must be present for new negotiators.'),
+                ),
+            ),
+            'null-content-name' => array(
+                array(
+                    'content_name' => null,
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('Content name provided is invalid; must be a string'),
+                ),
+            ),
+            'bool-content-name' => array(
+                array(
+                    'content_name' => true,
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('Content name provided is invalid; must be a string'),
+                ),
+            ),
+            'int-content-name' => array(
+                array(
+                    'content_name' => 1,
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('Content name provided is invalid; must be a string'),
+                ),
+            ),
+            'float-content-name' => array(
+                array(
+                    'content_name' => 1.1,
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('Content name provided is invalid; must be a string'),
+                ),
+            ),
+            'array-content-name' => array(
+                array(
+                    'content_name' => array('content_name'),
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('Content name provided is invalid; must be a string'),
+                ),
+            ),
+            'object-content-name' => array(
+                array(
+                    'content_name' => (object) array('content_name'),
+                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                ),
+                array(
+                    'content_name' => array('Content name provided is invalid; must be a string'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderIsValid
+     */
+    public function testIsValid($data)
+    {
+        $filter = new CreateContentNegotiationInputFilter;
+        $filter->setData($data);
+        $this->assertTrue($filter->isValid(), var_export($filter->getMessages(), 1));
+    }
+
+    /**
+     * @dataProvider dataProviderIsInvalid
+     */
+    public function testIsInvalid($data, $messages)
+    {
+        $filter = new CreateContentNegotiationInputFilter;
+        $filter->setData($data);
+        $this->assertFalse($filter->isValid());
+        $this->assertEquals($messages, $filter->getMessages());
+    }
+}

--- a/test/Model/ContentNegotiationResourceTest.php
+++ b/test/Model/ContentNegotiationResourceTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Admin\Model;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Config\Writer\PhpArray as ConfigWriter;
+use ZF\Apigility\Admin\Model\ContentNegotiationModel;
+use ZF\Apigility\Admin\Model\ContentNegotiationResource;
+use ZF\Configuration\ConfigResource;
+
+class ContentNegotiationResourceTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->configPath       = sys_get_temp_dir() . '/zf-apigility-admin/config';
+        $this->globalConfigPath = $this->configPath . '/global.php';
+        $this->removeConfigMocks();
+        $this->createConfigMocks();
+        $this->configWriter     = new ConfigWriter();
+    }
+
+    public function createConfigMocks()
+    {
+        if (!is_dir($this->configPath)) {
+            mkdir($this->configPath, 0775, true);
+        }
+
+        $contents = "<" . "?php\nreturn array();";
+        file_put_contents($this->globalConfigPath, $contents);
+    }
+
+    public function removeConfigMocks()
+    {
+        if (file_exists($this->globalConfigPath)) {
+            unlink($this->globalConfigPath);
+        }
+        if (is_dir($this->configPath)) {
+            rmdir($this->configPath);
+        }
+        if (is_dir(dirname($this->configPath))) {
+            rmdir(dirname($this->configPath));
+        }
+    }
+
+    public function createModelFromConfigArray(array $global)
+    {
+        $this->configWriter->toFile($this->globalConfigPath, $global);
+        $globalConfig = new ConfigResource($global, $this->globalConfigPath, $this->configWriter);
+        return new ContentNegotiationModel($globalConfig);
+    }
+
+    public function createResourceFromConfigArray(array $global)
+    {
+        return new ContentNegotiationResource($this->createModelFromConfigArray($global));
+    }
+
+
+    public function testCreateShouldAcceptContentNameAndReturnNewEntity()
+    {
+        $resource = $this->createResourceFromConfigArray(array());
+        $data = (object) array('content_name' => 'Test');
+        $entity = $resource->create($data);
+        $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
+        $this->assertEquals('Test', $entity->name);
+    }
+}


### PR DESCRIPTION
This fix addresses #249 by providing a new input filter used in POST requests
to the content-negotiation API. The new input filter checks for the presence of
a `content_name` value in the payload, and then passes the remaining data on to
the parent content negotiation input filter to validate.

A valid POST payload then looks like:

```JSON
{
    "content_name": "Test",
    "Zend\View\Model\ViewModel": [
        "text/html",
        "application/xhtml+xml"
    ]
}
```

While PATCH payloads remove the `content_name` parameter (as it's part of the URI).