### PR TITLE
Packaging fails due to inability to resolve routing configuration

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -22,6 +22,21 @@ class PackageController extends AbstractActionController
     private $sentPackage;
 
     /**
+     * @var string
+     */
+    private $zfdeployPath = 'vendor/zfcampus/zf-deploy/bin/zfdeploy.php';
+
+    /**
+     * @param null|string $zfdeployPath Path to use to zfdeploy.php.
+     */
+    public function __construct($zfdeployPath = null)
+    {
+        if (! empty($zfdeployPath) && is_string($zfdeployPath)) {
+            $this->zfdeployPath = $zfdeployPath;
+        }
+    }
+
+    /**
      * Handle incoming requests
      *
      * @return array|\Zend\Http\Response|ApiProblemResponse
@@ -123,10 +138,7 @@ class PackageController extends AbstractActionController
         $format   = strtolower($format);
         $fileId   = uniqid();
         $package  = $this->getPackageFile($fileId, $format);
-
-        // Use the resolved path within the vendor directory; otherwise,
-        // warnings about inability to locate the config/routes.php file occur
-        $cmd      = sprintf('php vendor/zfcampus/zf-deploy/bin/zfdeploy.php build %s', $package);
+        $cmd      = sprintf('php %s build %s', $this->zfdeployPath, $package);
 
         $apis = array_key_exists('apis', $params) ? $params['apis'] : null;
         $cmd .= $this->createModulesOption($apis);

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -123,7 +123,10 @@ class PackageController extends AbstractActionController
         $format   = strtolower($format);
         $fileId   = uniqid();
         $package  = $this->getPackageFile($fileId, $format);
-        $cmd      = sprintf('php vendor/bin/zfdeploy.php build %s', $package);
+
+        // Use the resolved path within the vendor directory; otherwise,
+        // warnings about inability to locate the config/routes.php file occur
+        $cmd      = sprintf('php vendor/zfcampus/zf-deploy/bin/zfdeploy.php build %s', $package);
 
         $apis = array_key_exists('apis', $params) ? $params['apis'] : null;
         $cmd .= $this->createModulesOption($apis);

--- a/test/Controller/PackageControllerTest.php
+++ b/test/Controller/PackageControllerTest.php
@@ -21,7 +21,8 @@ class PackageControllerTest extends TestCase
 {
     public function setUp()
     {
-        $this->controller = new PackageController();
+        // Seed with symlink path for zfdeploy.php
+        $this->controller = new PackageController('vendor/bin/zfdeploy.php');
         $this->plugins = new ControllerPluginManager();
         $this->plugins->setService('bodyParam', new BodyParam());
         $this->plugins->setService('bodyParams', new BodyParams());


### PR DESCRIPTION
I noticed when using the packaging feature that it failed, due to the API code being unable to resolve `config/routes.php` when executing `vendor/bin/zfdeploy.php`. The fix is to use the fully-qualified path: `vendor/zfcampus/zf-deploy/bin/zfdeploy.php`.