### PR TITLE
Working validation for content negotiation rules

### DIFF
--- a/src/InputFilter/ContentNegotiationInputFilter.php
+++ b/src/InputFilter/ContentNegotiationInputFilter.php
@@ -6,59 +6,16 @@
 
 namespace ZF\Apigility\Admin\InputFilter;
 
+use Zend\InputFilter\Input;
 use Zend\InputFilter\InputFilter;
 
 class ContentNegotiationInputFilter extends InputFilter
 {
-    protected $messages = array();
-
-    /**
-     * Is the data set valid?
-     *
-     * @return bool
-     */
-    public function isValid()
+    public function __construct()
     {
-        $this->messages = array();
-        $isValid = true;
-
-        foreach ($this->data as $className => $mediaTypes) {
-            if (! class_exists($className)) {
-                $this->messages[$className][] = 'Class name (' . $className . ') does not exist';
-                $isValid = false;
-                continue;
-            }
-
-            $interfaces = class_implements($className);
-            if (false === $interfaces || ! in_array('Zend\View\Model\ModelInterface', $interfaces)) {
-                $this->messages[$className][] = 'Class name (' . $className . ') is invalid;'
-                    . ' must be a valid Zend\View\Model\ModelInterface class';
-                $isValid = false;
-                continue;
-            }
-
-            if (!is_array($mediaTypes)) {
-                $this->messages[$className][] = 'Values for the media-types must be provided as an indexed array';
-                $isValid = false;
-                continue;
-            }
-
-            foreach ($mediaTypes as $mediaType) {
-                if (strpos($mediaType, '/') === false) {
-                    $this->messages[$className][] = 'Invalid media type (' . $mediaType . ') provided';
-                    $isValid = false;
-                }
-            }
-        }
-
-        return $isValid;
-    }
-
-    /**
-     * @return array
-     */
-    public function getMessages()
-    {
-        return $this->messages;
+        $input = new Input('selectors');
+        $chain = $input->getValidatorChain();
+        $chain->attach(new Validator\ContentNegotiationSelectorsValidator());
+        $this->add($input);
     }
 }

--- a/src/InputFilter/CreateContentNegotiationInputFilter.php
+++ b/src/InputFilter/CreateContentNegotiationInputFilter.php
@@ -6,47 +6,18 @@
 
 namespace ZF\Apigility\Admin\InputFilter;
 
+use Zend\InputFilter\Input;
+use Zend\Validator\Regex;
+
 class CreateContentNegotiationInputFilter extends ContentNegotiationInputFilter
 {
-    /**
-     * Is the data set valid?
-     *
-     * @return bool
-     */
-    public function isValid()
+    public function __construct()
     {
-        $this->messages = array();
-        $isValid = true;
-
-        if (! array_key_exists('content_name', $this->data)) {
-            $this->messages['content_name'][] = 'No content_name was provided; must be present for new negotiators.';
-            $isValid = false;
-        }
-
-        if (array_key_exists('content_name', $this->data) && ! is_string($this->data['content_name'])) {
-            $this->messages['content_name'][] = 'Content name provided is invalid; must be a string';
-            $isValid = false;
-        }
-
-        if (! $isValid) {
-            return false;
-        }
-
-        $contentName = $this->data['content_name'];
-        unset($this->data['content_name']);
-
-        $isValid = parent::isValid();
-
-        $this->data['content_name'] = $contentName;
-
-        return $isValid;
-    }
-
-    /**
-     * @return array
-     */
-    public function getMessages()
-    {
-        return $this->messages;
+        $input = new Input('content_name');
+        $input->setRequired(true);
+        $chain = $input->getValidatorChain();
+        $chain->attach(new Validator\IsStringValidator());
+        $this->add($input);
+        parent::__construct();
     }
 }

--- a/src/InputFilter/Validator/ContentNegotiationSelectorsValidator.php
+++ b/src/InputFilter/Validator/ContentNegotiationSelectorsValidator.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\InputFilter\Validator;
+
+use Zend\Validator\AbstractValidator as ZfAbstractValidator;
+
+class ContentNegotiationSelectorsValidator extends ZfAbstractValidator
+{
+    const INVALID_VALUE       = 'invalidValue';
+    const CLASS_NOT_FOUND     = 'classNotFound';
+    const INVALID_VIEW_MODEL  = 'invalidViewModel';
+    const INVALID_MEDIA_TYPES = 'invalidMediaTypes';
+    const INVALID_MEDIA_TYPE  = 'invalidMediaType';
+
+    protected $messageTemplates = array(
+        self::INVALID_VALUE       => 'Value must be an array; received %value%',
+        self::CLASS_NOT_FOUND     => 'Class name (%value%) does not exist',
+        self::INVALID_VIEW_MODEL  =>
+            'Class name (%value%) is invalid; must be a valid Zend\View\Model\ModelInterface instance',
+        self::INVALID_MEDIA_TYPES => 'Values for the media-types must be provided as an indexed array',
+        self::INVALID_MEDIA_TYPE  => 'Invalid media type (%value%) provided',
+    );
+
+    /**
+     * Test if a set of selectors is valid
+     *
+     * @param array $value
+     * @return bool
+     */
+    public function isValid($value)
+    {
+        $isValid = true;
+
+        if (! is_array($value)) {
+            $this->error(
+                self::INVALID_VALUE,
+                (is_object($value) ? get_class($value) : gettype($value))
+            );
+            return false;
+        }
+
+        foreach ($value as $className => $mediaTypes) {
+            if (! class_exists($className)) {
+                $isValid = false;
+                $this->error(self::CLASS_NOT_FOUND, $className);
+                continue;
+            }
+
+            $interfaces = class_implements($className);
+            if (false === $interfaces || ! in_array('Zend\View\Model\ModelInterface', $interfaces)) {
+                $isValid = false;
+                $this->error(self::INVALID_VIEW_MODEL, $className);
+                continue;
+            }
+
+            if (! is_array($mediaTypes)) {
+                $isValid = false;
+                $this->error(self::INVALID_MEDIA_TYPES);
+                continue;
+            }
+
+            foreach ($mediaTypes as $mediaType) {
+                if (strpos($mediaType, '/') === false) {
+                    $isValid = false;
+                    $this->error(self::INVALID_MEDIA_TYPE, $mediaType);
+                }
+            }
+        }
+
+        return $isValid;
+    }
+}

--- a/src/InputFilter/Validator/IsStringValidator.php
+++ b/src/InputFilter/Validator/IsStringValidator.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\InputFilter\Validator;
+
+use Zend\Validator\AbstractValidator as ZfAbstractValidator;
+
+class IsStringValidator extends ZfAbstractValidator
+{
+    const INVALID_TYPE = 'invalidType';
+
+    protected $messageTemplates = array(
+        self::INVALID_TYPE => 'Value must be a string; received %value%',
+    );
+
+    /**
+     * Test if a value is a string
+     *
+     * @param array $value
+     * @return bool
+     */
+    public function isValid($value)
+    {
+        if (! is_string($value)) {
+            $this->error(self::INVALID_TYPE, (is_object($value) ? get_class($value) : gettype($value)));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Model/ContentNegotiationResource.php
+++ b/src/Model/ContentNegotiationResource.php
@@ -49,7 +49,12 @@ class ContentNegotiationResource extends AbstractResourceListener
         $name = $data['content_name'];
         unset($data['content_name']);
 
-        return $this->model->create($name, $data);
+        $selectors = array();
+        if (isset($data['selectors'])) {
+            $selectors = (array) $data['selectors'];
+        }
+
+        return $this->model->create($name, $selectors);
     }
 
     public function patch($id, $data)
@@ -58,15 +63,15 @@ class ContentNegotiationResource extends AbstractResourceListener
             $data = (array) $data;
         }
 
-        if (!is_array($data)) {
+        if (! is_array($data) || ! isset($data['selectors'])) {
             return new ApiProblem(400, 'Invalid data provided for update');
         }
 
-        if (empty($data)) {
+        if (empty($data['selectors'])) {
             return new ApiProblem(400, 'No data provided for update');
         }
 
-        return $this->model->update($id, $data);
+        return $this->model->update($id, (array) $data['selectors']);
     }
 
     public function delete($id)

--- a/src/Model/ContentNegotiationResource.php
+++ b/src/Model/ContentNegotiationResource.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Apigility\Admin\Model;
 
+use Zend\InputFilter\InputFilterInterface;
 use ZF\ApiProblem\ApiProblem;
 use ZF\Rest\AbstractResourceListener;
 use ZF\Rest\Exception\CreationException;
@@ -20,6 +21,19 @@ class ContentNegotiationResource extends AbstractResourceListener
     public function __construct(ContentNegotiationModel $model)
     {
         $this->model = $model;
+    }
+
+    /**
+     * Inject the input filter.
+     *
+     * Primarily present for testing; input filters will be injected via event
+     * normally.
+     *
+     * @param InputFilterInterface $inputFilter
+     */
+    public function setInputFilter(InputFilterInterface $inputFilter)
+    {
+        $this->inputFilter = $inputFilter;
     }
 
     public function fetch($id)
@@ -38,9 +52,7 @@ class ContentNegotiationResource extends AbstractResourceListener
 
     public function create($data)
     {
-        if (is_object($data)) {
-            $data = (array) $data;
-        }
+        $data = $this->getInputFilter()->getValues();
 
         if (!isset($data['content_name'])) {
             throw new CreationException('Missing content_name', 422);
@@ -59,11 +71,9 @@ class ContentNegotiationResource extends AbstractResourceListener
 
     public function patch($id, $data)
     {
-        if (is_object($data)) {
-            $data = (array) $data;
-        }
+        $data = $this->getInputFilter()->getValues();
 
-        if (! is_array($data) || ! isset($data['selectors'])) {
+        if (empty($data) || ! array_key_exists('selectors', $data)) {
             return new ApiProblem(400, 'Invalid data provided for update');
         }
 

--- a/test/InputFilter/ContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/ContentNegotiationInputFilterTest.php
@@ -14,11 +14,11 @@ class ContentNegotiationInputFilterTest extends TestCase
     public function dataProviderIsValid()
     {
         return array(
-            'valid' => array(
+            'valid' => array(array('selectors' => 
                 array(
                     'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                 ),
-            ),
+            )),
         );
     }
 
@@ -26,31 +26,31 @@ class ContentNegotiationInputFilterTest extends TestCase
     {
         return array(
             'class-does-not-exist' => array(
-                array(
+                array('selectors' => array(
                     'Zend\View\Model\ViewMode' => array('text/html', 'application/xhtml+xml'),
-                ),
+                )),
                 array('Zend\View\Model\ViewMode' => array('Class name (Zend\View\Model\ViewMode) does not exist')),
             ),
             'class-is-not-view-model' => array(
-                array(
+                array('selectors' => array(
                     __CLASS__ => array('text/html', 'application/xhtml+xml'),
-                ),
+                )),
                 array(__CLASS__ => array(
                     'Class name (' . __CLASS__ . ') is invalid; must be a valid Zend\View\Model\ModelInterface class',
                 )),
             ),
             'media-types-not-array' => array(
-                array(
+                array('selectors' => array(
                     'Zend\View\Model\ViewModel' => 'foo',
-                ),
+                )),
                 array('Zend\View\Model\ViewModel' => array(
                     'Values for the media-types must be provided as an indexed array',
                 )),
             ),
             'invalid-media-type' => array(
-                array(
+                array('selectors' => array(
                     'Zend\View\Model\ViewModel' => array('texthtml', 'application/xhtml+xml'),
-                ),
+                )),
                 array('Zend\View\Model\ViewModel' => array('Invalid media type (texthtml) provided')),
             ),
         );

--- a/test/InputFilter/ContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/ContentNegotiationInputFilterTest.php
@@ -14,7 +14,7 @@ class ContentNegotiationInputFilterTest extends TestCase
     public function dataProviderIsValid()
     {
         return array(
-            'valid' => array(array('selectors' => 
+            'valid' => array(array('selectors' =>
                 array(
                     'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                 ),
@@ -29,29 +29,34 @@ class ContentNegotiationInputFilterTest extends TestCase
                 array('selectors' => array(
                     'Zend\View\Model\ViewMode' => array('text/html', 'application/xhtml+xml'),
                 )),
-                array('Zend\View\Model\ViewMode' => array('Class name (Zend\View\Model\ViewMode) does not exist')),
+                array('selectors' => array(
+                    'classNotFound' => 'Class name (Zend\View\Model\ViewMode) does not exist',
+                )),
             ),
             'class-is-not-view-model' => array(
                 array('selectors' => array(
                     __CLASS__ => array('text/html', 'application/xhtml+xml'),
                 )),
-                array(__CLASS__ => array(
-                    'Class name (' . __CLASS__ . ') is invalid; must be a valid Zend\View\Model\ModelInterface class',
+                array('selectors' => array(
+                    'invalidViewModel' => 'Class name (' . __CLASS__ . ') is invalid;'
+                    . ' must be a valid Zend\View\Model\ModelInterface instance',
                 )),
             ),
             'media-types-not-array' => array(
                 array('selectors' => array(
                     'Zend\View\Model\ViewModel' => 'foo',
                 )),
-                array('Zend\View\Model\ViewModel' => array(
-                    'Values for the media-types must be provided as an indexed array',
+                array('selectors' => array(
+                    'invalidMediaTypes' => 'Values for the media-types must be provided as an indexed array',
                 )),
             ),
             'invalid-media-type' => array(
                 array('selectors' => array(
                     'Zend\View\Model\ViewModel' => array('texthtml', 'application/xhtml+xml'),
                 )),
-                array('Zend\View\Model\ViewModel' => array('Invalid media type (texthtml) provided')),
+                array('selectors' => array(
+                    'invalidMediaType' => 'Invalid media type (texthtml) provided',
+                )),
             ),
         );
     }
@@ -73,6 +78,7 @@ class ContentNegotiationInputFilterTest extends TestCase
     {
         $filter = new ContentNegotiationInputFilter;
         $filter->setData($data);
+        $input = $filter->get('selectors');
         $this->assertFalse($filter->isValid());
         $this->assertEquals($messages, $filter->getMessages());
     }

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -35,7 +35,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                     ),
                 ),
                 array(
-                    'content_name' => array('No content_name was provided; must be present for new negotiators.'),
+                    'content_name' => array(
+                        'isEmpty' => 'Value is required and can\'t be empty'
+                    ),
                 ),
             ),
             'null-content-name' => array(
@@ -45,9 +47,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                         'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                     ),
                 ),
-                array(
-                    'content_name' => array('Content name provided is invalid; must be a string'),
-                ),
+                array('content_name' => array(
+                    'isEmpty' => 'Value is required and can\'t be empty',
+                )),
             ),
             'bool-content-name' => array(
                 array(
@@ -56,9 +58,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                         'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                     ),
                 ),
-                array(
-                    'content_name' => array('Content name provided is invalid; must be a string'),
-                ),
+                array('content_name' => array(
+                    'invalidType' => 'Value must be a string; received boolean',
+                )),
             ),
             'int-content-name' => array(
                 array(
@@ -67,9 +69,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                         'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                     )
                 ),
-                array(
-                    'content_name' => array('Content name provided is invalid; must be a string'),
-                ),
+                array('content_name' => array(
+                    'invalidType' => 'Value must be a string; received integer',
+                )),
             ),
             'float-content-name' => array(
                 array(
@@ -78,9 +80,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                         'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                     )
                 ),
-                array(
-                    'content_name' => array('Content name provided is invalid; must be a string'),
-                ),
+                array('content_name' => array(
+                    'invalidType' => 'Value must be a string; received double',
+                )),
             ),
             'array-content-name' => array(
                 array(
@@ -89,9 +91,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                         'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                     )
                 ),
-                array(
-                    'content_name' => array('Content name provided is invalid; must be a string'),
-                ),
+                array('content_name' => array(
+                    'invalidType' => 'Value must be a string; received array',
+                )),
             ),
             'object-content-name' => array(
                 array(
@@ -100,9 +102,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                         'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
                     ),
                 ),
-                array(
-                    'content_name' => array('Content name provided is invalid; must be a string'),
-                ),
+                array('content_name' => array(
+                    'invalidType' => 'Value must be a string; received stdClass',
+                )),
             ),
         );
     }

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -17,8 +17,10 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'with-content-name' => array(
                 array(
                     'content_name' => 'test',
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                )
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    ),
+                ),
             ),
         );
     }
@@ -28,7 +30,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
         return array(
             'missing-content-name' => array(
                 array(
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    ),
                 ),
                 array(
                     'content_name' => array('No content_name was provided; must be present for new negotiators.'),
@@ -37,7 +41,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'null-content-name' => array(
                 array(
                     'content_name' => null,
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    ),
                 ),
                 array(
                     'content_name' => array('Content name provided is invalid; must be a string'),
@@ -46,7 +52,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'bool-content-name' => array(
                 array(
                     'content_name' => true,
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    ),
                 ),
                 array(
                     'content_name' => array('Content name provided is invalid; must be a string'),
@@ -55,7 +63,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'int-content-name' => array(
                 array(
                     'content_name' => 1,
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    )
                 ),
                 array(
                     'content_name' => array('Content name provided is invalid; must be a string'),
@@ -64,7 +74,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'float-content-name' => array(
                 array(
                     'content_name' => 1.1,
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    )
                 ),
                 array(
                     'content_name' => array('Content name provided is invalid; must be a string'),
@@ -73,7 +85,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'array-content-name' => array(
                 array(
                     'content_name' => array('content_name'),
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    )
                 ),
                 array(
                     'content_name' => array('Content name provided is invalid; must be a string'),
@@ -82,7 +96,9 @@ class CreateContentNegotiationInputFilterTest extends TestCase
             'object-content-name' => array(
                 array(
                     'content_name' => (object) array('content_name'),
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    'selectors' => array(
+                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
+                    ),
                 ),
                 array(
                     'content_name' => array('Content name provided is invalid; must be a string'),

--- a/test/Model/ContentNegotiationResourceTest.php
+++ b/test/Model/ContentNegotiationResourceTest.php
@@ -8,6 +8,8 @@ namespace ZFTest\Apigility\Admin\Model;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Config\Writer\PhpArray as ConfigWriter;
+use ZF\Apigility\Admin\InputFilter\ContentNegotiationInputFilter;
+use ZF\Apigility\Admin\InputFilter\CreateContentNegotiationInputFilter;
 use ZF\Apigility\Admin\Model\ContentNegotiationModel;
 use ZF\Apigility\Admin\Model\ContentNegotiationResource;
 use ZF\Configuration\ConfigResource;
@@ -61,29 +63,41 @@ class ContentNegotiationResourceTest extends TestCase
 
     public function testCreateShouldAcceptContentNameAndReturnNewEntity()
     {
+        $data = array('content_name' => 'Test');
         $resource = $this->createResourceFromConfigArray(array());
-        $data = (object) array('content_name' => 'Test');
-        $entity = $resource->create($data);
+        $createFilter = new CreateContentNegotiationInputFilter();
+        $createFilter->setData($data);
+        $resource->setInputFilter($createFilter);
+
+        $entity = $resource->create(array());
+
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
         $this->assertEquals('Test', $entity->name);
     }
 
     public function testUpdateShouldAcceptContentNameAndSelectorsAndReturnUpdatedEntity()
     {
+        $data = array('content_name' => 'Test');
         $resource = $this->createResourceFromConfigArray(array());
-        $data = (object) array('content_name' => 'Test');
-        $entity = $resource->create($data);
+        $createFilter = new CreateContentNegotiationInputFilter();
+        $createFilter->setData($data);
+        $resource->setInputFilter($createFilter);
 
-        $data = (object) array('selectors' => array(
+        $entity = $resource->create(array());
+
+        $data = array('selectors' => array(
             'Zend\View\Model\ViewModel' => array(
                 'text/html',
                 'application/xhtml+xml',
             ),
         ));
+        $updateFilter = new ContentNegotiationInputFilter();
+        $updateFilter->setData($data);
+        $resource->setInputFilter($updateFilter);
 
-        $entity = $resource->patch('Test', $data);
+        $entity = $resource->patch('Test', array());
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
         $this->assertEquals('Test', $entity->name);
-        $this->assertEquals($data->selectors, $entity->config);
+        $this->assertEquals($data['selectors'], $entity->config);
     }
 }

--- a/test/Model/ContentNegotiationResourceTest.php
+++ b/test/Model/ContentNegotiationResourceTest.php
@@ -67,4 +67,23 @@ class ContentNegotiationResourceTest extends TestCase
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
         $this->assertEquals('Test', $entity->name);
     }
+
+    public function testUpdateShouldAcceptContentNameAndSelectorsAndReturnUpdatedEntity()
+    {
+        $resource = $this->createResourceFromConfigArray(array());
+        $data = (object) array('content_name' => 'Test');
+        $entity = $resource->create($data);
+
+        $data = (object) array('selectors' => array(
+            'Zend\View\Model\ViewModel' => array(
+                'text/html',
+                'application/xhtml+xml',
+            ),
+        ));
+
+        $entity = $resource->patch('Test', $data);
+        $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
+        $this->assertEquals('Test', $entity->name);
+        $this->assertEquals($data->selectors, $entity->config);
+    }
 }


### PR DESCRIPTION
InputFilters require named inputs. Previously, the CN input filter was attempting to allow setting the following data structure:

```php
[
   'view model class name' => [ /* array of mediatypes */ ],
]
```

This was failing, because we did not have inputs named after the view model class names (and really cannot).

The changes in this patch push the view-model/mediatype pairs under a "selectors" key, allowing them to be validated correctly. It does this by moving the validation logic to a validator, and then creating an input that composes that validator. The `content_name` validation was also moved into an `IsString` validator.

Since the input filter now has keys for each of `content_name` and `selectors`, the selectors data is now pulled from the latter.