### PR TITLE
ODM support for doctrine connections

### DIFF
--- a/src/Model/DoctrineAdapterEntity.php
+++ b/src/Model/DoctrineAdapterEntity.php
@@ -62,7 +62,7 @@ class DoctrineAdapterEntity implements ArraySerializableInterface
     {
         $baseKey = (isset($this->config['driverClass']))
             ? 'doctrine.entitymanager.'
-            : 'doctrine.documentmanager';
+            : 'doctrine.documentmanager.';
 
         return array_merge(array(
             'adapter_name' => $baseKey . $this->name,

--- a/src/Model/DoctrineAdapterEntity.php
+++ b/src/Model/DoctrineAdapterEntity.php
@@ -60,8 +60,12 @@ class DoctrineAdapterEntity implements ArraySerializableInterface
      */
     public function getArrayCopy()
     {
+        $baseKey = (isset($this->config['driverClass']))
+            ? 'doctrine.entitymanager.'
+            : 'doctrine.documentmanager';
+
         return array_merge(array(
-            'adapter_name' => 'doctrine.entitymanager.' . $this->name,
+            'adapter_name' => $baseKey . $this->name,
         ), $this->config);
     }
 }

--- a/src/Model/DoctrineAdapterModel.php
+++ b/src/Model/DoctrineAdapterModel.php
@@ -89,10 +89,7 @@ class DoctrineAdapterModel
                     return false;
                 }
 
-                // 'driverClass' is part of ORM configuration, and MUST be provided by the user;
-                // 'connectionString' is part of ODM configuration, and MUST be provided by the user.
-                // As such, absence of either of these means we do not have a valid connection.
-                if (! isset($connection['driverClass']) && ! isset($connection['connectionString'])) {
+                if (! $this->isOrmAdapter($connection) && ! $this->isOdmAdapter($connection)) {
                     return false;
                 }
             }
@@ -127,5 +124,36 @@ class DoctrineAdapterModel
             return false;
         }
         return new DoctrineAdapterEntity($name, $config['doctrine']['connection'][$name]);
+    }
+
+    /**
+     * Does the connection represent an ORM adapter?
+     *
+     * To be an ORM adapter, "driverClass" MUST be specified in the
+     * configuration.
+     *
+     * @param array $connection
+     * @return bool
+     */
+    private function isOrmAdapter(array $connection)
+    {
+        return isset($connection['driverClass']);
+    }
+
+    /**
+     * Does the connection represent an ODM adapter?
+     *
+     * To be an ODM adapter, one of "connectionString" OR "dbname" MUST be
+     * specified in the configuration.
+     *
+     * @param array $connection
+     * @return bool
+     */
+    private function isOdmAdapter(array $connection)
+    {
+        return (
+            isset($connection['connectionString'])
+            || isset($connection['dbname'])
+        );
     }
 }

--- a/src/Model/DoctrineAdapterModel.php
+++ b/src/Model/DoctrineAdapterModel.php
@@ -85,10 +85,14 @@ class DoctrineAdapterModel
             && is_array($fromConfigFile['doctrine']['connection'])
         ) {
             foreach ($fromConfigFile['doctrine']['connection'] as $connection) {
-                if (!is_array($connection)) {
+                if (! is_array($connection)) {
                     return false;
                 }
-                if (!isset($connection['driverClass'])) {
+
+                // 'driverClass' is part of ORM configuration, and MUST be provided by the user;
+                // 'connectionString' is part of ODM configuration, and MUST be provided by the user.
+                // As such, absence of either of these means we do not have a valid connection.
+                if (! isset($connection['driverClass']) && ! isset($connection['connectionString'])) {
                     return false;
                 }
             }

--- a/test/Model/DoctrineAdapterEntityTest.php
+++ b/test/Model/DoctrineAdapterEntityTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Admin\Model;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\Apigility\Admin\Model\DoctrineAdapterEntity;
+
+class DoctrineAdapterEntityTest extends TestCase
+{
+    public function testCanRepresentAnOrmEntity()
+    {
+        $config = array(
+            'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+            'params' => array(),
+        );
+        $entity = new DoctrineAdapterEntity('test', $config);
+        $serialized = $entity->getArrayCopy();
+
+        $this->assertArrayHasKey('adapter_name', $serialized);
+        $this->assertEquals('doctrine.entitymanager.test', $serialized['adapter_name']);
+    }
+
+    public function testCanRepresentAnOdmEntity()
+    {
+        $config = array(
+            'connectionString' => 'mongodb://localhost:27017',
+        );
+        $entity = new DoctrineAdapterEntity('test', $config);
+        $serialized = $entity->getArrayCopy();
+
+        $this->assertArrayHasKey('adapter_name', $serialized);
+        $this->assertEquals('doctrine.documentmanager.test', $serialized['adapter_name']);
+    }
+}

--- a/test/Model/DoctrineAdapterModelTest.php
+++ b/test/Model/DoctrineAdapterModelTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Admin\Model;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\Apigility\Admin\Model\DoctrineAdapterModel;
+use ZF\Configuration\ConfigResource;
+
+class DoctrineAdapterModelTest extends TestCase
+{
+    public function getMockWriter()
+    {
+        return $this->getMock('Zend\Config\Writer\WriterInterface');
+    }
+
+    public function getGlobalConfig()
+    {
+        return new ConfigResource(array(
+            'doctrine' => array(
+                'entitymanager' => array(
+                    'orm_default' => array(
+                    ),
+                ),
+                'documentationmanager' => array(
+                    'odm_default' => array(
+                    ),
+                ),
+            ),
+        ), 'php://temp', $this->getMockWriter());
+    }
+
+    public function getLocalConfig()
+    {
+        return new ConfigResource(array(
+            'doctrine' => array(
+                'connection' => array(
+                    'orm_default' => array(
+                        'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+                        'params' => array(),
+                    ),
+                    'odm_default' => array(
+                        'connectionString' => 'mongodb://localhost:27017',
+                        'options' => array(),
+                    ),
+                ),
+            ),
+        ), 'php://temp', $this->getMockWriter());
+    }
+
+    public function testFetchAllReturnsMixOfOrmAndOdmAdapters()
+    {
+        $model = new DoctrineAdapterModel($this->getGlobalConfig(), $this->getLocalConfig());
+        $adapters = $model->fetchAll();
+        $this->assertInternalType('array', $adapters);
+
+        foreach ($adapters as $adapter) {
+            $this->assertInstanceOf('ZF\Apigility\Admin\Model\DoctrineAdapterEntity', $adapter);
+            $data = $adapter->getArrayCopy();
+            $this->assertArrayHasKey('adapter_name', $data);
+            if (strrpos($data['adapter_name'], 'odm_default')) {
+                $this->assertContains('documentmanager', $data['adapter_name']);
+            } elseif (strrpos($data['adapter_name'], 'orm_default')) {
+                $this->assertContains('entitymanager', $data['adapter_name']);
+            }
+        }
+    }
+}

--- a/test/Model/DoctrineAdapterModelTest.php
+++ b/test/Model/DoctrineAdapterModelTest.php
@@ -46,6 +46,10 @@ class DoctrineAdapterModelTest extends TestCase
                         'connectionString' => 'mongodb://localhost:27017',
                         'options' => array(),
                     ),
+                    'odm_dbname' => array(
+                        'dbname' => 'test',
+                        'options' => array(),
+                    ),
                 ),
             ),
         ), 'php://temp', $this->getMockWriter());
@@ -61,7 +65,7 @@ class DoctrineAdapterModelTest extends TestCase
             $this->assertInstanceOf('ZF\Apigility\Admin\Model\DoctrineAdapterEntity', $adapter);
             $data = $adapter->getArrayCopy();
             $this->assertArrayHasKey('adapter_name', $data);
-            if (strrpos($data['adapter_name'], 'odm_default')) {
+            if (strrpos($data['adapter_name'], 'odm_')) {
                 $this->assertContains('documentmanager', $data['adapter_name']);
             } elseif (strrpos($data['adapter_name'], 'orm_default')) {
                 $this->assertContains('entitymanager', $data['adapter_name']);


### PR DESCRIPTION
- In the model, test for either 'driverClass' OR ('connectionString' OR 'dbname');
  former indicates a configured ORM connection, while latter indicates a
  configured ODM connection.
- In the entity, base the `adapter_name` on EITHER
  `doctrine.entitymanager` OR `doctrine.documentmanager` based on the
  adapter type represented.