### PR TITLE
[WIP] adding proof of concept psr-4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/*
 .project
 .buildpath
 .settings
+.idea

--- a/Module.php
+++ b/Module.php
@@ -174,19 +174,34 @@ class Module
                 return new Model\DbAdapterResource($model);
             },
             'ZF\Apigility\Admin\Model\ModulePathSpec' => function($services) {
+                if (!$services->has('ZF\Configuration\ModuleUtils')) {
+                    throw new ServiceNotCreatedException(
+                        'Cannot create ZF\Apigility\Admin\Model\ModulePathSpec service because ZF\Configuration\ModuleUtils service is not present'
+                    );
+                }
 
                 $pathSpec   = 'psr-0';
-
+                $path       = '.';
                 if ($services->has('Config')) {
                     $config = $services->get('Config');
                     if (!empty($config['zf-apigility-admin'])) {
                         if (!empty($config['zf-apigility-admin']['path_spec'])) {
                             $pathSpec = $config['zf-apigility-admin']['path_spec'];
                         }
+
+                        if (isset($config['zf-apigility-admin']['module_path'])) {
+                            $path = $config['zf-apigility-admin']['module_path'];
+                            if (!is_dir($path)) {
+                                throw new InvalidArgumentException(sprintf(
+                                    'Invalid module path "%s"; does not exist',
+                                    $path
+                                ));
+                            }
+                        }
                     }
                 }
 
-                $modulePathSpec = new Model\ModulePathSpec($services->get('ZF\Configuration\ModuleUtils'), $pathSpec);
+                $modulePathSpec = new Model\ModulePathSpec($services->get('ZF\Configuration\ModuleUtils'), $pathSpec, $path);
 
                 return $modulePathSpec;
             },
@@ -197,7 +212,6 @@ class Module
                     );
                 }
                 $modules    = $services->get('ModuleManager');
-                $modulesPathSpec = $services->get('ZF\Apigility\Admin\Model\ModulePathSpec');
 
                 $restConfig = array();
                 $rpcConfig  = array();
@@ -210,20 +224,14 @@ class Module
                         $rpcConfig = $config['zf-rpc'];
                     }
                 }
-                return new Model\ModuleModel($modules, $modulesPathSpec, $restConfig, $rpcConfig);
+                return new Model\ModuleModel($modules, $restConfig, $rpcConfig);
             },
             'ZF\Apigility\Admin\Model\ModuleResource' => function ($services) {
-                $moduleModel = $services->get('ZF\Apigility\Admin\Model\ModuleModel');
-                $listener    = new Model\ModuleResource($moduleModel);
+                $moduleModel     = $services->get('ZF\Apigility\Admin\Model\ModuleModel');
+                $modulePathSpec = $services->get('ZF\Apigility\Admin\Model\ModulePathSpec');
 
-                if ($services->has('Config')) {
-                    $config = $services->get('Config');
-                    if (isset($config['zf-apigility-admin'])) {
-                        if (isset($config['zf-apigility-admin']['module_path'])) {
-                            $listener->setModulePath($config['zf-apigility-admin']['module_path']);
-                        }
-                    }
-                }
+                $listener        = new Model\ModuleResource($moduleModel, $modulePathSpec);
+
                 return $listener;
             },
             'ZF\Apigility\Admin\Model\RestServiceModelFactory' => function ($services) {

--- a/Module.php
+++ b/Module.php
@@ -192,7 +192,7 @@ class Module
                         if (isset($config['zf-apigility-admin']['module_path'])) {
                             $path = $config['zf-apigility-admin']['module_path'];
                             if (!is_dir($path)) {
-                                throw new InvalidArgumentException(sprintf(
+                                throw new ServiceNotCreatedException(sprintf(
                                     'Invalid module path "%s"; does not exist',
                                     $path
                                 ));

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
             "AuthConfWithConfig\\": "test/Model/TestAsset/module/AuthConfWithConfig/",
             "BarConf\\": "test/Model/TestAsset/module/BarConf/src/BarConf/",
             "FooConf\\": "test/Model/TestAsset/module/FooConf/src/FooConf/",
+            "BazConf\\": "test/Model/TestAsset/module/BazConf",
             "InputFilter\\": "test/Model/TestAsset/module/InputFilter/",
             "Version\\": "test/Model/TestAsset/module/Version/src/Version/"
         }

--- a/src/Model/AuthorizationModel.php
+++ b/src/Model/AuthorizationModel.php
@@ -6,7 +6,7 @@
 
 namespace ZF\Apigility\Admin\Model;
 
-use ZF\Apigility\Model\ModulePathSpec;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Configuration\ConfigResource;
 use ZF\Configuration\ModuleUtils;
 

--- a/src/Model/AuthorizationModel.php
+++ b/src/Model/AuthorizationModel.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Apigility\Admin\Model;
 
+use ZF\Apigility\Model\ModulePathSpec;
 use ZF\Configuration\ConfigResource;
 use ZF\Configuration\ModuleUtils;
 
@@ -41,7 +42,7 @@ class AuthorizationModel
      * @param  ModuleUtils $modules
      * @param  ConfigResource $config
      */
-    public function __construct(ModuleEntity $moduleEntity, ModuleUtils $modules, ConfigResource $config)
+    public function __construct(ModuleEntity $moduleEntity, ModulePathSpec $modules, ConfigResource $config)
     {
         $this->module         = $moduleEntity->getName();
         $this->moduleEntity   = $moduleEntity;

--- a/src/Model/AuthorizationModelFactory.php
+++ b/src/Model/AuthorizationModelFactory.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Apigility\Admin\Model;
 
+use ZF\Apigility\Model\ModulePathSpec;
 use ZF\Configuration\ResourceFactory as ConfigResourceFactory;
 use ZF\Configuration\ModuleUtils;
 
@@ -38,7 +39,7 @@ class AuthorizationModelFactory
      * @param  ConfigResourceFactory $configFactory
      * @param  ModuleModel $moduleModel
      */
-    public function __construct(ModuleUtils $modules, ConfigResourceFactory $configFactory, ModuleModel $moduleModel)
+    public function __construct(ModulePathSpec $modules, ConfigResourceFactory $configFactory, ModuleModel $moduleModel)
     {
         $this->modules            = $modules;
         $this->configFactory      = $configFactory;

--- a/src/Model/AuthorizationModelFactory.php
+++ b/src/Model/AuthorizationModelFactory.php
@@ -6,7 +6,6 @@
 
 namespace ZF\Apigility\Admin\Model;
 
-use ZF\Apigility\Model\ModulePathSpec;
 use ZF\Configuration\ResourceFactory as ConfigResourceFactory;
 use ZF\Configuration\ModuleUtils;
 

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -163,7 +163,7 @@ class ModuleModel
         $renderer = new PhpRenderer();
         $renderer->setResolver($resolver);
 
-        if($pathSpec->getPathSpec() === 'psr-0') {
+        if ($pathSpec->getPathSpec() === 'psr-0') {
             $view->setTemplate('module/skeleton');
             $moduleRelClassPath = "$moduleSourceRelativePath/Module.php";
 

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -144,8 +144,8 @@ class ModuleModel
 
         mkdir($moduleConfigPath, 0775, true);
         mkdir($pathSpec->getModuleViewPath($module), 0775, true);
-        mkdir($pathSpec->getRestPath($module,1), 0775, true);
-        mkdir($pathSpec->getRpcPath($module,1), 0775, true);
+        mkdir($pathSpec->getRestPath($module, 1), 0775, true);
+        mkdir($pathSpec->getRpcPath($module, 1), 0775, true);
 
         if (!file_put_contents("$moduleConfigPath/module.config.php", "<" . "?php\nreturn array(\n);")) {
             return false;
@@ -163,7 +163,9 @@ class ModuleModel
         $renderer = new PhpRenderer();
         $renderer->setResolver($resolver);
 
-        if (!file_put_contents("$modulePath/Module.php", "<" . "?php\nrequire __DIR__ . '$moduleSourceRelativePath/Module.php';")) {
+        $moduleRelClassPath = "$moduleSourceRelativePath/Module.php";
+
+        if (!file_put_contents("$modulePath/Module.php", "<" . "?php\nrequire __DIR__ . '$moduleRelClassPath';")) {
             return false;
         }
         if (!file_put_contents("$moduleSourcePath/Module.php", "<" . "?php\n" . $renderer->render($view))) {

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -156,20 +156,28 @@ class ModuleModel
         ));
 
         $resolver = new Resolver\TemplateMapResolver(array(
-            'module/skeleton' => __DIR__ . '/../../view/module/skeleton.phtml'
+            'module/skeleton' => __DIR__ . '/../../view/module/skeleton.phtml',
+            'module/skeleton-psr4' => __DIR__ . '/../../view/module/skeleton-psr4.phtml',
         ));
 
-        $view->setTemplate('module/skeleton');
         $renderer = new PhpRenderer();
         $renderer->setResolver($resolver);
 
-        $moduleRelClassPath = "$moduleSourceRelativePath/Module.php";
+        if($pathSpec->getPathSpec() === 'psr-0') {
+            $view->setTemplate('module/skeleton');
+            $moduleRelClassPath = "$moduleSourceRelativePath/Module.php";
 
-        if (!file_put_contents("$modulePath/Module.php", "<" . "?php\nrequire __DIR__ . '$moduleRelClassPath';")) {
-            return false;
-        }
-        if (!file_put_contents("$moduleSourcePath/Module.php", "<" . "?php\n" . $renderer->render($view))) {
-            return false;
+            if (!file_put_contents("$modulePath/Module.php", "<" . "?php\nrequire __DIR__ . '$moduleRelClassPath';")) {
+                return false;
+            }
+            if (!file_put_contents("$moduleSourcePath/Module.php", "<" . "?php\n" . $renderer->render($view))) {
+                return false;
+            }
+        } else {
+            $view->setTemplate('module/skeleton-psr4');
+            if (!file_put_contents("$modulePath/Module.php", "<" . "?php\n" . $renderer->render($view))) {
+                return false;
+            }
         }
 
         // Add the module in application.config.php

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -130,20 +130,20 @@ class ModuleModel
             return false;
         }
 
-//        $modulePath = sprintf('%s/module/%s', $path, $module);
-//        if (file_exists($modulePath)) {
-//            throw new \Exception(sprintf(
-//                'Cannot create new API module; module by the name "%s" already exists',
-//                $module
-//            ), 409);
-//        }
-        $modulePath               = $this->modulePathSpec->getModulePath($module);
+        $modulePath = $this->modulePathSpec->getModulePath($module);
+        if (file_exists($modulePath)) {
+            throw new \Exception(sprintf(
+                'Cannot create new API module; module by the name "%s" already exists',
+                $module
+            ), 409);
+        }
+
         $moduleSourcePath         = $this->modulePathSpec->getModuleSourcePath($module);
         $moduleSourceRelativePath = $this->modulePathSpec->getModuleSourcePath($module, false);
         $moduleConfigPath         = $this->modulePathSpec->getModuleConfigPath();
 
         mkdir($moduleConfigPath, 0775, true);
-        mkdir($this->modulePathSpec->getModuleViewPath(), 0775, true);
+        mkdir($this->modulePathSpec->getModuleViewPath($module), 0775, true);
         mkdir($this->modulePathSpec->getRestPath($module), 0775, true);
         mkdir($this->modulePathSpec->getRpcPath($module), 0775, true);
 

--- a/src/Model/ModulePathSpec.php
+++ b/src/Model/ModulePathSpec.php
@@ -32,9 +32,9 @@ class ModulePathSpec
      * @param string $sourcePathSpec
      * @param string $modulePath
      */
-    public function __construct(ModuleUtils $modules, $sourcePathSpec = 'psr-0',  $applicationPath = ".")
+    public function __construct(ModuleUtils $modules, $sourcePathSpec = 'psr-0', $applicationPath = ".")
     {
-        if(!array_key_exists($sourcePathSpec, $this->psrSpecs)) {
+        if (!array_key_exists($sourcePathSpec, $this->psrSpecs)) {
             throw new InvalidArgumentException("Invalid sourcePathSpec valid values are psr-0, psr-4");
         }
 
@@ -64,7 +64,7 @@ class ModulePathSpec
         // see if we can get the path from ModuleUtils, if module isn't set will throw exception
         try {
             $modulePath = $this->modules->getModulePath($moduleName);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $modulePath = sprintf($this->modulePathSpec, $this->applicationPath, $moduleName);
         }
 
@@ -99,7 +99,9 @@ class ModulePathSpec
     {
         $find    = array("%modulePath%", "%moduleName%");
 
-        if(true === $fullPath) {
+        $moduleName = str_replace('\\', '/', $moduleName);
+
+        if (true === $fullPath) {
             $replace = array($this->getModulePath($moduleName), $moduleName);
         } else {
             $replace = array('', $moduleName);
@@ -124,7 +126,7 @@ class ModulePathSpec
         $path = $this->getModuleSourcePath($moduleName);
         $path .= str_replace($find, $replace, $this->restPathSpec);
 
-        if(substr($path, -1) != "/") {
+        if (substr($path, -1) != "/") {
             $path .= "/";
         }
 
@@ -141,7 +143,7 @@ class ModulePathSpec
         $path = $this->getModuleSourcePath($moduleName);
         $path .= str_replace($find, $replace, $this->rpcPathSpec);
 
-        if(substr($path, -1) != "/") {
+        if (substr($path, -1) != "/") {
             $path .= "/";
         }
 

--- a/src/Model/ModulePathSpec.php
+++ b/src/Model/ModulePathSpec.php
@@ -16,6 +16,8 @@ class ModulePathSpec
         'psr-4' => '%modulePath%/src'
     );
 
+    protected $currentSpec = 'psr-0';
+
     /**
      * @var string  PSR-0
      */
@@ -41,6 +43,12 @@ class ModulePathSpec
         $this->modules              = $modules;
         $this->moduleSourcePathSpec = $this->psrSpecs[$sourcePathSpec];
         $this->applicationPath      = $applicationPath;
+        $this->currentSpec          = $sourcePathSpec;
+    }
+
+    public function getPathSpec()
+    {
+        return $this->currentSpec;
     }
 
     /**

--- a/src/Model/ModulePathSpec.php
+++ b/src/Model/ModulePathSpec.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace ZF\Apigility\Admin\Model;
+
+use \InvalidArgumentException;
+use ZF\Configuration\ModuleUtils;
+
+class ModulePathSpec
+{
+    protected $modules;
+
+    protected $psrSpecs = array(
+        'psr-0' => '%modulePath%/src/%moduleName%',
+        'psr-4' => '%modulePath%/src'
+    );
+
+    /**
+     * @var string  PSR-0
+     */
+    protected $moduleSourcePathSpec;
+
+    protected $restPathSpec = "/V%version%/Rest";
+
+    protected $rpcPathSpec = "/V%version%/Rpc";
+
+
+    public function __construct(ModuleUtils $modules, $sourcePathSpec = 'psr-0')
+    {
+        if(!array_key_exists($sourcePathSpec, $this->psrSpecs)) {
+            throw new InvalidArgumentException("Invalid sourcePathSpec valid values are psr-0, psr-4");
+        }
+
+        $this->modules = $modules;
+        $this->moduleSourcePathSpec = $this->psrSpecs[$sourcePathSpec];
+    }
+
+    public function getModulePath($moduleName)
+    {
+        return $this->modules->getModulePath($moduleName);
+    }
+
+    /**
+     * @todo add support for custom rest/rpc path specs.  This will require that className resolution is also provided.
+    public function setRestPathSpec($spec)
+    {
+        if(empty($spec)) {
+            return;
+        }
+
+        $this->restPathSpec = $spec;
+
+        return $this;
+    }
+
+    public function setRpcPathSpec($spec)
+    {
+        if(empty($spec)) {
+            return;
+        }
+
+        $this->rpcPathSpec = $spec;
+
+        return $this;
+    }*/
+
+    public function getModuleSourcePath($moduleName, $fullPath = true)
+    {
+        $find    = array("%modulePath%", "%moduleName%");
+
+        if(true === $fullPath) {
+            $replace = array($this->getModulePath($moduleName), $moduleName);
+        } else {
+            $replace = array('', $moduleName);
+        }
+
+        return str_replace($find, $replace, $this->moduleSourcePathSpec);
+    }
+
+    /**
+     * Get the REST service path for a given module, service name and version
+     *
+     * @param string $moduleName
+     * @param string $serviceName
+     * @param int $version
+     * @return string
+     */
+    public function getRestPath($moduleName, $version = 1, $serviceName = null)
+    {
+        $find    = array("%serviceName%", "%version%");
+        $replace = array($serviceName, $version);
+
+        $path = $this->getModuleSourcePath($moduleName);
+        $path .= str_replace($find, $replace, $this->restPathSpec);
+
+        if(substr($path, -1) != "/") {
+            $path .= "/";
+        }
+
+        $path .= (!empty($serviceName)) ? $serviceName : '';
+
+        return $path;
+    }
+
+    public function getRpcPath($moduleName, $version = 1, $serviceName = null)
+    {
+        $find    = array("%version%");
+        $replace = array($version);
+
+        $path = $this->getModuleSourcePath($moduleName);
+        $path .= str_replace($find, $replace, $this->rpcPathSpec);
+
+        if(substr($path, -1) != "/") {
+            $path .= "/";
+        }
+
+        $path .= (!empty($serviceName)) ? $serviceName : '';
+
+        return $path;
+    }
+
+    public function getModuleConfigPath($moduleName)
+    {
+        return $this->modules->getModulePath($moduleName) . "/config";
+    }
+
+    public function getModuleViewPath($moduleName)
+    {
+        return $this->modules->getModulePath($moduleName) . "/view";
+    }
+}

--- a/src/Model/ModuleResource.php
+++ b/src/Model/ModuleResource.php
@@ -22,12 +22,15 @@ class ModuleResource extends AbstractResourceListener
      */
     protected $modulePath = '.';
 
+    protected $modulePathSpec;
+
     /**
      * @param ModuleModel $modules
      */
-    public function __construct(ModuleModel $modules)
+    public function __construct(ModuleModel $modules, ModulePathSpec $pathSpec)
     {
         $this->modules = $modules;
+        $this->modulePathSpec = $pathSpec;
     }
 
     /**
@@ -39,13 +42,12 @@ class ModuleResource extends AbstractResourceListener
      */
     public function setModulePath($path)
     {
-        if (!is_dir($path)) {
-            throw new InvalidArgumentException(sprintf(
-                'Invalid module path "%s"; does not exist',
-                $path
-            ));
-        }
-        $this->modulePath = $path;
+        /*
+         * maintain backwards compatibility
+         * NOTE: modulePath in this case, is really the application path
+         */
+        $this->modulePathSpec->setApplicationPath($path);
+
         return $this;
     }
 
@@ -73,7 +75,7 @@ class ModuleResource extends AbstractResourceListener
             throw new CreationException('Invalid module name; must be a valid PHP namespace name');
         }
 
-        if (false === $this->modules->createModule($name, $this->modulePath, $version)) {
+        if (false === $this->modules->createModule($name, $this->modulePathSpec)) {
             throw new CreationException('Unable to create module; check your paths and permissions');
         }
 

--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -93,7 +93,7 @@ class RestServiceModel implements EventManagerAwareInterface
      * @param  ModuleUtils $modules
      * @param  ConfigResource $config
      */
-    public function __construct(ModuleEntity $moduleEntity, ModuleUtils $modules, ConfigResource $config)
+    public function __construct(ModuleEntity $moduleEntity, ModulePathSpec $modules, ConfigResource $config)
     {
         $this->module         = $moduleEntity->getName();
         $this->moduleEntity   = $moduleEntity;
@@ -952,7 +952,7 @@ class RestServiceModel implements EventManagerAwareInterface
     /**
      * Delete content-negotiation configuration associated with a service
      *
-     * @param  RestServiceEntity $entity
+     * @param  RestServiceEntity $entitysource
      */
     public function deleteContentNegotiationConfig(RestServiceEntity $entity)
     {
@@ -1130,10 +1130,16 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     protected function getSourcePath($serviceName)
     {
-        $sourcePath = sprintf(
-            '%s/src/%s/V%s/Rest/%s',
-            $this->modulePath,
-            str_replace('\\', '/', $this->module),
+//        $sourcePath = sprintf(
+//            '%s/src/%s/V%s/Rest/%s',
+//            $this->modulePath,
+//            str_replace('\\', '/', $this->module),
+//            $this->moduleEntity->getLatestVersion(),
+//            $serviceName
+//        );
+
+        $sourcePath = $this->modules->getRestPath(
+            $this->module,
             $this->moduleEntity->getLatestVersion(),
             $serviceName
         );

--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -1130,14 +1130,6 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     protected function getSourcePath($serviceName)
     {
-//        $sourcePath = sprintf(
-//            '%s/src/%s/V%s/Rest/%s',
-//            $this->modulePath,
-//            str_replace('\\', '/', $this->module),
-//            $this->moduleEntity->getLatestVersion(),
-//            $serviceName
-//        );
-
         $sourcePath = $this->modules->getRestPath(
             $this->module,
             $this->moduleEntity->getLatestVersion(),

--- a/src/Model/RpcServiceModel.php
+++ b/src/Model/RpcServiceModel.php
@@ -293,7 +293,8 @@ class RpcServiceModel
         $module     = $this->module;
         $modulePath = $this->modules->getModulePath($module);
         $version    = $this->moduleEntity->getLatestVersion();
-        
+        $serviceName = str_replace("\\", "/", $serviceName);
+
         $srcPath = $this->modules->getRpcPath($module, $version, $serviceName);
 
         if (!file_exists($srcPath)) {

--- a/src/Model/RpcServiceModel.php
+++ b/src/Model/RpcServiceModel.php
@@ -50,7 +50,7 @@ class RpcServiceModel
      * @param  ModuleUtils $modules
      * @param  ConfigResource $config
      */
-    public function __construct(ModuleEntity $moduleEntity, ModuleUtils $modules, ConfigResource $config)
+    public function __construct(ModuleEntity $moduleEntity, ModulePathSpec $modules, ConfigResource $config)
     {
         $this->module         = $moduleEntity->getName();
         $this->moduleEntity   = $moduleEntity;
@@ -241,21 +241,13 @@ class RpcServiceModel
     public function createFactoryController($serviceName)
     {
         $module     = $this->module;
-        $modulePath = $this->modules->getModulePath($module);
         $version    = $this->moduleEntity->getLatestVersion();
 
-        $srcPath = sprintf(
-            '%s/src/%s/V%s/Rpc/%s',
-            $modulePath,
-            str_replace('\\', '/', $module),
-            $version,
-            $serviceName
-        );
+        $srcPath = $this->modules->getRpcPath($module, $version, $serviceName);
 
         $className         = sprintf('%sController', $serviceName);
         $classFactory      = sprintf('%sControllerFactory', $serviceName);
         $classPath         = sprintf('%s/%s.php', $srcPath, $classFactory);
-        $controllerService = sprintf('%s\\V%s\\Rpc\\%s\\Controller', $module, $version, $serviceName);
 
         if (file_exists($classPath)) {
             throw new Exception\RuntimeException(sprintf(
@@ -301,14 +293,8 @@ class RpcServiceModel
         $module     = $this->module;
         $modulePath = $this->modules->getModulePath($module);
         $version    = $this->moduleEntity->getLatestVersion();
-
-        $srcPath = sprintf(
-            '%s/src/%s/V%s/Rpc/%s',
-            $modulePath,
-            str_replace('\\', '/', $module),
-            $version,
-            $serviceName
-        );
+        
+        $srcPath = $this->modules->getRpcPath($module, $version, $serviceName);
 
         if (!file_exists($srcPath)) {
             mkdir($srcPath, 0775, true);

--- a/src/Model/RpcServiceModelFactory.php
+++ b/src/Model/RpcServiceModelFactory.php
@@ -46,9 +46,9 @@ class RpcServiceModelFactory
      * @param  ModuleModel $moduleModel
      */
     public function __construct(
-        ModuleUtils $modules,
-        ConfigResourceFactory $configFactory,
-        SharedEventManagerInterface $sharedEvents,
+        ModulePathSpec $modules, 
+        ConfigResourceFactory $configFactory, 
+        SharedEventManagerInterface $sharedEvents, 
         ModuleModel $moduleModel
     ) {
         $this->modules            = $modules;

--- a/src/Model/RpcServiceModelFactory.php
+++ b/src/Model/RpcServiceModelFactory.php
@@ -46,9 +46,9 @@ class RpcServiceModelFactory
      * @param  ModuleModel $moduleModel
      */
     public function __construct(
-        ModulePathSpec $modules, 
-        ConfigResourceFactory $configFactory, 
-        SharedEventManagerInterface $sharedEvents, 
+        ModulePathSpec $modules,
+        ConfigResourceFactory $configFactory,
+        SharedEventManagerInterface $sharedEvents,
         ModuleModel $moduleModel
     ) {
         $this->modules            = $modules;

--- a/src/Model/VersioningModelFactory.php
+++ b/src/Model/VersioningModelFactory.php
@@ -6,7 +6,6 @@
 
 namespace ZF\Apigility\Admin\Model;
 
-use ZF\Apigility\Model\ModulePathSpec;
 use ZF\Configuration\ModuleUtils;
 use ZF\Configuration\ResourceFactory as ConfigResourceFactory;
 

--- a/src/Model/VersioningModelFactory.php
+++ b/src/Model/VersioningModelFactory.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Apigility\Admin\Model;
 
+use ZF\Apigility\Model\ModulePathSpec;
 use ZF\Configuration\ModuleUtils;
 use ZF\Configuration\ResourceFactory as ConfigResourceFactory;
 
@@ -31,7 +32,7 @@ class VersioningModelFactory
     /**
      * @param  ConfigResourceFactory $configFactory
      */
-    public function __construct(ConfigResourceFactory $configFactory, ModuleUtils $moduleUtils)
+    public function __construct(ConfigResourceFactory $configFactory, ModulePathSpec $moduleUtils)
     {
         $this->configFactory = $configFactory;
         $this->moduleUtils   = $moduleUtils;

--- a/test/Controller/ModuleCreationControllerTest.php
+++ b/test/Controller/ModuleCreationControllerTest.php
@@ -13,6 +13,8 @@ use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\MvcEvent;
 use ZF\Apigility\Admin\Controller\ModuleCreationController;
 use ZF\Apigility\Admin\Model\ModuleModel;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
+use ZF\Configuration\ModuleUtils;
 use ZF\ContentNegotiation\ParameterDataContainer;
 
 class ModuleCreationControllerTest extends TestCase
@@ -20,7 +22,11 @@ class ModuleCreationControllerTest extends TestCase
     public function setUp()
     {
         $this->moduleManager  = new ModuleManager(array());
-        $this->moduleResource = new ModuleModel($this->moduleManager, array(), array());
+        $this->moduleResource = new ModuleModel(
+            $this->moduleManager,
+            array(),
+            array()
+        );
         $this->controller     = new ModuleCreationController($this->moduleResource);
     }
 
@@ -72,7 +78,11 @@ class ModuleCreationControllerTest extends TestCase
                       ->method('getLoadedModules')
                       ->will($this->returnValue(array('Foo' => new \Foo\Module)));
 
-        $moduleResource = new ModuleModel($moduleManager, array(), array());
+        $moduleResource = new ModuleModel(
+            $moduleManager,
+            array(),
+            array()
+        );
         $controller     = new ModuleCreationController($moduleResource);
 
         $request = new Request();

--- a/test/Controller/SourceControllerTest.php
+++ b/test/Controller/SourceControllerTest.php
@@ -11,6 +11,8 @@ use Zend\Http\Request;
 use Zend\ModuleManager\ModuleManager;
 use ZF\Apigility\Admin\Controller\SourceController;
 use ZF\Apigility\Admin\Model\ModuleModel;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
+use ZF\Configuration\ModuleUtils;
 use ZFTest\Apigility\Admin\Model\TestAsset\Bar\Module as BarModule;
 
 class SourceControllerTest extends TestCase
@@ -18,7 +20,11 @@ class SourceControllerTest extends TestCase
     public function setUp()
     {
         $this->moduleManager  = new ModuleManager(array());
-        $this->moduleResource = new ModuleModel($this->moduleManager, array(), array());
+        $this->moduleResource = new ModuleModel(
+            $this->moduleManager,
+            array(),
+            array()
+        );
         $this->controller     = new SourceController($this->moduleResource);
     }
 

--- a/test/Model/AuthorizationModelTest.php
+++ b/test/Model/AuthorizationModelTest.php
@@ -15,6 +15,7 @@ use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\AuthorizationEntity;
 use ZF\Apigility\Admin\Model\AuthorizationModel;
 use ZF\Apigility\Admin\Model\ModuleEntity;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Configuration\ResourceFactory;
 use ZF\Configuration\ModuleUtils;
 
@@ -72,8 +73,9 @@ class AuthorizationModelTest extends TestCase
                             ->will($this->returnValue($modules));
 
         $this->writer   = new PhpArray();
-        $this->modules  = new ModuleUtils($this->moduleManager);
-        $this->resource = new ResourceFactory($this->modules, $this->writer);
+        $moduleUtils    = new ModuleUtils($this->moduleManager);
+        $this->modules  = new ModulePathSpec($moduleUtils);
+        $this->resource = new ResourceFactory($moduleUtils, $this->writer);
         $this->model    = new AuthorizationModel(
             $this->moduleEntity,
             $this->modules,

--- a/test/Model/DbConnectedRestServiceModelTest.php
+++ b/test/Model/DbConnectedRestServiceModelTest.php
@@ -14,6 +14,7 @@ use Zend\EventManager\Event;
 use ZF\Apigility\Admin\Model\DbConnectedRestServiceModel;
 use ZF\Apigility\Admin\Model\DbConnectedRestServiceEntity;
 use ZF\Apigility\Admin\Model\ModuleEntity;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Apigility\Admin\Model\RestServiceEntity;
 use ZF\Apigility\Admin\Model\RestServiceModel;
 use ZF\Configuration\ResourceFactory;
@@ -70,8 +71,9 @@ class DbConnectedRestServiceModelTest extends TestCase
                             ->will($this->returnValue($modules));
 
         $this->writer   = new PhpArray();
-        $this->modules  = new ModuleUtils($this->moduleManager);
-        $this->resource = new ResourceFactory($this->modules, $this->writer);
+        $moduleUtils    = new ModuleUtils($this->moduleManager);
+        $this->modules  = new ModulePathSpec($moduleUtils);
+        $this->resource = new ResourceFactory($moduleUtils, $this->writer);
         $this->codeRest = new RestServiceModel(
             $this->moduleEntity,
             $this->modules,

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -9,6 +9,8 @@ namespace ZFTest\Apigility\Admin\Model;
 use PHPUnit_Framework_TestCase as TestCase;
 use ZF\Apigility\Admin\Model\ModuleModel;
 use Test;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
+use ZF\Configuration\ModuleUtils;
 
 class ModuleModelTest extends TestCase
 {
@@ -52,7 +54,11 @@ class ModuleModelTest extends TestCase
             'ZFTest\Apigility\Admin\Model\TestAsset\Bob\Controller\Do'  => null,
         );
 
-        $this->model         = new ModuleModel($this->moduleManager, $restConfig, $rpcConfig);
+        $this->model         = new ModuleModel(
+            $this->moduleManager,
+            $restConfig,
+            $rpcConfig
+        );
     }
 
     public function tearDown()
@@ -128,8 +134,16 @@ class ModuleModelTest extends TestCase
         $this->assertEquals($expected['rpc'], $module->getRpcServices());
     }
 
+    /**
+     * @group listofservices
+     */
     public function testCanRetrieveListOfAllApigilityModulesAndTheirServices()
     {
+        /* If this is running from a vendor directory, markTestSkipped() */
+        if (preg_match('#[/\\\\]vendor[/\\\\]#', __FILE__)) {
+            $this->markTestSkipped('Running from a vendor directory.');
+        }
+
         $expected = array(
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar' => array(
                 'vendor' => false,
@@ -216,7 +230,9 @@ class ModuleModelTest extends TestCase
         mkdir("$modulePath/config", 0775, true);
         file_put_contents("$modulePath/config/application.config.php", '<' . '?php return array();');
 
-        $this->assertTrue($this->model->createModule($module, $modulePath));
+        $pathSpec = $this->getPathSpec($modulePath);
+
+        $this->assertTrue($this->model->createModule($module, $pathSpec));
         $this->assertTrue(file_exists("$modulePath/module/$module"));
         $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/V1/Rpc"));
         $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/V1/Rest"));
@@ -227,6 +243,15 @@ class ModuleModelTest extends TestCase
 
         $this->removeDir($modulePath);
         return true;
+    }
+
+    protected function getPathSpec($modulePath)
+    {
+        return new ModulePathSpec(
+            new ModuleUtils($this->moduleManager),
+            'psr-0',
+            $modulePath
+        );
     }
 
     /**
@@ -243,7 +268,10 @@ class ModuleModelTest extends TestCase
             "$modulePath/config/application.config.php",
             '<' . '?php return array("modules" => array());'
         );
-        $this->assertTrue($this->model->createModule($module, $modulePath));
+
+        $pathSpec = $this->getPathSpec($modulePath);
+
+        $this->assertTrue($this->model->createModule($module, $pathSpec));
         $config = include $modulePath . '/config/application.config.php';
         $this->assertArrayHasKey('modules', $config, var_export($config, 1));
 
@@ -273,7 +301,9 @@ class ModuleModelTest extends TestCase
             "$modulePath/config/application.config.php",
             '<' . '?php return array("modules" => array());'
         );
-        $this->assertTrue($this->model->createModule($module, $modulePath));
+        $pathSpec = $this->getPathSpec($modulePath);
+
+        $this->assertTrue($this->model->createModule($module, $pathSpec));
 
         // Now try and delete
         $this->assertTrue($this->model->deleteModule($module, $modulePath, true));
@@ -297,8 +327,9 @@ class ModuleModelTest extends TestCase
             "$modulePath/config/application.config.php",
             '<' . "?php return array(\n    'modules' => array(\n        'Foo',\n    )\n);"
         );
+        $pathSpec = $this->getPathSpec($modulePath);
 
-        $this->assertFalse($this->model->createModule($module, $modulePath));
+        $this->assertFalse($this->model->createModule($module, $pathSpec));
     }
 
     public function testUpdateExistingApiModule()
@@ -364,7 +395,11 @@ class ModuleModelTest extends TestCase
                       ->method('getLoadedModules')
                       ->will($this->returnValue($modules));
 
-        $model = new ModuleModel($moduleManager, array(), array());
+        $model = new ModuleModel(
+            $moduleManager,
+            array(),
+            array()
+        );
 
         $modules = $model->getModules();
         foreach ($modules as $module) {
@@ -385,7 +420,11 @@ class ModuleModelTest extends TestCase
                       ->method('getLoadedModules')
                       ->will($this->returnValue($modules));
 
-        $model = new ModuleModel($moduleManager, array(), array());
+        $model = new ModuleModel(
+            $moduleManager,
+            array(),
+            array()
+        );
 
         $modules = $model->getModules();
 
@@ -415,9 +454,12 @@ class ModuleModelTest extends TestCase
         mkdir("$modulePath/config", 0775, true);
         file_put_contents("$modulePath/config/application.config.php", '<' . '?php return array();');
 
-        $this->assertTrue($this->model->createModule($module, $modulePath));
+        $pathSpec = $this->getPathSpec($modulePath);
+
+        $this->assertTrue($this->model->createModule($module, $pathSpec));
 
         $this->setExpectedException('Exception', 'exists', 409);
-        $this->model->createModule($module, $modulePath);
+
+        $this->model->createModule($module, $pathSpec);
     }
 }

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -245,11 +245,38 @@ class ModuleModelTest extends TestCase
         return true;
     }
 
-    protected function getPathSpec($modulePath)
+
+    /**
+     * @group feature/psr4
+     */
+    public function testCreateModulePSR4()
+    {
+        $module     = 'Foo';
+        $modulePath = sys_get_temp_dir() . "/" . uniqid(str_replace('\\', '_', __NAMESPACE__) . '_');
+
+        mkdir("$modulePath/module", 0775, true);
+        mkdir("$modulePath/config", 0775, true);
+        file_put_contents("$modulePath/config/application.config.php", '<' . '?php return array();');
+
+        $pathSpec = $this->getPathSpec($modulePath, 'psr-4');
+
+        $this->assertTrue($this->model->createModule($module, $pathSpec));
+        $this->assertTrue(file_exists("$modulePath/module/$module"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/src/V1/Rpc"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/src/V1/Rest"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/view"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/Module.php"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/config/module.config.php"));
+
+        $this->removeDir($modulePath);
+        return true;
+    }
+
+    protected function getPathSpec($modulePath, $spec = 'psr-0')
     {
         return new ModulePathSpec(
             new ModuleUtils($this->moduleManager),
-            'psr-0',
+            $spec,
             $modulePath
         );
     }

--- a/test/Model/ModuleResourceTest.php
+++ b/test/Model/ModuleResourceTest.php
@@ -10,6 +10,8 @@ use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 use ZF\Apigility\Admin\Model\ModuleModel;
 use ZF\Apigility\Admin\Model\ModuleResource;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
+use ZF\Configuration\ModuleUtils;
 
 class ModuleResourceTest extends TestCase
 {
@@ -23,18 +25,31 @@ class ModuleResourceTest extends TestCase
                             ->method('getLoadedModules')
                             ->will($this->returnValue($modules));
 
-        $this->model = new ModuleModel($this->moduleManager, array(), array());
-        $this->resource = new ModuleResource($this->model);
-
         $this->modulePath = sprintf(
             '%s/%s',
             sys_get_temp_dir(),
             uniqid(str_replace('\\', '_', __NAMESPACE__) . '_')
         );
         mkdir($this->modulePath . '/config', 0775, true);
+
+        $this->model = new ModuleModel(
+            $this->moduleManager,
+            array(),
+            array()
+        );
+
+        $this->resource = new ModuleResource(
+            $this->model,
+            new ModulePathSpec(
+                new ModuleUtils($this->moduleManager),
+                'psr-0',
+                $this->modulePath
+            )
+        );
+
         $this->seedApplicationConfig();
         $this->setupModuleAutoloader();
-        $this->resource->setModulePath($this->modulePath);
+//        $this->resource->setModulePath($this->modulePath);
     }
 
     public function tearDown()
@@ -127,8 +142,12 @@ class ModuleResourceTest extends TestCase
             ->method('getLoadedModules')
             ->will($this->returnValue($modules));
 
-        $model    = new ModuleModel($moduleManager, array(), array());
-        $resource = new ModuleResource($model);
+        $model    = new ModuleModel(
+            $moduleManager,
+            array(),
+            array()
+        );
+        $resource = new ModuleResource($model, new ModulePathSpec(new ModuleUtils($moduleManager)));
         $module   = $resource->fetch($moduleName);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $module);
         $this->assertEquals(array(1), $module->getVersions());
@@ -157,8 +176,12 @@ class ModuleResourceTest extends TestCase
             ->method('getLoadedModules')
             ->will($this->returnValue($modules));
 
-        $model    = new ModuleModel($moduleManager, array(), array());
-        $resource = new ModuleResource($model);
+        $model    = new ModuleModel(
+            $moduleManager,
+            array(),
+            array()
+        );
+        $resource = new ModuleResource($model, new ModulePathSpec(new ModuleUtils($moduleManager)));
         $module   = $resource->fetch($moduleName);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $module);
         $this->assertEquals(array(1, 2, 3), $module->getVersions());

--- a/test/Model/RestServiceModelTest.php
+++ b/test/Model/RestServiceModelTest.php
@@ -7,6 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use BarConf;
+use BazConf;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 use Zend\Config\Writer\PhpArray;
@@ -40,16 +41,32 @@ class RestServiceModelTest extends TestCase
         }
         return rmdir($dir);
     }
-
     protected function cleanUpAssets()
     {
+        $pathSpec = (empty($this->modules)) ? 'psr-0' : $this->modules->getPathSpec();
+
+        $modulePath = array(
+            'psr-0' => '%s/src/%s/V*',
+            'psr-4' => '%s/src/V*'
+        );
+
         $basePath   = sprintf('%s/TestAsset/module/%s', __DIR__, $this->module);
         $configPath = $basePath . '/config';
-        foreach (glob(sprintf('%s/src/%s/V*', $basePath, $this->module)) as $dir) {
+        foreach (glob(sprintf($modulePath[$pathSpec], $basePath, $this->module)) as $dir) {
             $this->removeDir($dir);
         }
         copy($configPath . '/module.config.php.dist', $configPath . '/module.config.php');
     }
+
+//    protected function cleanUpAssets()
+//    {
+//        $basePath   = sprintf('%s/TestAsset/module/%s', __DIR__, $this->module);
+//        $configPath = $basePath . '/config';
+//        foreach (glob(sprintf('%s/src/%s/V*', $basePath, $this->module)) as $dir) {
+//            $this->removeDir($dir);
+//        }
+//        copy($configPath . '/module.config.php.dist', $configPath . '/module.config.php');
+//    }
 
     public function setUp()
     {
@@ -57,7 +74,8 @@ class RestServiceModelTest extends TestCase
         $this->cleanUpAssets();
 
         $modules = array(
-            'BarConf' => new BarConf\Module()
+            'BarConf' => new BarConf\Module(),
+            'BazConf' => new BazConf\Module()
         );
 
         $this->moduleEntity  = new ModuleEntity($this->module, array(), array(), false);
@@ -155,6 +173,35 @@ class RestServiceModelTest extends TestCase
 
         $className = str_replace($this->module . '\\V1\\Rest\\Foo\\', '', $resourceClass);
         $path      = realpath(__DIR__) . '/TestAsset/module/BarConf/src/BarConf/V1/Rest/Foo/' . $className . '.php';
+        $this->assertTrue(file_exists($path));
+
+        require_once $path;
+
+        $r = new ReflectionClass($resourceClass);
+        $this->assertInstanceOf('ReflectionClass', $r);
+        $parent = $r->getParentClass();
+        $this->assertEquals('ZF\Rest\AbstractResourceListener', $parent->getName());
+    }
+
+    /**
+     * @group feature/psr4
+     */
+    public function testCreateResourceClassCreatesClassFileWithNamedResourceClassPSR4()
+    {
+        $this->module = 'BazConf';
+        $this->moduleEntity  = new ModuleEntity($this->module);
+        $moduleUtils    = new ModuleUtils($this->moduleManager);
+        $this->modules  = new ModulePathSpec($moduleUtils, 'psr-4', __DIR__ . '/TestAsset');
+        $this->codeRest = new RestServiceModel(
+            $this->moduleEntity,
+            $this->modules,
+            $this->resource->factory('BazConf')
+        );
+
+        $resourceClass = $this->codeRest->createResourceClass('Foo');
+
+        $className = str_replace($this->module . '\\V1\\Rest\\Foo\\', '', $resourceClass);
+        $path      = realpath(__DIR__) . '/TestAsset/module/BazConf/src/V1/Rest/Foo/' . $className . '.php';
         $this->assertTrue(file_exists($path));
 
         require_once $path;
@@ -680,6 +727,33 @@ class RestServiceModelTest extends TestCase
         $this->codeRest->fetch($service->controllerServiceName);
     }
 
+    /**
+     * @group feature/psr4
+     */
+    public function testCanDeleteAServicePSR4()
+    {
+        $this->module = 'BazConf';
+        $this->moduleEntity  = new ModuleEntity($this->module);
+        $moduleUtils    = new ModuleUtils($this->moduleManager);
+        $this->modules  = new ModulePathSpec($moduleUtils, 'psr-4', __DIR__ . '/TestAsset');
+        $this->codeRest = new RestServiceModel(
+            $this->moduleEntity,
+            $this->modules,
+            $this->resource->factory('BazConf')
+        );
+
+        $details = $this->getCreationPayload();
+        $service = $this->codeRest->createService($details);
+
+        $this->assertTrue($this->codeRest->deleteService($service->controllerServiceName));
+
+        $fooPath = __DIR__ . '/TestAsset/module/BazConf/src/V1/Rest/Foo';
+        $this->assertTrue(file_exists($fooPath));
+
+        $this->setExpectedException('ZF\Apigility\Admin\Exception\RuntimeException', 'find', 404);
+        $this->codeRest->fetch($service->controllerServiceName);
+    }
+
     public function testCanDeleteAServiceRecursive()
     {
         $details = $this->getCreationPayload();
@@ -688,6 +762,30 @@ class RestServiceModelTest extends TestCase
         $this->assertTrue($this->codeRest->deleteService($service->controllerServiceName, true));
 
         $fooPath = __DIR__ . '/TestAsset/module/BarConf/src/BarConf/V1/Rest/Foo';
+        $this->assertFalse(file_exists($fooPath));
+    }
+
+    /**
+     * @group feature/psr4
+     */
+    public function testCanDeleteAServiceRecursivePSR4()
+    {
+        $this->module = 'BazConf';
+        $this->moduleEntity  = new ModuleEntity($this->module);
+        $moduleUtils    = new ModuleUtils($this->moduleManager);
+        $this->modules  = new ModulePathSpec($moduleUtils, 'psr-4', __DIR__ . '/TestAsset');
+        $this->codeRest = new RestServiceModel(
+            $this->moduleEntity,
+            $this->modules,
+            $this->resource->factory('BazConf')
+        );
+
+        $details = $this->getCreationPayload();
+        $service = $this->codeRest->createService($details);
+
+        $this->assertTrue($this->codeRest->deleteService($service->controllerServiceName, true));
+
+        $fooPath = __DIR__ . '/TestAsset/module/BazConf/src/V1/Rest/Foo';
         $this->assertFalse(file_exists($fooPath));
     }
 

--- a/test/Model/RestServiceModelTest.php
+++ b/test/Model/RestServiceModelTest.php
@@ -11,6 +11,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\ModuleEntity;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Apigility\Admin\Model\NewRestServiceEntity;
 use ZF\Apigility\Admin\Model\RestServiceEntity;
 use ZF\Apigility\Admin\Model\RestServiceModel;
@@ -68,8 +69,9 @@ class RestServiceModelTest extends TestCase
                             ->will($this->returnValue($modules));
 
         $this->writer   = new PhpArray();
-        $this->modules  = new ModuleUtils($this->moduleManager);
-        $this->resource = new ResourceFactory($this->modules, $this->writer);
+        $moduleUtils    = new ModuleUtils($this->moduleManager);
+        $this->modules  = new ModulePathSpec($moduleUtils);
+        $this->resource = new ResourceFactory($moduleUtils, $this->writer);
         $this->codeRest = new RestServiceModel(
             $this->moduleEntity,
             $this->modules,

--- a/test/Model/RestServiceResourceTest.php
+++ b/test/Model/RestServiceResourceTest.php
@@ -14,6 +14,7 @@ use Zend\EventManager\SharedEventManager;
 use ZF\Apigility\Admin\Model\DbConnectedRestServiceModel;
 use ZF\Apigility\Admin\Model\ModuleEntity;
 use ZF\Apigility\Admin\Model\ModuleModel;
+use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Apigility\Admin\Model\RestServiceEntity;
 use ZF\Apigility\Admin\Model\RestServiceModel;
 use ZF\Apigility\Admin\Model\RestServiceModelFactory;
@@ -72,8 +73,9 @@ class RestServiceResourceTest extends TestCase
                             ->will($this->returnValue($modules));
 
         $this->writer        = new PhpArray();
-        $this->modules       = new ModuleUtils($this->moduleManager);
-        $this->configFactory = new ResourceFactory($this->modules, $this->writer);
+        $moduleUtils         = new ModuleUtils($this->moduleManager);
+        $this->modules       = new ModulePathSpec($moduleUtils);
+        $this->configFactory = new ResourceFactory($moduleUtils, $this->writer);
         $config = $this->configFactory->factory('BarConf');
 
         $this->restServiceModel = new RestServiceModel($this->moduleEntity, $this->modules, $config);
@@ -126,13 +128,13 @@ class RestServiceResourceTest extends TestCase
     public function testPatchOfADbConnectedServiceUpdatesDbConnectedConfiguration()
     {
         $moduleManager           = $this->moduleManager;
-        $moduleUtils             = $this->modules;
+        $modulePathSpec          = $this->modules;
         $writer                  = $this->writer;
         $configResourceFactory   = $this->configFactory;
         $moduleModel             = new ModuleModel($moduleManager, array(), array());
         $sharedEvents            = new SharedEventManager();
         $restServiceModelFactory = new RestServiceModelFactory(
-            $moduleUtils,
+            $modulePathSpec,
             $configResourceFactory,
             $sharedEvents,
             $moduleModel

--- a/test/Model/RpcServiceModelTest.php
+++ b/test/Model/RpcServiceModelTest.php
@@ -204,7 +204,7 @@ class RpcServiceModelTest extends TestCase
         );
 
         $serviceName = 'Bar';
-        $moduleSrcPath = sprintf('%s/TestAsset/module/%s/src', __DIR__,  $this->module);
+        $moduleSrcPath = sprintf('%s/TestAsset/module/%s/src', __DIR__, $this->module);
         if (!is_dir($moduleSrcPath)) {
             mkdir($moduleSrcPath, 0775, true);
         }
@@ -638,7 +638,7 @@ class RpcServiceModelTest extends TestCase
         $filepath = $servicePath . "/". $serviceName . "Controller.php";
 
         /** deleteService calls class_exists.  ensure that it's loaded in case the autoloader doesn't pick it up */
-        if(file_exists($filepath)) {
+        if (file_exists($filepath)) {
             require_once $filepath;
         }
 

--- a/test/Model/RpcServiceModelTest.php
+++ b/test/Model/RpcServiceModelTest.php
@@ -114,7 +114,7 @@ class RpcServiceModelTest extends TestCase
      */
     public function testCanCreateControllerServiceNameFromResourceNameSpace()
     {
-//        $this->markTestSkipped('Invalid use case');
+        $this->markTestSkipped('Invalid use case');
 
         /**
          * @todo is this the expected behavior?

--- a/test/Model/RpcServiceModelTest.php
+++ b/test/Model/RpcServiceModelTest.php
@@ -114,7 +114,7 @@ class RpcServiceModelTest extends TestCase
      */
     public function testCanCreateControllerServiceNameFromResourceNameSpace()
     {
-        $this->markTestSkipped('Invalid use case');
+//        $this->markTestSkipped('Invalid use case');
 
         /**
          * @todo is this the expected behavior?

--- a/test/Model/TestAsset/module/BazConf/Module.php
+++ b/test/Model/TestAsset/module/BazConf/Module.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace BazConf;
+
+class Module
+{
+    public function getAutoloaderConfig()
+    {
+        return array(
+            'Zend\Loader\StandardAutoloader' => array(
+                'namespaces' => array(
+                    __NAMESPACE__ => __DIR__ . '/src',
+                ),
+            ),
+        );
+    }
+
+    public function getConfig()
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+}

--- a/test/Model/TestAsset/module/BazConf/config/module.config.php
+++ b/test/Model/TestAsset/module/BazConf/config/module.config.php
@@ -1,0 +1,2 @@
+<?php
+return array();

--- a/test/Model/TestAsset/module/BazConf/config/module.config.php.dist
+++ b/test/Model/TestAsset/module/BazConf/config/module.config.php.dist
@@ -1,0 +1,2 @@
+<?php
+return array();

--- a/view/module/skeleton-psr4.phtml
+++ b/view/module/skeleton-psr4.phtml
@@ -1,0 +1,22 @@
+namespace <?php echo $module ?>;
+
+use ZF\Apigility\Provider\ApigilityProviderInterface;
+
+class Module implements ApigilityProviderInterface
+{
+    public function getConfig()
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+
+    public function getAutoloaderConfig()
+    {
+        return array(
+            'ZF\Apigility\Autoloader' => array(
+                'namespaces' => array(
+                    __NAMESPACE__ => __DIR__ . '/src',
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
@weierophinney Here is a quick prototype of how PSR-4 support can be added to apigility-admin while keeping PSR-0 support.

I'm putting it here for review and refinement.  The idea is that you add the following to your module.config.php file (or in an autoload/apigility.local.php file).
```
return [
    'zf-apigility-admin' => [
        'path_spec' => 'psr-4'
    ]
];
```
The default is PSR-0.

In addition I was thinking about adding different path specs for RPC and REST directories as well.  You can see the general idea by looking at Model\ModulePathSpec.php.

Look forward to your thoughts.