### PR TITLE
Selectors should be optional for CN creation

### DIFF
--- a/src/InputFilter/CreateContentNegotiationInputFilter.php
+++ b/src/InputFilter/CreateContentNegotiationInputFilter.php
@@ -13,11 +13,14 @@ class CreateContentNegotiationInputFilter extends ContentNegotiationInputFilter
 {
     public function __construct()
     {
+        parent::__construct();
+
+        $this->get('selectors')->setRequired(false);
+
         $input = new Input('content_name');
         $input->setRequired(true);
         $chain = $input->getValidatorChain();
         $chain->attach(new Validator\IsStringValidator());
         $this->add($input);
-        parent::__construct();
     }
 }

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -14,7 +14,12 @@ class CreateContentNegotiationInputFilterTest extends TestCase
     public function dataProviderIsValid()
     {
         return array(
-            'with-content-name' => array(
+            'content-name-only' => array(
+                array(
+                    'content_name' => 'test',
+                ),
+            ),
+            'content-name-and-selectors' => array(
                 array(
                     'content_name' => 'test',
                     'selectors' => array(


### PR DESCRIPTION
Per the topic: selectors should be optional when creating a new content-negotiation selector definition.