### PR TITLE
Empty DSN should not be saved in config file

### DIFF
--- a/src/Model/DbAdapterModel.php
+++ b/src/Model/DbAdapterModel.php
@@ -46,6 +46,10 @@ class DbAdapterModel
         ) {
             unset($adapterConfig['charset']);
         }
+        
+        if (empty($adapterConfig['dsn'])) {
+            unset($adapterConfig['dsn']);
+        }
 
         $this->globalConfig->patchKey($key, array());
         $this->localConfig->patchKey($key, $adapterConfig);


### PR DESCRIPTION
This PR fixes issue with empty dsn.
If we pass empty dsn to `/apigility/api/db-adapter` endpoint apigility will create/update config file with empty key `dsn`. This will not work in API. For example, DB Autodiscovering is not working then.