### PR TITLE
[WIP] Change the authentication type per API and version

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -321,3 +321,39 @@ Admin UI Improvements
     - [ ] Potentially allow toggling; clicking on a disabled one would also enable
       that method for the service.
         - column/row toggles should never do this, however!
+
+Issue #247: per-API authentication
+----------------------------------
+
+On first load:
+
+- [ ] If authentication is setup (`DefaultAuthenticationListener` has a single
+  adapter) AND no `map` configuration setup:
+  - [ ] Get the authentication type provided from the listener
+  - [ ] Get the list of services and versions
+  - [ ] Create the map; each service/version pair maps to the configured type
+
+Create/configure adapter:
+
+- [ ] Make sure it merges, not replaces, the configuration
+
+Get list of supported authentication types:
+
+This one needs to be revised; currently, it will return configuration for one
+style of authentication only, based on opportunistic fetching (either HTTP or
+OAuth2, but not both). 
+
+- [ ] GET `/authentication`: return list of authentication types, keyed by type.
+  This will need a new version modifier: `application/vnd.apigility.authentication.v2+json`.
+
+Per-API authentication setup:
+
+- [ ] GET `module/:name/authentication[?version=:version`: return the configured
+  authentication for the given module and version; returned as an object with
+  the key "authentication_type" and value, if any.
+- [ ] PUT `/module/:name/authentication`: add/replace the given authentication
+  type for the given module at the latest version of the module.
+- [ ] DELETE `/module/:name/authentication`: remove authentication
+  for the given module at the latest version of the module
+
+PUT accepts `"authentication_type": "named type"`.


### PR DESCRIPTION
Now the authentication type isf for application, that means we cannot choose a different authentication type per API. There are a lot of good use case that can benefit from this new feature. 

We need a new API for that, I propose to reuse the authorization API:
`/api/module/:name/authorization?version=x`
adding the authentication type in the body:
 `{ auth_type: 'basic, digest or oauth2' }`
We need to support PATCH for this API, as reported in #246.