### PR TITLE
[#246] Authorization changes should occur with PATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ resource](#authorization).
   Expects an [authorization resource](#authorization) with all details
   necessary for specifying authorization rules.
 
-- HTTP methods: `GET`, `PUT`
+- HTTP methods: `GET`, `PATCH`
 
   `GET` will always return an entity; if no configuration existed previously
   for the module, or if any given service at the given version was not listed
   in the configuration, it will provide the default values.
 
-  `PUT` will return a `200` response on success, along with the updated
+  `PATCH` will return a `200` response on success, along with the updated
   entity.
 
 - Errors: `application/problem+json`

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -720,7 +720,7 @@ return array(
             'route_name'   => 'zf-apigility/api/authentication',
         ),
         'ZF\Apigility\Admin\Controller\Authorization' => array(
-            'http_methods' => array('GET', 'PUT'),
+            'http_methods' => array('GET', 'PATCH', 'PUT'),
             'route_name'   => 'zf-apigility/api/module/authorization',
         ),
         'ZF\Apigility\Admin\Controller\CacheEnabled' => array(

--- a/src/Controller/AuthorizationController.php
+++ b/src/Controller/AuthorizationController.php
@@ -41,6 +41,12 @@ class AuthorizationController extends AbstractActionController
                 $entity = $model->fetch($version);
                 break;
             case $request::METHOD_PUT:
+                $this->getResponse()->getHeaders()->addHeaderLine(
+                    'X-Deprecated',
+                    'This service has deprecated the PUT method; please use PATCH'
+                );
+                // intentionally fall through
+            case $request::METHOD_PATCH:
                 $entity = $model->update($this->bodyParams(), $version);
                 break;
             default:


### PR DESCRIPTION
Implemented PATCH as an HTTP method for the authorization service, and
deprecated PUT.

Fixes #246