### PR TITLE
Added metadata for renamed filters, validators

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,4 +1,4 @@
-<?php
+<?php // @codingStandardsIgnoreFile
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
@@ -1067,6 +1067,10 @@ return array(
             'allowAttribs' => 'string',
             'allowTags' => 'string',
         ),
+        'Zend\Filter\ToInt' => array(),
+        'Zend\Filter\ToNull' => array(
+            'type' => 'int|string',
+        ),
         'Zend\Filter\UriNormalize' => array(
             'defaultscheme' => 'string',
             'enforcedscheme' => 'string',
@@ -1382,6 +1386,12 @@ return array(
             'locale' => 'string',
         ),
         'Zend\I18n\Validator\Int' => array(
+            'locale' => 'string',
+        ),
+        'Zend\I18n\Validator\IsFloat' => array(
+            'locale' => 'string',
+        ),
+        'Zend\I18n\Validator\IsInt' => array(
             'locale' => 'string',
         ),
         'Zend\I18n\Validator\PhoneNumber' => array(


### PR DESCRIPTION
Addresses zfcampus/zf-content-validation#39 by adding metadata for the
renamed filters and validators; the originals were kept as well, for
backwards compatibility.