### PR TITLE
Fixed AuthenticationTypeController

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -410,12 +410,6 @@ class Module
                 $model    = $services->get('ZF\Apigility\Admin\Model\AuthenticationModel');
                 return new Controller\AuthenticationController($model);
             },
-            'ZF\Apigility\Admin\Controller\AuthenticationType' => function ($controllers) {
-                $services = $controllers->getServiceLocator();
-                $model    = $services->get('ZF\Apigility\Admin\Model\AuthenticationModel');
-                $listener = $services->get('ZF\MvcAuth\Authentication\DefaultAuthenticationListener');
-                return new Controller\AuthenticationTypeController($model, $listener);
-            },
             'ZF\Apigility\Admin\Controller\Authorization' => function ($controllers) {
                 $services = $controllers->getServiceLocator();
                 $factory  = $services->get('ZF\Apigility\Admin\Model\AuthorizationModelFactory');

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,4 +1,4 @@
-<?php
+<?php // @codingStandardsIgnoreFile
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
@@ -33,6 +33,7 @@ return array(
             'ZF\Apigility\Admin\Controller\Package' => 'ZF\Apigility\Admin\Controller\PackageController'
         ),
         'factories' => array(
+            'ZF\Apigility\Admin\Controller\AuthenticationType' => 'ZF\Apigility\Admin\Controller\AuthenticationTypeControllerFactory',
             'ZF\Apigility\Admin\Controller\DbAutodiscovery' => 'ZF\Apigility\Admin\Controller\DbAutodiscoveryControllerFactory',
             'ZF\Apigility\Admin\Controller\Dashboard' => 'ZF\Apigility\Admin\Controller\DashboardControllerFactory',
             'ZF\Apigility\Admin\Controller\Documentation' => 'ZF\Apigility\Admin\Controller\DocumentationControllerFactory',

--- a/src/Controller/AuthenticationTypeController.php
+++ b/src/Controller/AuthenticationTypeController.php
@@ -10,15 +10,13 @@ use ZF\ContentNegotiation\ViewModel;
 use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\ApiProblemResponse;
 use ZF\MvcAuth\Authentication\DefaultAuthenticationListener as AuthListener;
-use ZF\Apigility\Admin\Model\AuthenticationModel as AuthModel;
 
 class AuthenticationTypeController extends AbstractAuthenticationController
 {
     protected $model;
 
-    public function __construct(AuthModel $model, AuthListener $authListener)
+    public function __construct(AuthListener $authListener)
     {
-        $this->model        = $model;
         $this->authListener = $authListener;
     }
 
@@ -61,20 +59,7 @@ class AuthenticationTypeController extends AbstractAuthenticationController
      */
     private function createAdapterCollection()
     {
-        if (! $this->model->fetchAllAuthenticationAdapter()) {
-            // Check for old authentication configuration
-            $adapters = array();
-            if ($this->model->fetch()) {
-                // Create a new authentication adapter for each API/version
-                $adapters = array($this->model->transformAuthPerApis());
-            }
-            return $this->createViewModel($adapters);
-        }
-
         $adapters = $this->authListener->getAuthenticationTypes();
-        if ($adapters && isset($adapters['adapters'])) {
-            $adapters = array_keys($adapters['adapters']);
-        }
         return $this->createViewModel($adapters);
     }
 

--- a/src/Controller/AuthenticationTypeControllerFactory.php
+++ b/src/Controller/AuthenticationTypeControllerFactory.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\Controller;
+
+class AuthenticationTypeControllerFactory
+{
+    public function __invoke($controllers)
+    {
+        $services = $controllers->getServiceLocator();
+        return new AuthenticationTypeController(
+            $services->get('ZF\MvcAuth\Authentication\DefaultAuthenticationListener')
+        );
+    }
+}


### PR DESCRIPTION
- It should only pull data from DefaultAuthenticationListener; removed
  dependency on AuthenticationModel.
- Test setup and expectations should match zf-mvc-auth:
  - Ensured that authentication types for old-style authentication
    configuration are properly injected.
  - Ensured that expectations are part of the data set when testing
    old-style authentication.
  - Corrected expectations for new-style data as well.
- Created factory class for AuthenticationTypeController, and removed injection
  of AuthenticationModel.