### PR TITLE
Update minimum PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-    - php: 5.4
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true

--- a/composer.json
+++ b/composer.json
@@ -26,20 +26,20 @@
         }
     },
     "require": {
-        "php": ">=5.3.23",
-        "zendframework/zend-code": ">=2.3,<2.5",
-        "zendframework/zend-eventmanager": ">=2.3,<2.5",
-        "zendframework/zend-filter": ">=2.3,<2.5",
-        "zendframework/zend-http": ">=2.3,<2.5",
-        "zendframework/zend-inputfilter": ">=2.3,<2.5",
-        "zendframework/zend-modulemanager": ">=2.3,<2.5",
-        "zendframework/zend-mvc": ">=2.3,<2.5",
-        "zendframework/zend-servicemanager": ">=2.3,<2.5",
-        "zendframework/zend-stdlib": ">=2.3,<2.5",
-        "zendframework/zend-validator": ">=2.3,<2.5",
+        "php": ">=5.5",
+        "zendframework/zend-code": "~2.3",
+        "zendframework/zend-eventmanager": "~2.3",
+        "zendframework/zend-filter": "~2.3",
+        "zendframework/zend-http": "~2.3",
+        "zendframework/zend-inputfilter": "~2.3",
+        "zendframework/zend-modulemanager": "~2.3",
+        "zendframework/zend-mvc": "~2.3",
+        "zendframework/zend-servicemanager": "~2.3",
+        "zendframework/zend-stdlib": "~2.3",
+        "zendframework/zend-validator": "~2.3",
         "zendframework/zend-view": ">2.3",
         "zfcampus/zf-apigility": "~1.0",
-        "zfcampus/zf-apigility-admin-ui": ">=1.1.4,<2.0",
+        "zfcampus/zf-apigility-admin-ui": "^1.1.4",
         "zfcampus/zf-apigility-provider": "~1.0",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-configuration": "~1.0",
@@ -53,16 +53,15 @@
         "zfcampus/zf-versioning": "~1.0"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "3.7.*",
-        "squizlabs/php_codesniffer": "~2.0",
-        "zendframework/zend-config": ">=2.3,<2.5",
-        "zendframework/zend-loader": ">=2.3,<2.5",
+        "phpunit/phpunit": "~4.7",
+        "squizlabs/php_codesniffer": "^2.3.1",
+        "zendframework/zend-config": "~2.3",
+        "zendframework/zend-loader": "~2.3",
         "zfcampus/zf-deploy": "~1.0"
     },
     "autoload": {
         "psr-4": {
-            "ZF\\Apigility\\Admin\\": "src/",
-            "ZFTest\\Apigility\\Admin\\": "test/"
+            "ZF\\Apigility\\Admin\\": "src/"
         },
         "classmap": [
             "Module.php"
@@ -80,7 +79,9 @@
             "FooConf\\": "test/Model/TestAsset/module/FooConf/src/FooConf/",
             "BazConf\\": "test/Model/TestAsset/module/BazConf",
             "InputFilter\\": "test/Model/TestAsset/module/InputFilter/",
-            "Version\\": "test/Model/TestAsset/module/Version/src/Version/"
+            "Version\\": "test/Model/TestAsset/module/Version/src/Version/",
+            "ZFTest\\Apigility\\Admin\\": "test/",
+            "ZFTest\\Configuration\\": "vendor/zfcampus/zf-configuration/test/"
         }
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
 
     <!-- inherit rules from: -->
     <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,4 +18,5 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+    <exclude-pattern>*/module.config.php</exclude-pattern>
 </ruleset>

--- a/src/Controller/AbstractConfigController.php
+++ b/src/Controller/AbstractConfigController.php
@@ -48,7 +48,7 @@ abstract class AbstractConfigController extends AbstractActionController
                 }
 
                 // If tree was not submitted, but is Accepted, create nested values
-                $return = array();
+                $return = [];
                 foreach ($params as $key => $value) {
                     $config->createNestedKeyValuePair($return, $key, $value);
                 }

--- a/src/Controller/AbstractPluginManagerController.php
+++ b/src/Controller/AbstractPluginManagerController.php
@@ -38,7 +38,7 @@ abstract class AbstractPluginManagerController extends AbstractActionController
             );
         }
 
-        $model = new JsonModel(array($this->property => $this->model->fetchAll()));
+        $model = new JsonModel([$this->property => $this->model->fetchAll()]);
         $model->setTerminal(true);
         return $model;
     }

--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -86,11 +86,11 @@ class AuthenticationController extends AbstractAuthenticationController
         }
 
         $halEntity = new Entity($entity, null);
-        $halEntity->getLinks()->add(Link::factory(array(
+        $halEntity->getLinks()->add(Link::factory([
             'rel' => 'self',
             'route' => $this->getRouteForEntity($entity),
-        )));
-        return new ViewModel(array('payload' => $halEntity));
+        ]));
+        return new ViewModel(['payload' => $halEntity]);
     }
 
     /**
@@ -271,7 +271,7 @@ class AuthenticationController extends AbstractAuthenticationController
             'Location',
             $this->url()->fromRoute(
                 'zf-apigility/api/authentication',
-                array( 'authentication_adapter' => $entity['name'] )
+                [ 'authentication_adapter' => $entity['name'] ]
             )
         );
 
@@ -370,19 +370,19 @@ class AuthenticationController extends AbstractAuthenticationController
      */
     private function createCollection($collection)
     {
-        $halCollection = array();
+        $halCollection = [];
         foreach ($collection as $entity) {
             $halEntity = new Entity($entity, 'name');
-            $halEntity->getLinks()->add(Link::factory(array(
+            $halEntity->getLinks()->add(Link::factory([
                 'rel' => 'self',
-                'route' => array(
+                'route' => [
                     'name'   => 'zf-apigility/api/authentication',
-                    'params' => array('authentication_adapter' => $entity['name'])
-                )
-            )));
+                    'params' => ['authentication_adapter' => $entity['name']]
+                ]
+            ]));
             $halCollection[] = $halEntity;
         }
-        return new ViewModel(array('payload' => new Collection($halCollection)));
+        return new ViewModel(['payload' => new Collection($halCollection)]);
     }
 
     /**
@@ -394,14 +394,14 @@ class AuthenticationController extends AbstractAuthenticationController
     private function createEntity($entity)
     {
         $halEntity = new Entity($entity, 'name');
-        $halEntity->getLinks()->add(Link::factory(array(
+        $halEntity->getLinks()->add(Link::factory([
             'rel' => 'self',
-            'route' => array(
+            'route' => [
                 'name'   => 'zf-apigility/api/authentication',
-                'params' => array('authentication_adapter' => $entity['name'])
-            )
-        )));
-        return new ViewModel(array('payload' => $halEntity));
+                'params' => ['authentication_adapter' => $entity['name']]
+            ]
+        ]));
+        return new ViewModel(['payload' => $halEntity]);
     }
 
     /**
@@ -412,9 +412,9 @@ class AuthenticationController extends AbstractAuthenticationController
      */
     private function createAuthenticationMapResult($adapter)
     {
-        $model = new ViewModel(array(
+        $model = new ViewModel([
             'authentication' => $adapter
-        ));
+        ]);
         $model->setTerminal(true);
         return $model;
     }

--- a/src/Controller/AuthenticationTypeController.php
+++ b/src/Controller/AuthenticationTypeController.php
@@ -69,9 +69,9 @@ class AuthenticationTypeController extends AbstractAuthenticationController
      */
     private function createViewModel($adapters)
     {
-        $model = new ViewModel(array(
+        $model = new ViewModel([
             'auth-types' => $adapters
-        ));
+        ]);
         $model->setTerminal(true);
         return $model;
     }

--- a/src/Controller/AuthorizationController.php
+++ b/src/Controller/AuthorizationController.php
@@ -56,21 +56,21 @@ class AuthorizationController extends AbstractActionController
         }
 
         $entity = new Entity($entity, null);
-        $entity->getLinks()->add(Link::factory(array(
+        $entity->getLinks()->add(Link::factory([
             'rel'   => 'self',
-            'route' => array(
+            'route' => [
                 'name'    => 'zf-apigility/api/module/authorization',
-                'params'  => array(
+                'params'  => [
                     'name' => $this->moduleName,
-                ),
-                'options' => array(
-                    'query' => array(
+                ],
+                'options' => [
+                    'query' => [
                         'version' => $version,
-                    ),
-                ),
-            )
-        )));
-        return new ViewModel(array('payload' => $entity));
+                    ],
+                ],
+            ]
+        ]));
+        return new ViewModel(['payload' => $entity]);
     }
 
     /**

--- a/src/Controller/CacheEnabledController.php
+++ b/src/Controller/CacheEnabledController.php
@@ -44,7 +44,7 @@ class CacheEnabledController extends AbstractActionController
                 break;
         }
 
-        $viewModel = new ViewModel(array('cache_enabled' => $cacheEnabled));
+        $viewModel = new ViewModel(['cache_enabled' => $cacheEnabled]);
         $viewModel->setTerminal(true);
         return $viewModel;
     }

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -73,30 +73,30 @@ class DashboardController extends AbstractActionController
             $rpc = array_map($map, $rpc);
             sort($rpc);
 
-            $module->exchangeArray(array(
+            $module->exchangeArray([
                 'rest' => $rest,
                 'rpc'  => $rpc,
-            ));
+            ]);
         }
 
         $modulesCollection = new Collection($modules);
         $modulesCollection->setCollectionRoute('zf-apigility/api/module');
 
-        $dashboard = array(
+        $dashboard = [
             'db_adapter'       => $dbAdapters,
             'module'           => $modulesCollection,
-        );
+        ];
 
         $entity = new Entity($dashboard, 'dashboard');
         $links  = $entity->getLinks();
-        $links->add(Link::factory(array(
+        $links->add(Link::factory([
             'rel' => 'self',
-            'route' => array(
+            'route' => [
                 'name' => 'zf-apigility/api/dashboard',
-            ),
-        )));
+            ],
+        ]));
 
-        return new ViewModel(array('payload' => $entity));
+        return new ViewModel(['payload' => $entity]);
     }
 
     public function settingsDashboardAction()
@@ -105,10 +105,10 @@ class DashboardController extends AbstractActionController
         if ($authentication) {
             $authenticationEntity = $authentication;
             $authentication = new Entity($authentication, null);
-            $authentication->getLinks()->add(Link::factory(array(
+            $authentication->getLinks()->add(Link::factory([
                 'rel' => 'self',
                 'route' => $this->getRouteForEntity($authenticationEntity),
-            )));
+            ]));
         }
 
         $dbAdapters = new Collection($this->dbAdapters->fetchAll());
@@ -117,22 +117,22 @@ class DashboardController extends AbstractActionController
         $contentNegotiation = new Collection($this->contentNegotiation->fetchAll());
         $contentNegotiation->setCollectionRoute('zf-apigility/api/content-negotiation');
 
-        $dashboard = array(
+        $dashboard = [
             'authentication'      => $authentication,
             'content_negotiation' => $contentNegotiation,
             'db_adapter'          => $dbAdapters,
-        );
+        ];
 
         $entity = new Entity($dashboard, 'settings-dashboard');
         $links  = $entity->getLinks();
-        $links->add(Link::factory(array(
+        $links->add(Link::factory([
             'rel' => 'self',
-            'route' => array(
+            'route' => [
                 'name' => 'zf-apigility/api/settings-dashboard',
-            ),
-        )));
+            ],
+        ]));
 
-        return new ViewModel(array('payload' => $entity));
+        return new ViewModel(['payload' => $entity]);
     }
 
     /**

--- a/src/Controller/DbAutodiscoveryController.php
+++ b/src/Controller/DbAutodiscoveryController.php
@@ -40,6 +40,6 @@ class DbAutodiscoveryController extends AbstractActionController
 
         $data = $this->model->fetchColumns($module, $version, $adapter_name);
 
-        return new ViewModel(array('payload' => $data));
+        return new ViewModel(['payload' => $data]);
     }
 }

--- a/src/Controller/DocumentationController.php
+++ b/src/Controller/DocumentationController.php
@@ -87,12 +87,12 @@ class DocumentationController extends AbstractActionController
         $e = $this->getEvent();
         $e->setParam('ZFContentNegotiationFallback', 'HalJson');
 
-        return new ViewModel(array('payload' => $result));
+        return new ViewModel(['payload' => $result]);
     }
 
     protected function deriveRouteName($route)
     {
-        $matches = array();
+        $matches = [];
         preg_match('/(?P<type>rpc|rest)/', $route, $matches);
         return sprintf('zf-apigility/api/module/%s-service/doc', $matches['type']);
     }

--- a/src/Controller/FsPermissionsController.php
+++ b/src/Controller/FsPermissionsController.php
@@ -37,10 +37,10 @@ class FsPermissionsController extends AbstractActionController
     public function fsPermissionsAction()
     {
         $isWritable = $this->configIsWritable() && $this->moduleIsWritable();
-        $viewModel = new ViewModel(array(
+        $viewModel = new ViewModel([
             'fs_perms' => $isWritable,
             'www_user' => getenv('USER') ?: '',
-        ));
+        ]);
         return $viewModel;
     }
 

--- a/src/Controller/InputFilterController.php
+++ b/src/Controller/InputFilterController.php
@@ -60,16 +60,16 @@ class InputFilterController extends AbstractActionController
                 if ($result instanceof InputFilterCollection) {
                     $result = new HalCollection($result);
                     $result->setCollectionName('input_filter');
-                    $result->getLinks()->add(Link::factory(array(
+                    $result->getLinks()->add(Link::factory([
                         'rel' => 'self',
-                        'route' => array(
+                        'route' => [
                             'name' => $route,
-                            'params' => array(
+                            'params' => [
                                 'name'                    => $module,
                                 'controller_service_name' => str_replace('\\', '-', $controller),
-                            ),
-                        ),
-                    )));
+                            ],
+                        ],
+                    ]));
                     $result->setEntityRoute($route);
                     break;
                 }
@@ -124,7 +124,7 @@ class InputFilterController extends AbstractActionController
         $e = $this->getEvent();
         $e->setParam('ZFContentNegotiationFallback', 'HalJson');
 
-        return new ViewModel(array('payload' => $result));
+        return new ViewModel(['payload' => $result]);
     }
 
     /**
@@ -135,7 +135,7 @@ class InputFilterController extends AbstractActionController
      */
     protected function removeKey($inputFilter)
     {
-        $result = array();
+        $result = [];
         foreach ($inputFilter as $key => $value) {
             $result[] = $value;
         }
@@ -158,23 +158,23 @@ class InputFilterController extends AbstractActionController
 
     protected function deriveRouteName($route)
     {
-        $matches = array();
+        $matches = [];
         preg_match('/(?P<type>rpc|rest)/', $route, $matches);
         return sprintf('zf-apigility/api/module/%s-service/input-filter', $matches['type']);
     }
 
     public function injectEntitySelfLink($links, $route, $module, $controller, $inputFilterName)
     {
-        $links->add(Link::factory(array(
+        $links->add(Link::factory([
             'rel' => 'self',
-            'route' => array(
+            'route' => [
                 'name' => $route,
-                'params' => array(
+                'params' => [
                     'name'                    => $module,
                     'controller_service_name' => $controller,
                     'input_filter_name'       => $inputFilterName,
-                ),
-            ),
-        )));
+                ],
+            ],
+        ]));
     }
 }

--- a/src/Controller/ModuleCreationController.php
+++ b/src/Controller/ModuleCreationController.php
@@ -53,14 +53,14 @@ class ModuleCreationController extends AbstractActionController
 
                 $metadata = new ModuleEntity($module);
                 $entity   = new Entity($metadata, $module);
-                $entity->getLinks()->add(Link::factory(array(
+                $entity->getLinks()->add(Link::factory([
                     'rel'   => 'self',
-                    'route' => array(
+                    'route' => [
                         'name'   => 'zf-apigility/api/module',
-                        'params' => array('module' => $module),
-                    ),
-                )));
-                return new ViewModel(array('payload' => $entity));
+                        'params' => ['module' => $module],
+                    ],
+                ]));
+                return new ViewModel(['payload' => $entity]);
 
             default:
                 return new ApiProblemResponse(

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -123,7 +123,7 @@ class PackageController extends AbstractActionController
     {
         if (! $format
             || ! is_string($format)
-            || ! in_array(strtolower($format), array('zip', 'tar', 'tgz', 'zpk'))
+            || ! in_array(strtolower($format), ['zip', 'tar', 'tgz', 'zpk'])
         ) {
             return new ApiProblemResponse(
                 new ApiProblem(
@@ -165,7 +165,7 @@ class PackageController extends AbstractActionController
             );
         }
 
-        return array('token' => $fileId, 'format' => $format);
+        return ['token' => $fileId, 'format' => $format];
     }
 
     /**
@@ -199,7 +199,7 @@ class PackageController extends AbstractActionController
             glob('module/*', GLOB_ONLYDIR)
         );
 
-        $toInclude = array();
+        $toInclude = [];
 
         foreach ($modules as $mod) {
             if (! isset($apis[$mod]) || $apis[$mod]) {

--- a/src/Controller/SourceController.php
+++ b/src/Controller/SourceController.php
@@ -77,12 +77,12 @@ class SourceController extends AbstractActionController
                 $reflector = new ReflectionClass($class);
                 $fileName = $reflector->getFileName();
 
-                $metadata = array(
+                $metadata = [
                     'module' => $module,
                     'class'  => $class,
                     'file'   => $fileName,
                     'source' => $this->highlightFileWithNum($fileName)
-                );
+                ];
 
                 $model = new ViewModel($metadata);
                 $model->setTerminal(true);

--- a/src/Controller/StrategyController.php
+++ b/src/Controller/StrategyController.php
@@ -18,7 +18,7 @@ class StrategyController extends AbstractActionController
         $strategy_name = $this->params()->fromRoute('strategy_name', false);
         if ($this->getServiceLocator()->has($strategy_name)) {
             if ($this->getServiceLocator()->get($strategy_name) instanceof StrategyInterface) {
-                return array('exists' => true);
+                return ['exists' => true];
             } else {
                 return new ApiProblemModel(new ApiProblem(422, 'This service does not implement StrategyInterface'));
             }

--- a/src/Controller/VersioningController.php
+++ b/src/Controller/VersioningController.php
@@ -51,7 +51,7 @@ class VersioningController extends AbstractActionController
         $model = $this->modelFactory->factory($module);
 
         if ($model->setDefaultVersion($version)) {
-            return array('success' => true, 'version' => $version);
+            return ['success' => true, 'version' => $version];
         } else {
             return new ApiProblemModel(
                 new ApiProblem(500, 'An unexpected error occurred while attempting to set the default version')
@@ -106,9 +106,9 @@ class VersioningController extends AbstractActionController
             );
         }
 
-        return array(
+        return [
             'success' => true,
             'version' => $version,
-        );
+        ];
     }
 }

--- a/src/InputFilter/Authentication/BaseInputFilter.php
+++ b/src/InputFilter/Authentication/BaseInputFilter.php
@@ -12,27 +12,27 @@ class BaseInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'name',
             'error_message' => 'Please provide a name for HTTP authentication',
-            'filters' => array(
-                array('name' => 'StringToLower'),
-            )
-        ));
-        $this->add(array(
+            'filters' => [
+                ['name' => 'StringToLower'],
+            ]
+        ]);
+        $this->add([
             'name' => 'type',
             'error_message' => 'Please provide the HTTP authentication type',
-            'filters' => array(
-                array('name' => 'StringToLower'),
-            ),
-            'validators' => array(
-                array(
+            'filters' => [
+                ['name' => 'StringToLower'],
+            ],
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
-                        return in_array($value, array('basic', 'digest', 'oauth2'));
-                    }),
-                )
-            )
-        ));
+                    'options' => ['callback' => function ($value) {
+                        return in_array($value, ['basic', 'digest', 'oauth2']);
+                    }],
+                ]
+            ]
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/BasicInputFilter.php
+++ b/src/InputFilter/Authentication/BasicInputFilter.php
@@ -12,43 +12,43 @@ class BasicInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'accept_schemes',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         if (!is_array($value)) {
                             return false;
                         }
-                        $allowed = array('digest', 'basic');
+                        $allowed = ['digest', 'basic'];
                         foreach ($value as $v) {
                             if (!in_array($v, $allowed)) {
                                 return false;
                             }
                         }
                         return true;
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Accept Schemes must be an array containing one or more'
                 . ' of the values "basic" or "digest"',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'realm',
             'error_message' => 'Please provide a realm for HTTP basic authentication',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'htpasswd',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return file_exists($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Path provided for htpasswd file must exist',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/BasicInputFilter2.php
+++ b/src/InputFilter/Authentication/BasicInputFilter2.php
@@ -12,21 +12,21 @@ class BasicInputFilter2 extends BaseInputFilter
     {
         parent::init();
 
-        $this->add(array(
+        $this->add([
             'name' => 'realm',
             'error_message' => 'Please provide a realm for HTTP basic authentication',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'htpasswd',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return file_exists($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Path provided for htpasswd file must exist',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/DigestInputFilter.php
+++ b/src/InputFilter/Authentication/DigestInputFilter.php
@@ -12,54 +12,54 @@ class DigestInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'accept_schemes',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         if (! is_array($value)) {
                             return false;
                         }
-                        $allowed = array('digest', 'basic');
+                        $allowed = ['digest', 'basic'];
                         foreach ($value as $v) {
                             if (! in_array($v, $allowed)) {
                                 return false;
                             }
                         }
                         return true;
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Accept Schemes must be an array containing one or more'
                 . ' of the values "basic" or "digest"',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'realm',
             'error_message' => 'Please provide a realm for HTTP basic authentication',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'htdigest',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return file_exists($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Path provided for htdigest file must exist',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'nonce_timeout',
-            'validators' => array(
-                array('name' => 'Zend\Validator\Digits')
-            ),
+            'validators' => [
+                ['name' => 'Zend\Validator\Digits']
+            ],
             'error_message' => 'Nonce Timeout must be an integer',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'digest_domains',
             'error_message' => 'Digest Domains must be provided as a string',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/DigestInputFilter2.php
+++ b/src/InputFilter/Authentication/DigestInputFilter2.php
@@ -12,37 +12,37 @@ class DigestInputFilter2 extends BaseInputFilter
     {
         parent::init();
 
-        $this->add(array(
+        $this->add([
             'name' => 'realm',
             'error_message' => 'Please provide a realm for HTTP digest authentication',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'digest_domains',
             'error_message' => 'Please provide a digest domains for HTTP digest authentication'
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'nonce_timeout',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return is_numeric($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid nonce timeout for HTTP digest authentication'
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'htdigest',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return file_exists($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Path provided for htdigest file must exist',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/OAuth2InputFilter.php
+++ b/src/InputFilter/Authentication/OAuth2InputFilter.php
@@ -15,13 +15,13 @@ class OAuth2InputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'dsn',
             'continue_if_empty' => true,
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value, $context) {
+                    'options' => ['callback' => function ($value, $context) {
                         if (! isset($context['dsn_type']) || empty($context['dsn_type'])) {
                             // PDO is default DSN type; mark as invalid if none provided
                             return false;
@@ -46,19 +46,19 @@ class OAuth2InputFilter extends InputFilter
                          * @todo PDO DSN validation should move out of model to here
                          */
                         return true;
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid DSN (value will vary based on'
                 . ' whether you are selecting Mongo or PDO for the DSN type)',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'database',
             'continue_if_empty' => true,
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value, $context) {
+                    'options' => ['callback' => function ($value, $context) {
                         if (! isset($context['dsn_type']) || $context['dsn_type'] !== 'Mongo') {
                             // Database is only relevant to Mongo
                             return true;
@@ -73,35 +73,35 @@ class OAuth2InputFilter extends InputFilter
                         }
 
                         return true;
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid Mongo database',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'dsn_type',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'InArray',
-                    'options' => array('haystack' => array(
+                    'options' => ['haystack' => [
                         'PDO',
                         'Mongo',
-                    )),
-                ),
-            ),
+                    ]],
+                ],
+            ],
             'error_message' => 'Indicate whether you are using Mongo or PDO',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'username',
             'required' => false,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'password',
             'required' => false,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'route_match',
             'error_message' => 'Please provide a valid URI path for where OAuth2 will respond',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/OAuth2MongoInputFilter2.php
+++ b/src/InputFilter/Authentication/OAuth2MongoInputFilter2.php
@@ -12,59 +12,59 @@ class OAuth2MongoInputFilter2 extends BaseInputFilter
     {
         parent::init();
 
-        $this->add(array(
+        $this->add([
             'name' => 'oauth2_type',
-            'filters' => array(
-                array('name' => 'StringToLower'),
-            ),
-            'validators' => array(
-                array(
+            'filters' => [
+                ['name' => 'StringToLower'],
+            ],
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return ($value === 'mongo');
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid DSN type adapter (pdo, mongo)',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_dsn',
             'error_message' => 'Please provide a valid DSN for OAuth2 database',
             'required' => false
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_database',
             'error_message' => 'Please provide a valid database name for OAuth2 Mongo adapter'
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_route',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Uri',
-                    'options' => array(
+                    'options' => [
                         'allowRelative' => true
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'error_message' => 'Please provide a valid URL route for OAuth2 Mongo adapter'
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_locator_name',
             'error_message' => 'Please provide a valid locator name for OAuth2 Mongo adapter',
             'required' => false
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_options',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return is_array($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid options for OAuth2 Mongo adapter',
             'required' => false
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Authentication/OAuth2PdoInputFilter2.php
+++ b/src/InputFilter/Authentication/OAuth2PdoInputFilter2.php
@@ -12,59 +12,59 @@ class OAuth2PdoInputFilter2 extends BaseInputFilter
     {
         parent::init();
 
-        $this->add(array(
+        $this->add([
             'name' => 'oauth2_type',
-            'filters' => array(
-                array('name' => 'StringToLower'),
-            ),
-            'validators' => array(
-                array(
+            'filters' => [
+                ['name' => 'StringToLower'],
+            ],
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return ($value === 'pdo');
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid DSN type adapter (pdo, mongo)',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_dsn',
             'error_message' => 'Please provide a valid DSN for OAuth2 PDO adapter',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_username',
             'error_message' => 'Please provide a username for OAuth2 PDO database',
             'required' => false
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_password',
             'error_message' => 'Please provide a password DSN for OAuth2 PDO database',
             'required' => false
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_route',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Uri',
-                    'options' => array(
+                    'options' => [
                         'allowRelative' => true
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'error_message' => 'Please provide a valid URL route for OAuth2 PDO adapter'
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'oauth2_options',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Callback',
-                    'options' => array('callback' => function ($value) {
+                    'options' => ['callback' => function ($value) {
                         return is_array($value);
-                    }),
-                ),
-            ),
+                    }],
+                ],
+            ],
             'error_message' => 'Please provide a valid options for OAuth2 PDO adapter',
             'required' => false
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/AuthorizationInputFilter.php
+++ b/src/InputFilter/AuthorizationInputFilter.php
@@ -10,7 +10,7 @@ use Zend\InputFilter\InputFilter;
 
 class AuthorizationInputFilter extends InputFilter
 {
-    protected $messages = array();
+    protected $messages = [];
 
     /**
      * Is the data set valid?
@@ -19,7 +19,7 @@ class AuthorizationInputFilter extends InputFilter
      */
     public function isValid()
     {
-        $this->messages = array();
+        $this->messages = [];
         $isValid = true;
         foreach ($this->data as $className => $httpMethods) {
             // validate the structure of the controller service name / method
@@ -37,7 +37,7 @@ class AuthorizationInputFilter extends InputFilter
             }
 
             foreach ($httpMethods as $httpMethod => $isRequired) {
-                if (!in_array($httpMethod, array('GET', 'POST', 'PUT', 'PATCH', 'DELETE'))) {
+                if (!in_array($httpMethod, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])) {
                     $this->messages[$className][] = 'Invalid HTTP method (' . $httpMethod . ') provided.';
                     $isValid = false;
                 }

--- a/src/InputFilter/DbAdapterInputFilter.php
+++ b/src/InputFilter/DbAdapterInputFilter.php
@@ -14,66 +14,66 @@ class DbAdapterInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'adapter_name',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'Please provide a unique, non-empty name for your database connection',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'database',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'Please provide the database name; for SQLite, this will be a filesystem path',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'driver',
             'error_message' => 'Please provide a Database Adapter driver name available to Zend Framework',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'dsn',
             'required' => false,
             'allow_empty' => true,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'username',
             'required' => false,
             'allow_empty' => true,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'password',
             'required' => false,
             'allow_empty' => true,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'hostname',
             'required' => false,
             'allow_empty' => true,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'port',
             'required' => false,
             'allow_empty' => true,
-            'validators' => array(
-                array('name' => 'Digits')
-            ),
+            'validators' => [
+                ['name' => 'Digits']
+            ],
             'error_message' => 'Please provide a valid port for accessing the database; must be an integer',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'charset',
             'required' => false,
             'allow_empty' => true,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'driver_options',
             'required' => false,
             'allow_empty' => true,
-            'validators' => array(
+            'validators' => [
                 new CallbackValidator(function ($value) {
                     return ArrayUtils::isHashTable($value);
                 }),
-            ),
+            ],
             'error_message' => 'Driver options must be provided as a set of key/value pairs',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/DocumentationInputFilter.php
+++ b/src/InputFilter/DocumentationInputFilter.php
@@ -13,27 +13,27 @@ class DocumentationInputFilter extends InputFilter
     /**
      * @var array
      */
-    protected $messages = array();
+    protected $messages = [];
 
     /**
      * @var array
      */
-    protected $validHttpMethodDocumentationKeys = array(
+    protected $validHttpMethodDocumentationKeys = [
         'description',
         'request',
         'response',
-    );
+    ];
 
     /**
      * @var array
      */
-    protected $validHttpMethods = array(
+    protected $validHttpMethods = [
         'GET',
         'POST',
         'PUT',
         'PATCH',
         'DELETE',
-    );
+    ];
 
     /**
      * Is the data set valid?
@@ -42,7 +42,7 @@ class DocumentationInputFilter extends InputFilter
      */
     public function isValid()
     {
-        $this->messages = array();
+        $this->messages = [];
         $isValid = true;
 
         if (!is_array($this->data)) {
@@ -68,7 +68,7 @@ class DocumentationInputFilter extends InputFilter
                 continue;
             }
 
-            if (in_array($key, array('collection', 'entity'))) {
+            if (in_array($key, ['collection', 'entity'])) {
                 // valid collection or entity
                 if (! is_array($data)) {
                     $this->messages[$key][] = 'Collections and entities methods must be an array of HTTP methods;'

--- a/src/InputFilter/InputFilterInputFilter.php
+++ b/src/InputFilter/InputFilterInputFilter.php
@@ -14,7 +14,7 @@ class InputFilterInputFilter extends InputFilter
     /**
      * @var array
      */
-    protected $messages = array();
+    protected $messages = [];
 
     /**
      * @var InputFilterFactory
@@ -36,7 +36,7 @@ class InputFilterInputFilter extends InputFilter
      */
     public function isValid()
     {
-        $this->messages = array();
+        $this->messages = [];
         try {
             $this->validationFactory->createInputFilter($this->data);
             return true;

--- a/src/InputFilter/ModuleInputFilter.php
+++ b/src/InputFilter/ModuleInputFilter.php
@@ -12,14 +12,14 @@ class ModuleInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'name',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'ZF\Apigility\Admin\InputFilter\Validator\ModuleNameValidator',
-                ),
-            ),
+                ],
+            ],
             'error_message' => 'The API name must be a valid PHP namespace',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -17,60 +17,60 @@ class PatchInputFilter extends PostInputFilter
         parent::init();
 
         // classes
-        $this->add(array(
+        $this->add([
             'name' => 'resource_class',
             'required' => true,
             'allow_empty' => true,
             'error_message' => 'The Resource Class must be a valid class name',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'collection_class',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'The Collection Class must be a valid class name',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'entity_class',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'The Entity Class must be a valid class name',
-        ));
+        ]);
 
-        $this->add(array(
+        $this->add([
             'name' => 'route_match',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'The Route must be a non-empty URI path',
-        ));
+        ]);
 
-        $this->add(array(
+        $this->add([
             'name' => 'accept_whitelist',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
             'error_message' => 'The Accept Whitelist must be an array of valid mediatype expressions',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'content_type_whitelist',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
             'error_message' => 'The Content-Type Whitelist must be an array of valid mediatype expressions',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'selector',
             'required' => false,
             'allow_empty' => true,
             'error_message' => 'The Content Negotiation Selector must be a valid,'
                 . ' defined zf-content-negotiation selector',
-        ));
+        ]);
 
-        $this->add(array(
+        $this->add([
             'name' => 'page_size',
             'required' => false,
             'allow_empty' => true,
             'continue_if_empty' => true,
-            'validators' => array(
+            'validators' => [
                 new CallbackValidator(function ($value) {
                     if (intval($value) != $value) {
                         return false;
@@ -85,68 +85,68 @@ class PatchInputFilter extends PostInputFilter
 
                     return false;
                 }),
-            ),
+            ],
             'error_message' => 'The Page Size must be either a positive integer'
                 . ' or the value "-1" (disabling pagination)',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'collection_http_methods',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\HttpMethodArrayValidator')
-            ),
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\HttpMethodArrayValidator']
+            ],
             'error_message' => 'The Collection HTTP Methods must be an array of valid HTTP methods',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'entity_http_methods',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\HttpMethodArrayValidator')
-            ),
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\HttpMethodArrayValidator']
+            ],
             'error_message' => 'The Entity HTTP Methods must be an array of valid HTTP methods',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'route_identifier_name',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'The Route Identifier Name must be a non-empty string',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'entity_identifier_name',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'The Entity Identifier Name must be a non-empty string',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'hydrator_name',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
             'error_message' => 'The Hydrator Name must be either empty, or a valid Hydrator service name',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'collection_name',
             'required' => true,
             'allow_empty' => false,
             'error_message' => 'The Collection Name must be a non-empty string',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'page_size_param',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
             'error_message' => 'The Page Size Parameter must empty or a string',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'collection_query_whitelist',
             'required' => true,
             'allow_empty' => true,
             'continue_if_empty' => true,
             'error_message' => 'The Collection Query Whitelist must either be empty or an array of strings',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/RestService/PostInputFilter.php
+++ b/src/InputFilter/RestService/PostInputFilter.php
@@ -25,21 +25,21 @@ class PostInputFilter extends InputFilter
      */
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'service_name',
             'required' => false,
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\ServiceNameValidator'),
-            ),
-        ));
-        $this->add(array(
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\ServiceNameValidator'],
+            ],
+        ]);
+        $this->add([
             'name' => 'adapter_name',
             'required' => false,
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'table_name',
             'required' => false,
-        ));
+        ]);
     }
 
     /**
@@ -85,10 +85,10 @@ class PostInputFilter extends InputFilter
             && (!isset($context['adapter_name']) || $context['adapter_name'] === null)
             && (!isset($context['table_name']) || $context['table_name'] === null)
         ) {
-            $this->localMessages = array(
+            $this->localMessages = [
                 'service_name' => 'You must provide either a Code-Connected service name'
                     . ' OR a DB-Connected database adapter and table name',
-            );
+            ];
             return false;
         }
 
@@ -101,10 +101,10 @@ class PostInputFilter extends InputFilter
             if ((isset($context['adapter_name']) && $context['adapter_name'] !== null)
                 || (isset($context['table_name']) && $context['table_name'] !== null)
             ) {
-                $this->localMessages = array(
+                $this->localMessages = [
                     'service_name' => 'You must provide either a Code-Connected service name'
                         . ' OR a DB-Connected database adapter and table name',
-                );
+                ];
                 return false;
             }
             return true;
@@ -113,18 +113,18 @@ class PostInputFilter extends InputFilter
         if ((isset($context['adapter_name']) && !empty($context['adapter_name']))
             && (!isset($context['table_name']) || $context['table_name'] === null)
         ) {
-            $this->localMessages = array(
+            $this->localMessages = [
                 'table_name' => 'DB-Connected services require both a database adapter and table name',
-            );
+            ];
             return false;
         }
 
         if ((!isset($context['adapter_name']) || $context['adapter_name'] === null)
             && (isset($context['table_name']) && !empty($context['table_name']))
         ) {
-            $this->localMessages = array(
+            $this->localMessages = [
                 'adapter_name' => 'DB-Connected services require both a database adapter and table name',
-            );
+            ];
             return false;
         }
 

--- a/src/InputFilter/RpcService/PatchInputFilter.php
+++ b/src/InputFilter/RpcService/PatchInputFilter.php
@@ -12,40 +12,40 @@ class PatchInputFilter extends PostInputFilter
     {
         parent::init();
 
-        $this->add(array(
+        $this->add([
             'name' => 'controller_class',
             'required' => true,
             'error_message' => 'The Controller Class must be a valid, fully qualified, PHP class name',
-        ));
+        ]);
 
-        $this->add(array(
+        $this->add([
             'name' => 'accept_whitelist',
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\MediaTypeArrayValidator')
-            ),
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\MediaTypeArrayValidator']
+            ],
             'error_message' => 'The Accept Whitelist must be an array of valid media type expressions',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'content_type_whitelist',
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\MediaTypeArrayValidator')
-            ),
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\MediaTypeArrayValidator']
+            ],
             'error_message' => 'The Content-Type Whitelist must be an array of valid media type expressions',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'selector',
             'required' => false,
             'allow_empty' => true,
             'error_message' => 'The Content Negotiation Selector must be a valid,'
                 . ' defined zf-content-negotiation selector name',
-        ));
+        ]);
 
-        $this->add(array(
+        $this->add([
             'name' => 'http_methods',
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\HttpMethodArrayValidator')
-            ),
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\HttpMethodArrayValidator']
+            ],
             'error_message' => 'The HTTP Methods must be an array of valid HTTP method names',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/RpcService/PostInputFilter.php
+++ b/src/InputFilter/RpcService/PostInputFilter.php
@@ -12,18 +12,18 @@ class PostInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'service_name',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'ZF\Apigility\Admin\InputFilter\Validator\ServiceNameValidator',
-                ),
-            ),
+                ],
+            ],
             'error_message' => 'Service Name is required, and must be a valid PHP class name',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'route_match',
             'error_message' => 'Route Match is required, and must be a valid URI path',
-        ));
+        ]);
     }
 }

--- a/src/InputFilter/Validator/AbstractValidator.php
+++ b/src/InputFilter/Validator/AbstractValidator.php
@@ -10,7 +10,7 @@ use Zend\Validator\AbstractValidator as BaseAbstractValidator;
 
 abstract class AbstractValidator extends BaseAbstractValidator
 {
-    protected $reservedWords = array(
+    protected $reservedWords = [
         '__halt_compiler',
         'abstract',
         'and',
@@ -76,7 +76,7 @@ abstract class AbstractValidator extends BaseAbstractValidator
         'var',
         'while',
         'xor',
-    );
+    ];
 
     /**
      * Is the given string a valid "name" in PHP?

--- a/src/InputFilter/Validator/ContentNegotiationSelectorsValidator.php
+++ b/src/InputFilter/Validator/ContentNegotiationSelectorsValidator.php
@@ -16,14 +16,14 @@ class ContentNegotiationSelectorsValidator extends ZfAbstractValidator
     const INVALID_MEDIA_TYPES = 'invalidMediaTypes';
     const INVALID_MEDIA_TYPE  = 'invalidMediaType';
 
-    protected $messageTemplates = array(
+    protected $messageTemplates = [
         self::INVALID_VALUE       => 'Value must be an array; received %value%',
         self::CLASS_NOT_FOUND     => 'Class name (%value%) does not exist',
         self::INVALID_VIEW_MODEL  =>
             'Class name (%value%) is invalid; must be a valid Zend\View\Model\ModelInterface instance',
         self::INVALID_MEDIA_TYPES => 'Values for the media-types must be provided as an indexed array',
         self::INVALID_MEDIA_TYPE  => 'Invalid media type (%value%) provided',
-    );
+    ];
 
     /**
      * Test if a set of selectors is valid

--- a/src/InputFilter/Validator/HttpMethodArrayValidator.php
+++ b/src/InputFilter/Validator/HttpMethodArrayValidator.php
@@ -15,21 +15,21 @@ class HttpMethodArrayValidator extends AbstractValidator
     /**
      * @var array
      */
-    protected $validHttpMethods = array(
+    protected $validHttpMethods = [
         'OPTIONS',
         'GET',
         'POST',
         'PATCH',
         'PUT',
         'DELETE'
-    );
+    ];
 
     /**
      * @var array
      */
-    protected $messageTemplates = array(
+    protected $messageTemplates = [
         self::HTTP_METHOD_ARRAY => "'%value%' is not http method"
-    );
+    ];
 
     /**
      * @param  mixed $value

--- a/src/InputFilter/Validator/IsStringValidator.php
+++ b/src/InputFilter/Validator/IsStringValidator.php
@@ -12,9 +12,9 @@ class IsStringValidator extends ZfAbstractValidator
 {
     const INVALID_TYPE = 'invalidType';
 
-    protected $messageTemplates = array(
+    protected $messageTemplates = [
         self::INVALID_TYPE => 'Value must be a string; received %value%',
-    );
+    ];
 
     /**
      * Test if a value is a string

--- a/src/InputFilter/Validator/MediaTypeArrayValidator.php
+++ b/src/InputFilter/Validator/MediaTypeArrayValidator.php
@@ -15,9 +15,9 @@ class MediaTypeArrayValidator extends AbstractValidator
     /**
      * @var array
      */
-    protected $messageTemplates = array(
+    protected $messageTemplates = [
         self::MEDIA_TYPE_ARRAY => "'%value%' is not a correctly formatted media type"
-    );
+    ];
 
     /**
      * @param  mixed $value

--- a/src/InputFilter/Validator/ModuleNameValidator.php
+++ b/src/InputFilter/Validator/ModuleNameValidator.php
@@ -13,9 +13,9 @@ class ModuleNameValidator extends AbstractValidator
     /**
      * @var array
      */
-    protected $messageTemplates = array(
+    protected $messageTemplates = [
         self::API_NAME => "'%value%' is not a valid api name"
-    );
+    ];
 
     /**
      * @param  mixed $value

--- a/src/InputFilter/Validator/ServiceNameValidator.php
+++ b/src/InputFilter/Validator/ServiceNameValidator.php
@@ -13,9 +13,9 @@ class ServiceNameValidator extends AbstractValidator
     /**
      * @var array
      */
-    protected $messageTemplates = array(
+    protected $messageTemplates = [
         self::SERVICE_NAME => "'%value%' is not a valid service name"
-    );
+    ];
 
     /**
      * @param  mixed $value

--- a/src/InputFilter/VersionInputFilter.php
+++ b/src/InputFilter/VersionInputFilter.php
@@ -12,24 +12,24 @@ class VersionInputFilter extends InputFilter
 {
     public function init()
     {
-        $this->add(array(
+        $this->add([
             'name' => 'module',
-            'validators' => array(
-                array('name' => 'ZF\Apigility\Admin\InputFilter\Validator\ModuleNameValidator'),
-            ),
+            'validators' => [
+                ['name' => 'ZF\Apigility\Admin\InputFilter\Validator\ModuleNameValidator'],
+            ],
             'error_message' => 'Please provide a valid API module name',
-        ));
-        $this->add(array(
+        ]);
+        $this->add([
             'name' => 'version',
-            'validators' => array(
-                array(
+            'validators' => [
+                [
                     'name' => 'Regex',
-                    'options' => array(
+                    'options' => [
                         'pattern' => '/^[a-z0-9_]+$/',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             'error_message' => 'Please provide a valid version string; may consist of a-Z, 0-9, and "_"',
-        ));
+        ]);
     }
 }

--- a/src/Listener/CryptFilterListener.php
+++ b/src/Listener/CryptFilterListener.php
@@ -17,7 +17,7 @@ class CryptFilterListener extends AbstractListenerAggregate
     public function attach(EventManagerInterface $events)
     {
         // Trigger between content negotiation (-625) and content validation (-650)
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onRoute'), -630);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, [$this, 'onRoute'], -630);
     }
 
     /**

--- a/src/Model/AbstractAutodiscoveryModel.php
+++ b/src/Model/AbstractAutodiscoveryModel.php
@@ -21,37 +21,37 @@ abstract class AbstractAutodiscoveryModel implements ServiceLocatorAwareInterfac
     /**
      * @var array
      */
-    protected $validators = array(
-        'text' => array(
+    protected $validators = [
+        'text' => [
             'name' => 'Zend\Validator\StringLength',
-            'options' => array(
+            'options' => [
                 'min' => 1,
                 'max' => 1,
-            ),
-        ),
-        'unique' => array(
+            ],
+        ],
+        'unique' => [
             'name' => 'ZF\ContentValidation\Validator\DbNoRecordExists',
-            'options' => array(),
-        ),
-        'foreign_key' => array(
+            'options' => [],
+        ],
+        'foreign_key' => [
             'name' => 'ZF\ContentValidation\Validator\DbRecordExists',
-            'options' => array(),
-        ),
-    );
+            'options' => [],
+        ],
+    ];
 
     /**
      * @var array
      */
-    protected $filters = array(
-        'text' => array(
-            array('name' => 'Zend\Filter\StringTrim'),
-            array('name' => 'Zend\Filter\StripTags'),
-        ),
-        'integer' => array(
-            array('name' => 'Zend\Filter\StripTags'),
-            array('name' => 'Zend\Filter\Digits'),
-        ),
-    );
+    protected $filters = [
+        'text' => [
+            ['name' => 'Zend\Filter\StringTrim'],
+            ['name' => 'Zend\Filter\StripTags'],
+        ],
+        'integer' => [
+            ['name' => 'Zend\Filter\StripTags'],
+            ['name' => 'Zend\Filter\Digits'],
+        ],
+    ];
 
     /**
      * Get service locator

--- a/src/Model/AuthenticationEntity.php
+++ b/src/Model/AuthenticationEntity.php
@@ -99,9 +99,9 @@ class AuthenticationEntity
      */
     protected $database;
 
-    public function __construct($type = self::TYPE_BASIC, $realmOrParams = 'api', array $params = array())
+    public function __construct($type = self::TYPE_BASIC, $realmOrParams = 'api', array $params = [])
     {
-        $this->type = in_array($type, array(self::TYPE_BASIC, self::TYPE_DIGEST, self::TYPE_OAUTH2))
+        $this->type = in_array($type, [self::TYPE_BASIC, self::TYPE_DIGEST, self::TYPE_OAUTH2])
             ? $type
             : self::TYPE_BASIC;
 
@@ -119,30 +119,30 @@ class AuthenticationEntity
     {
         switch ($this->type) {
             case self::TYPE_BASIC:
-                return array(
+                return [
                     'type'           => 'http_basic',
-                    'accept_schemes' => array(self::TYPE_BASIC),
+                    'accept_schemes' => [self::TYPE_BASIC],
                     'realm'          => $this->realm,
                     'htpasswd'       => $this->htpasswd,
-                );
+                ];
             case self::TYPE_DIGEST:
-                return array(
+                return [
                     'type'           => 'http_digest',
-                    'accept_schemes' => array(self::TYPE_DIGEST),
+                    'accept_schemes' => [self::TYPE_DIGEST],
                     'realm'          => $this->realm,
                     'htdigest'       => $this->htdigest,
                     'digest_domains' => $this->digestDomains,
                     'nonce_timeout'  => $this->nonceTimeout,
-                );
+                ];
             case self::TYPE_OAUTH2:
-                $array = array(
+                $array = [
                     'type'        => 'oauth2',
                     'dsn_type'    => $this->dsnType,
                     'dsn'         => $this->dsn,
                     'username'    => $this->username,
                     'password'    => $this->password,
                     'route_match' => $this->routeMatch,
-                );
+                ];
                 if ($this->getDsnType() === self::DSN_MONGO) {
                     $array['database'] = $this->database;
 
@@ -160,13 +160,13 @@ class AuthenticationEntity
     {
         switch ($this->type) {
             case self::TYPE_BASIC:
-                $allowedKeys = array('realm', 'htpasswd');
+                $allowedKeys = ['realm', 'htpasswd'];
                 break;
             case self::TYPE_DIGEST:
-                $allowedKeys = array('realm', 'htdigest', 'digestdomains', 'noncetimeout');
+                $allowedKeys = ['realm', 'htdigest', 'digestdomains', 'noncetimeout'];
                 break;
             case self::TYPE_OAUTH2:
-                $allowedKeys = array('dsntype', 'database', 'dsn', 'username', 'password', 'routematch');
+                $allowedKeys = ['dsntype', 'database', 'dsn', 'username', 'password', 'routematch'];
                 break;
         }
 

--- a/src/Model/AuthenticationModel.php
+++ b/src/Model/AuthenticationModel.php
@@ -301,13 +301,13 @@ class AuthenticationModel
      */
     public function remove()
     {
-        $configKeys = array(
+        $configKeys = [
             'zf-mvc-auth.authentication.http',
             'zf-oauth2.db',
             'zf-oauth2.mongo',
             'zf-oauth2.storage',
             'router.routes.oauth',
-        );
+        ];
         foreach ($configKeys as $key) {
             $this->globalConfig->deleteKey($key);
             $this->localConfig->deleteKey($key);
@@ -365,7 +365,7 @@ class AuthenticationModel
      */
     public function fetchAllAuthenticationAdapter()
     {
-        $result = array();
+        $result = [];
         $config = $this->localConfig->fetch(true);
 
         if (! isset($config['zf-mvc-auth']['authentication']['adapters'])) {
@@ -557,9 +557,9 @@ class AuthenticationModel
      */
     protected function fetchOAuth2Configuration(array $config)
     {
-        $oauth2Config = array(
+        $oauth2Config = [
             'route_match' => '/oauth',
-        );
+        ];
 
         if (isset($config['router']['routes']['oauth']['options']['route'])) {
             $oauth2Config['route_match'] = $config['router']['routes']['oauth']['options']['route'];
@@ -611,17 +611,17 @@ class AuthenticationModel
 
         switch ($entity->getDsnType()) {
             case AuthenticationEntity::DSN_MONGO:
-                $toSet = array(
+                $toSet = [
                     'storage' => 'ZF\OAuth2\Adapter\MongoAdapter',
                     'mongo'   => $local,
-                );
+                ];
                 break;
             case AuthenticationEntity::DSN_PDO:
             default:
-                $toSet = array(
+                $toSet = [
                     'storage' => 'ZF\OAuth2\Adapter\PdoAdapter',
                     'db'      => $local,
-                );
+                ];
                 break;
         }
 
@@ -684,38 +684,38 @@ class AuthenticationModel
         $key = 'zf-mvc-auth.authentication.adapters.' . $adapter['name'];
         switch ($adapter['type']) {
             case AuthenticationEntity::TYPE_BASIC:
-                $config = array(
+                $config = [
                     'adapter' => self::ADAPTER_HTTP,
-                    'options' => array(
-                        'accept_schemes' => array(AuthenticationEntity::TYPE_BASIC),
+                    'options' => [
+                        'accept_schemes' => [AuthenticationEntity::TYPE_BASIC],
                         'realm'          => $adapter['realm'],
                         'htpasswd'       => $adapter['htpasswd']
-                    )
-                );
+                    ]
+                ];
                 break;
             case AuthenticationEntity::TYPE_DIGEST:
-                $config = array(
+                $config = [
                     'adapter' => self::ADAPTER_HTTP,
-                    'options' => array(
-                        'accept_schemes' => array(AuthenticationEntity::TYPE_DIGEST),
+                    'options' => [
+                        'accept_schemes' => [AuthenticationEntity::TYPE_DIGEST],
                         'realm'          => $adapter['realm'],
                         'digest_domains' => $adapter['digest_domains'],
                         'nonce_timeout'  => $adapter['nonce_timeout'],
                         'htdigest'       => $adapter['htdigest']
-                    )
-                );
+                    ]
+                ];
                 break;
             case AuthenticationEntity::TYPE_OAUTH2:
                 switch (strtolower($adapter['oauth2_type'])) {
                     case strtolower(AuthenticationEntity::DSN_PDO):
-                        $config = array(
+                        $config = [
                             'adapter' => self::ADAPTER_OAUTH2,
-                            'storage' => array(
+                            'storage' => [
                                 'adapter' => strtolower(AuthenticationEntity::DSN_PDO),
                                 'dsn'     => $adapter['oauth2_dsn'],
                                 'route'   => $adapter['oauth2_route']
-                            )
-                        );
+                            ]
+                        ];
                         if (isset($adapter['oauth2_username'])) {
                             $config['storage']['username'] = $adapter['oauth2_username'];
                         }
@@ -724,15 +724,15 @@ class AuthenticationModel
                         }
                         break;
                     case strtolower(AuthenticationEntity::DSN_MONGO):
-                        $config = array(
+                        $config = [
                             'adapter' => self::ADAPTER_OAUTH2,
-                            'storage' => array(
+                            'storage' => [
                                 'adapter'  => strtolower(AuthenticationEntity::DSN_MONGO),
                                 'dsn'      => $adapter['oauth2_dsn'],
                                 'database' => $adapter['oauth2_database'],
                                 'route'   => $adapter['oauth2_route']
-                            )
-                        );
+                            ]
+                        ];
                         if (isset($adapter['oauth2_locator_name'])) {
                             $config['storage']['locator_name'] = $adapter['oauth2_locator_name'];
                         }
@@ -761,7 +761,7 @@ class AuthenticationModel
     public function fromOAuth2RegexToArray($config)
     {
         if (! isset($config['router']['routes']['oauth']['options']['regex'])) {
-            return array();
+            return [];
         }
         $regex = $config['router']['routes']['oauth']['options']['regex'];
         return explode('|', substr($regex, 11, strlen($regex) - 13));
@@ -788,10 +788,10 @@ class AuthenticationModel
             return strlen($b) - strlen($a);
         });
 
-        $options = array(
+        $options = [
             'spec'  => '%oauth%',
             'regex' => '(?P<oauth>(' . implode('|', $routes) . '))'
-        );
+        ];
         $this->globalConfig->patchKey('router.routes.oauth.options', $options);
         $this->globalConfig->patchKey('router.routes.oauth.type', 'regex');
     }
@@ -824,10 +824,10 @@ class AuthenticationModel
             usort($routes, function ($a, $b) {
                 return strlen($b) - strlen($a);
             });
-            $options = array(
+            $options = [
                 'spec'  => '%oauth%',
                 'regex' => '(?P<oauth>(' . implode('|', $routes) . '))'
-            );
+            ];
             $this->globalConfig->patchKey('router.routes.oauth.options', $options);
             $this->globalConfig->patchKey('router.routes.oauth.type', 'regex');
             return true;
@@ -847,7 +847,7 @@ class AuthenticationModel
      */
     protected function loadAuthenticationAdapterFromConfig($name, array $config)
     {
-        $result = array();
+        $result = [];
         if (isset($config['zf-mvc-auth']['authentication']['adapters'][$name])) {
             $adapter = $config['zf-mvc-auth']['authentication']['adapters'][$name];
             $result['name'] = $name;
@@ -901,12 +901,12 @@ class AuthenticationModel
      */
     public function removeOldAuthentication()
     {
-        $configKeys = array(
+        $configKeys = [
             'zf-mvc-auth.authentication.http',
             'zf-oauth2.db',
             'zf-oauth2.mongo',
             'zf-oauth2.storage'
-        );
+        ];
         foreach ($configKeys as $key) {
             $this->globalConfig->deleteKey($key);
             $this->localConfig->deleteKey($key);
@@ -933,30 +933,30 @@ class AuthenticationModel
         $oldAuth = $oldAuth->getArrayCopy();
         switch ($oldAuth['type']) {
             case 'http_basic':
-                $adapter = array(
+                $adapter = [
                     'name'     => 'http_basic',
                     'type'     => AuthenticationEntity::TYPE_BASIC,
                     'realm'    => $oldAuth['realm'],
                     'htpasswd' => $oldAuth['htpasswd']
-                );
+                ];
                 break;
             case 'http_digest':
-                $adapter = array(
+                $adapter = [
                     'name'           => 'http_digest',
                     'type'           => AuthenticationEntity::TYPE_DIGEST,
                     'realm'          => $oldAuth['realm'],
                     'htdigest'       => $oldAuth['htdigest'],
                     'digest_domains' => $oldAuth['digest_domains'],
                     'nonce_timeout'  => $oldAuth['nonce_timeout']
-                );
+                ];
                 break;
             case AuthenticationEntity::TYPE_OAUTH2:
-                $adapter = array(
+                $adapter = [
                     'type'         => AuthenticationEntity::TYPE_OAUTH2,
                     'oauth2_type'  => $oldAuth['dsn_type'],
                     'oauth2_dsn'   => $oldAuth['dsn'],
                     'oauth2_route' => $oldAuth['route_match']
-                );
+                ];
                 switch ($oldAuth['dsn_type']) {
                     case AuthenticationEntity::DSN_PDO:
                         $adapter['name']            = 'oauth2_pdo';

--- a/src/Model/AuthorizationEntity.php
+++ b/src/Model/AuthorizationEntity.php
@@ -18,22 +18,22 @@ class AuthorizationEntity implements
     const TYPE_ENTITY     = 'entity';
     const TYPE_COLLECTION = 'collection';
 
-    protected $allowedRestTypes = array(
+    protected $allowedRestTypes = [
         self::TYPE_ENTITY,
         self::TYPE_COLLECTION,
-    );
+    ];
 
-    protected $defaultPrivileges = array(
+    protected $defaultPrivileges = [
         'GET'    => false,
         'POST'   => false,
         'PATCH'  => false,
         'PUT'    => false,
         'DELETE' => false,
-    );
+    ];
 
-    protected $servicePrivileges = array();
+    protected $servicePrivileges = [];
 
-    public function __construct(array $services = array())
+    public function __construct(array $services = [])
     {
         foreach ($services as $serviceName => $privileges) {
             $this->servicePrivileges[$serviceName] = $this->filterPrivileges($privileges);

--- a/src/Model/AuthorizationModel.php
+++ b/src/Model/AuthorizationModel.php
@@ -90,11 +90,11 @@ class AuthorizationModel
      */
     public function update(array $privileges, $version = 1)
     {
-        $toStore = array(
-            'zf-mvc-auth' => array(
+        $toStore = [
+            'zf-mvc-auth' => [
                 'authorization' => $this->remapServiceNamesForStorage($privileges),
-            ),
-        );
+            ],
+        ];
 
         $this->configResource->patch($toStore, true);
         return $this->fetch($version);
@@ -298,7 +298,7 @@ class AuthorizationModel
         if (isset($config['zf-rest'])
             && is_array($config['zf-rest'])
         ) {
-            $missingServices = array();
+            $missingServices = [];
             foreach (array_keys($config['zf-rest']) as $serviceName) {
                 if (!preg_match('/' . preg_quote('\\') . 'V' . $version . preg_quote('\\') . '/', $serviceName)) {
                     continue;
@@ -314,7 +314,7 @@ class AuthorizationModel
         if (isset($config['zf-rpc'])
             && is_array($config['zf-rpc'])
         ) {
-            $missingServices = array();
+            $missingServices = [];
             foreach ($config['zf-rpc'] as $serviceName => $serviceConfig) {
                 if (!preg_match('/' . preg_quote('\\') . 'V' . $version . preg_quote('\\') . '/', $serviceName)) {
                     continue;

--- a/src/Model/AuthorizationModelFactory.php
+++ b/src/Model/AuthorizationModelFactory.php
@@ -21,7 +21,7 @@ class AuthorizationModelFactory
      *
      * @var array
      */
-    protected $models = array();
+    protected $models = [];
 
     /**
      * @var ModuleModel

--- a/src/Model/ContentNegotiationEntity.php
+++ b/src/Model/ContentNegotiationEntity.php
@@ -22,8 +22,8 @@ class ContentNegotiationEntity
     public function getArrayCopy()
     {
         return array_merge(
-            array('content_name' => $this->name),
-            array('selectors' => $this->config)
+            ['content_name' => $this->name],
+            ['selectors' => $this->config]
         );
     }
 
@@ -34,7 +34,7 @@ class ContentNegotiationEntity
      */
     public function exchangeArray(array $array)
     {
-        $this->config = array();
+        $this->config = [];
         foreach ($array as $key => $value) {
             switch (strtolower($key)) {
                 case 'content_name':

--- a/src/Model/ContentNegotiationModel.php
+++ b/src/Model/ContentNegotiationModel.php
@@ -69,7 +69,7 @@ class ContentNegotiationModel
      */
     public function fetchAll()
     {
-        $config = array();
+        $config = [];
         $fromConfigFile = $this->globalConfig->fetch(true);
         if (isset($fromConfigFile['zf-content-negotiation']['selectors'])
             && is_array($fromConfigFile['zf-content-negotiation']['selectors'])
@@ -77,7 +77,7 @@ class ContentNegotiationModel
             $config = $fromConfigFile['zf-content-negotiation']['selectors'];
         }
 
-        $negotiations = array();
+        $negotiations = [];
         foreach ($config as $name => $contentConfig) {
             $negotiations[] = new ContentNegotiationEntity($name, $contentConfig);
         }

--- a/src/Model/ContentNegotiationResource.php
+++ b/src/Model/ContentNegotiationResource.php
@@ -45,7 +45,7 @@ class ContentNegotiationResource extends AbstractResourceListener
         return $entity;
     }
 
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         return $this->model->fetchAll();
     }
@@ -61,7 +61,7 @@ class ContentNegotiationResource extends AbstractResourceListener
         $name = $data['content_name'];
         unset($data['content_name']);
 
-        $selectors = array();
+        $selectors = [];
         if (isset($data['selectors'])) {
             $selectors = (array) $data['selectors'];
         }

--- a/src/Model/DbAdapterEntity.php
+++ b/src/Model/DbAdapterEntity.php
@@ -21,9 +21,9 @@ class DbAdapterEntity
      */
     public function getArrayCopy()
     {
-        return array_merge(array(
+        return array_merge([
             'adapter_name' => $this->name,
-        ), $this->config);
+        ], $this->config);
     }
 
     /**
@@ -33,7 +33,7 @@ class DbAdapterEntity
      */
     public function exchangeArray(array $array)
     {
-        $this->config = array();
+        $this->config = [];
         foreach ($array as $key => $value) {
             switch (strtolower($key)) {
                 case 'adapter_name':

--- a/src/Model/DbAdapterModel.php
+++ b/src/Model/DbAdapterModel.php
@@ -51,7 +51,7 @@ class DbAdapterModel
             unset($adapterConfig['dsn']);
         }
 
-        $this->globalConfig->patchKey($key, array());
+        $this->globalConfig->patchKey($key, []);
         $this->localConfig->patchKey($key, $adapterConfig);
 
         return new DbAdapterEntity($name, $adapterConfig);
@@ -90,7 +90,7 @@ class DbAdapterModel
      */
     public function fetchAll()
     {
-        $config = array();
+        $config = [];
         $fromConfigFile = $this->localConfig->fetch(true);
         if (isset($fromConfigFile['db'])
             && isset($fromConfigFile['db']['adapters'])
@@ -99,7 +99,7 @@ class DbAdapterModel
             $config = $fromConfigFile['db']['adapters'];
         }
 
-        $adapters = array();
+        $adapters = [];
         foreach ($config as $name => $adapterConfig) {
             $adapters[] = new DbAdapterEntity($name, $adapterConfig);
         }

--- a/src/Model/DbAdapterResource.php
+++ b/src/Model/DbAdapterResource.php
@@ -31,7 +31,7 @@ class DbAdapterResource extends AbstractResourceListener
         return $entity;
     }
 
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         return $this->model->fetchAll();
     }

--- a/src/Model/DbAutodiscoveryModel.php
+++ b/src/Model/DbAutodiscoveryModel.php
@@ -24,7 +24,7 @@ class DbAutodiscoveryModel extends AbstractAutodiscoveryModel
      */
     public function fetchColumns($module, $version, $adapter_name)
     {
-        $tables = array();
+        $tables = [];
         if (!isset($this->config['db']['adapters'])) {
             // error
         }
@@ -41,25 +41,25 @@ class DbAutodiscoveryModel extends AbstractAutodiscoveryModel
                 continue;
             }
 
-            $tableData = array(
+            $tableData = [
                 'table_name' => $tableName,
-            );
+            ];
             $table = $metadata->getTable($tableName);
 
-            $tableData['columns'] = array();
+            $tableData['columns'] = [];
 
             $constraints = $this->getConstraints($metadata, $tableName);
 
             /** @var \Zend\Db\Metadata\Object\ColumnObject $column */
             foreach ($table->getColumns() as $column) {
-                $item = array(
+                $item = [
                     'name' => $column->getName(),
                     'type' => $column->getDataType(),
                     'required' => !$column->isNullable(),
-                    'filters' => array(),
-                    'validators' => array(),
-                    'constraints' => array(),
-                );
+                    'filters' => [],
+                    'validators' => [],
+                    'constraints' => [],
+                ];
 
                 foreach ($constraints as $constraint) {
                     if ($column->getName() == $constraint['column']) {
@@ -77,28 +77,28 @@ class DbAutodiscoveryModel extends AbstractAutodiscoveryModel
 
                                 $validator = $this->validators['foreign_key'];
                                 $referencedColumns = $constraintObj->getReferencedColumns();
-                                $validator['options'] = array(
+                                $validator['options'] = [
                                     'adapter' => $adapter_name,
                                     'table' => $constraintObj->getReferencedTableName(),
                                     //TODO: handle composite key constraint
                                     'field' => $referencedColumns[0]
-                                );
+                                ];
                                 $item['validators'][] = $validator;
                                 break;
                             case 'UNIQUE':
                                 $validator = $this->validators['unique'];
-                                $validator['options'] = array(
+                                $validator['options'] = [
                                     'adapter' => $adapter_name,
                                     'table' => $tableName,
                                     'field' => $column->getName(),
-                                );
+                                ];
                                 $item['validators'][] = $validator;
                                 break;
                         }
                     }
                 }
 
-                if (in_array(strtolower($column->getDataType()), array('varchar', 'text'))) {
+                if (in_array(strtolower($column->getDataType()), ['varchar', 'text'])) {
                     $item['length'] = $column->getCharacterMaximumLength();
                     if (in_array('Primary key', array_values($item['constraints']))) {
                         unset($item['filters']);
@@ -110,8 +110,8 @@ class DbAutodiscoveryModel extends AbstractAutodiscoveryModel
                     $validator = $this->validators['text'];
                     $validator['options']['max'] = $column->getCharacterMaximumLength();
                     $item['validators'][] = $validator;
-                } elseif (in_array(strtolower($column->getDataType()), array(
-                    'tinyint', 'smallint', 'mediumint', 'int', 'bigint'))) {
+                } elseif (in_array(strtolower($column->getDataType()), [
+                    'tinyint', 'smallint', 'mediumint', 'int', 'bigint'])) {
                     $item['length'] = $column->getNumericPrecision();
                     if (in_array('Primary key', array_values($item['constraints']))) {
                         unset($item['filters']);
@@ -137,14 +137,14 @@ class DbAutodiscoveryModel extends AbstractAutodiscoveryModel
      */
     protected function getConstraints(Metadata $metadata, $tableName)
     {
-        $constraints = array();
+        $constraints = [];
         /** @var \Zend\Db\Metadata\Object\ConstraintObject $constraint */
         foreach ($metadata->getConstraints($tableName) as $constraint) {
             foreach ($constraint->getColumns() as $column) {
-                $constraints[] = array(
+                $constraints[] = [
                     'column' => $column,
                     'type' => $constraint->getType(),
-                );
+                ];
             }
         }
 

--- a/src/Model/DbConnectedRestServiceModel.php
+++ b/src/Model/DbConnectedRestServiceModel.php
@@ -39,7 +39,7 @@ class DbConnectedRestServiceModel
             return;
         }
 
-        $config = $e->getParam('config', array());
+        $config = $e->getParam('config', []);
         if (!isset($config['zf-apigility'])
             || !isset($config['zf-apigility']['db-connected'])
             || !isset($config['zf-apigility']['db-connected'][$entity->resourceClass])
@@ -58,7 +58,7 @@ class DbConnectedRestServiceModel
 
         // If no override resource class is present, remove it from the returned entity
         if ($e->getParam('fetch', true) && ! isset($config['resource_class'])) {
-            $dbConnectedEntity->exchangeArray(array('resource_class' => null));
+            $dbConnectedEntity->exchangeArray(['resource_class' => null]);
         }
 
         return $dbConnectedEntity;
@@ -92,23 +92,23 @@ class DbConnectedRestServiceModel
         );
         $mediaType         = $restModel->createMediaType();
 
-        $entity->exchangeArray(array(
+        $entity->exchangeArray([
             'collection_class'        => $collectionClass,
             'controller_service_name' => $controllerService,
             'entity_class'            => $entityClass,
             'module'                  => $restModel->module,
             'resource_class'          => $resourceClass,
             'route_name'              => $routeName,
-            'accept_whitelist'        => array(
+            'accept_whitelist'        => [
                 $mediaType,
                 'application/hal+json',
                 'application/json',
-            ),
-            'content_type_whitelist'  => array(
+            ],
+            'content_type_whitelist'  => [
                 $mediaType,
                 'application/json',
-            ),
-        ));
+            ],
+        ]);
 
         $restModel->createRestConfig($entity, $controllerService, $resourceClass, $routeName);
         $restModel->createContentNegotiationConfig($entity, $controllerService);
@@ -131,9 +131,9 @@ class DbConnectedRestServiceModel
 
         // We need the resource class in order to update db-connected config!
         if (! $entity->resourceClass && $updatedEntity->resourceClass) {
-            $entity->exchangeArray(array(
+            $entity->exchangeArray([
                 'resource_class' => $updatedEntity->resourceClass,
-            ));
+            ]);
         }
 
         $updatedProps   = $this->updateDbConnectedConfig($entity);
@@ -144,7 +144,7 @@ class DbConnectedRestServiceModel
         $config = $this->restModel->configResource->fetch(true);
         $config = $config['zf-apigility']['db-connected'][$entity->resourceClass];
         if (! isset($config['resource_class'])) {
-            $entity->exchangeArray(array('resource_class' => null));
+            $entity->exchangeArray(['resource_class' => null]);
         }
 
         return $updatedEntity;
@@ -176,19 +176,19 @@ class DbConnectedRestServiceModel
      */
     public function createDbConnectedConfig(DbConnectedRestServiceEntity $entity)
     {
-        $entity->exchangeArray(array(
+        $entity->exchangeArray([
             'table_service' => sprintf('%s\\Table', $entity->resourceClass),
-        ));
+        ]);
 
-        $config = array('zf-apigility' => array('db-connected' => array(
-            $entity->resourceClass => array(
+        $config = ['zf-apigility' => ['db-connected' => [
+            $entity->resourceClass => [
                 'adapter_name'            => $entity->adapterName,
                 'table_name'              => $entity->tableName,
                 'hydrator_name'           => $entity->hydratorName,
                 'controller_service_name' => $entity->controllerServiceName,
                 'entity_identifier_name'  => $entity->entityIdentifierName,
-            ),
-        )));
+            ],
+        ]]];
         $this->restModel->configResource->patch($config, true);
     }
 
@@ -199,15 +199,15 @@ class DbConnectedRestServiceModel
      */
     public function updateDbConnectedConfig(DbConnectedRestServiceEntity $entity)
     {
-        $properties = array('zf-apigility' => array('db-connected' => array(
-            $entity->resourceClass => array(
+        $properties = ['zf-apigility' => ['db-connected' => [
+            $entity->resourceClass => [
                 'adapter_name'           => $entity->adapterName,
                 'table_name'             => $entity->tableName,
                 'table_service'          => $entity->tableService,
                 'hydrator_name'          => $entity->hydratorName,
                 'entity_identifier_name' => $entity->entityIdentifierName,
-            ),
-        )));
+            ],
+        ]]];
         $this->restModel->configResource->patch($properties, true);
         return $properties['zf-apigility']['db-connected'][$entity->resourceClass];
     }
@@ -235,7 +235,7 @@ class DbConnectedRestServiceModel
      */
     public function deleteDbConnectedConfig(DbConnectedRestServiceEntity $entity)
     {
-        $key = array('zf-apigility', 'db-connected', $entity->resourceClass);
+        $key = ['zf-apigility', 'db-connected', $entity->resourceClass];
         $this->restModel->configResource->deleteKey($key);
     }
 }

--- a/src/Model/DoctrineAdapterEntity.php
+++ b/src/Model/DoctrineAdapterEntity.php
@@ -40,7 +40,7 @@ class DoctrineAdapterEntity implements ArraySerializableInterface
      */
     public function exchangeArray(array $array)
     {
-        $this->config = array();
+        $this->config = [];
         foreach ($array as $key => $value) {
             switch (strtolower($key)) {
                 case 'adapter_name':
@@ -64,8 +64,8 @@ class DoctrineAdapterEntity implements ArraySerializableInterface
             ? 'doctrine.entitymanager.'
             : 'doctrine.documentmanager.';
 
-        return array_merge(array(
+        return array_merge([
             'adapter_name' => $baseKey . $this->name,
-        ), $this->config);
+        ], $this->config);
     }
 }

--- a/src/Model/DoctrineAdapterModel.php
+++ b/src/Model/DoctrineAdapterModel.php
@@ -40,7 +40,7 @@ class DoctrineAdapterModel
     public function create($name, array $adapterConfig)
     {
         $key = "doctrine.connection.{$name}";
-        $this->globalConfig->patchKey($key, array());
+        $this->globalConfig->patchKey($key, []);
         $this->localConfig->patchKey($key, $adapterConfig);
 
         return new DoctrineAdapterEntity($name, $adapterConfig);
@@ -98,7 +98,7 @@ class DoctrineAdapterModel
             return false;
         }
 
-        $adapters = array();
+        $adapters = [];
         foreach ($config as $name => $adapterConfig) {
             $adapters[] = new DoctrineAdapterEntity($name, $adapterConfig);
         }

--- a/src/Model/DoctrineAdapterResource.php
+++ b/src/Model/DoctrineAdapterResource.php
@@ -75,7 +75,7 @@ class DoctrineAdapterResource extends AbstractResourceListener implements Servic
      * @param array $params
      * @return array
      */
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         $modules = $this->getServiceLocator()->get('ModuleManager');
         $loaded = $modules->getLoadedModules(false);
@@ -87,7 +87,7 @@ class DoctrineAdapterResource extends AbstractResourceListener implements Servic
         }
 
         if (false === ($adapters = $this->model->fetchAll($params))) {
-            return array();
+            return [];
         }
 
         return $adapters;

--- a/src/Model/DocumentationModel.php
+++ b/src/Model/DocumentationModel.php
@@ -32,34 +32,34 @@ class DocumentationModel
     {
         switch ($type) {
             case self::TYPE_REST:
-                return array(
-                    'collection' => array(
+                return [
+                    'collection' => [
                         'description' => null,
-                        'GET'    => array('description' => null, 'request' => null, 'response' => null),
-                        'POST'   => array('description' => null, 'request' => null, 'response' => null),
-                        'PUT'    => array('description' => null, 'request' => null, 'response' => null),
-                        'PATCH'  => array('description' => null, 'request' => null, 'response' => null),
-                        'DELETE' => array('description' => null, 'request' => null, 'response' => null),
-                    ),
-                    'entity' => array(
+                        'GET'    => ['description' => null, 'request' => null, 'response' => null],
+                        'POST'   => ['description' => null, 'request' => null, 'response' => null],
+                        'PUT'    => ['description' => null, 'request' => null, 'response' => null],
+                        'PATCH'  => ['description' => null, 'request' => null, 'response' => null],
+                        'DELETE' => ['description' => null, 'request' => null, 'response' => null],
+                    ],
+                    'entity' => [
                         'description' => null,
-                        'GET'    => array('description' => null, 'request' => null, 'response' => null),
-                        'POST'   => array('description' => null, 'request' => null, 'response' => null),
-                        'PUT'    => array('description' => null, 'request' => null, 'response' => null),
-                        'PATCH'  => array('description' => null, 'request' => null, 'response' => null),
-                        'DELETE' => array('description' => null, 'request' => null, 'response' => null),
-                    ),
+                        'GET'    => ['description' => null, 'request' => null, 'response' => null],
+                        'POST'   => ['description' => null, 'request' => null, 'response' => null],
+                        'PUT'    => ['description' => null, 'request' => null, 'response' => null],
+                        'PATCH'  => ['description' => null, 'request' => null, 'response' => null],
+                        'DELETE' => ['description' => null, 'request' => null, 'response' => null],
+                    ],
                     'description' => null
-                );
+                ];
             case self::TYPE_RPC:
-                return array(
+                return [
                     'description' => null,
-                    'GET'    => array('description' => null, 'request' => null, 'response' => null),
-                    'POST'   => array('description' => null, 'request' => null, 'response' => null),
-                    'PUT'    => array('description' => null, 'request' => null, 'response' => null),
-                    'PATCH'  => array('description' => null, 'request' => null, 'response' => null),
-                    'DELETE' => array('description' => null, 'request' => null, 'response' => null),
-                );
+                    'GET'    => ['description' => null, 'request' => null, 'response' => null],
+                    'POST'   => ['description' => null, 'request' => null, 'response' => null],
+                    'PUT'    => ['description' => null, 'request' => null, 'response' => null],
+                    'PATCH'  => ['description' => null, 'request' => null, 'response' => null],
+                    'DELETE' => ['description' => null, 'request' => null, 'response' => null],
+                ];
         }
     }
 
@@ -70,7 +70,7 @@ class DocumentationModel
         if (isset($value[$controllerServiceName])) {
             return $value[$controllerServiceName];
         }
-        return array();
+        return [];
     }
 
     public function storeDocumentation(
@@ -81,9 +81,9 @@ class DocumentationModel
         $replace = false
     ) {
         $configResource = $this->getDocumentationConfigResource($module);
-        $template = array($controllerServiceName => $this->getSchemaTemplate($controllerType));
+        $template = [$controllerServiceName => $this->getSchemaTemplate($controllerType)];
         $templateFlat = $configResource->traverseArray($template);
-        $documentationFlat = $configResource->traverseArray(array($controllerServiceName => $documentation));
+        $documentationFlat = $configResource->traverseArray([$controllerServiceName => $documentation]);
 
         $validDocumentationFlat = array_intersect_key($documentationFlat, $templateFlat);
 
@@ -153,7 +153,7 @@ class DocumentationModel
     {
         $moduleConfigPath = $this->moduleUtils->getModuleConfigPath($module);
         $docConfigPath = dirname($moduleConfigPath) . '/documentation.config.php';
-        $docArray = (file_exists($docConfigPath)) ? include $docConfigPath : array();
+        $docArray = (file_exists($docConfigPath)) ? include $docConfigPath : [];
         return $this->configFactory->createConfigResource($docArray, $docConfigPath);
     }
 }

--- a/src/Model/FiltersModel.php
+++ b/src/Model/FiltersModel.php
@@ -24,7 +24,7 @@ class FiltersModel extends AbstractPluginManagerModel
      * @param ServiceManager $pluginManager
      * @param array $metadata
      */
-    public function __construct(ServiceManager $pluginManager, array $metadata = array())
+    public function __construct(ServiceManager $pluginManager, array $metadata = [])
     {
         if (! $pluginManager instanceof FilterPluginManager) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -57,7 +57,7 @@ class FiltersModel extends AbstractPluginManagerModel
 
         array_walk($plugins, function (& $value, $key) use ($metadata) {
             if (! array_key_exists($key, $metadata)) {
-                $value = array();
+                $value = [];
                 return;
             }
             $value = $metadata[$key];

--- a/src/Model/FiltersModelFactory.php
+++ b/src/Model/FiltersModelFactory.php
@@ -27,7 +27,7 @@ class FiltersModelFactory implements FactoryInterface
             ));
         }
 
-        $metadata = array();
+        $metadata = [];
         if ($services->has('Config')) {
             $config = $services->get('Config');
             if (isset($config['filter_metadata'])

--- a/src/Model/InputFilterModel.php
+++ b/src/Model/InputFilterModel.php
@@ -133,7 +133,7 @@ class InputFilterModel
         if (!isset($config['zf-content-validation'][$controller])) {
             $validatorName = $validatorName ?: $this->generateValidatorName($controller);
             $config = $configModule->patchKey(
-                array('zf-content-validation', $controller, 'input_filter'),
+                ['zf-content-validation', $controller, 'input_filter'],
                 $validatorName
             );
         }
@@ -141,16 +141,16 @@ class InputFilterModel
         $validator = $config['zf-content-validation'][$controller]['input_filter'];
 
         if (!isset($config['input_filter_specs'])) {
-            $config['input_filter_specs'] = array();
+            $config['input_filter_specs'] = [];
         }
 
         if (!isset($config['input_filter_specs'][$validator])) {
-            $config['input_filter_specs'][$validator] = array();
+            $config['input_filter_specs'][$validator] = [];
         }
 
         $config['input_filter_specs'][$validator] = $inputFilter;
 
-        $updated = $configModule->patchKey(array('input_filter_specs', $validator), $inputFilter);
+        $updated = $configModule->patchKey(['input_filter_specs', $validator], $inputFilter);
         if (!is_array($updated)) {
             return false;
         }

--- a/src/Model/ModuleEntity.php
+++ b/src/Model/ModuleEntity.php
@@ -45,7 +45,7 @@ class ModuleEntity
     /**
      * @var array
      */
-    protected $versions = array();
+    protected $versions = [];
 
     /**
      * @param  string $name
@@ -56,8 +56,8 @@ class ModuleEntity
      */
     public function __construct(
         $namespace,
-        array $restServices = array(),
-        array $rpcServices = array(),
+        array $restServices = [],
+        array $rpcServices = [],
         $isVendor = null
     ) {
         if (!class_exists($namespace . '\\Module')) {
@@ -207,7 +207,7 @@ class ModuleEntity
      */
     public function getArrayCopy()
     {
-        return array(
+        return [
             'name'            => $this->name,
             'namespace'       => $this->namespace,
             'is_vendor'       => $this->isVendor(),
@@ -215,7 +215,7 @@ class ModuleEntity
             'rpc'             => $this->getRpcServices(),
             'versions'        => $this->versions,
             'default_version' => $this->defaultVersion,
-        );
+        ];
     }
 
     /**

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -24,7 +24,7 @@ class ModuleModel
      * Services for each module
      * @var array
      */
-    protected $services = array();
+    protected $services = [];
 
     /**
      * @var ModuleManager
@@ -151,14 +151,14 @@ class ModuleModel
             return false;
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
             'module'  => $module
-        ));
+        ]);
 
-        $resolver = new Resolver\TemplateMapResolver(array(
+        $resolver = new Resolver\TemplateMapResolver([
             'module/skeleton' => __DIR__ . '/../../view/module/skeleton.phtml',
             'module/skeleton-psr4' => __DIR__ . '/../../view/module/skeleton-psr4.phtml',
-        ));
+        ]);
 
         $renderer = new PhpRenderer();
         $renderer->setResolver($resolver);
@@ -296,7 +296,7 @@ class ModuleModel
             return $this->modules;
         }
 
-        $this->modules = array();
+        $this->modules = [];
         foreach ($this->moduleManager->getLoadedModules() as $moduleName => $module) {
             if (!$module instanceof ApigilityProviderInterface && !$module instanceof ApigilityModuleInterface) {
                 continue;
@@ -313,10 +313,10 @@ class ModuleModel
             $services = $this->getServicesByModule($moduleName);
             $versions = $this->getVersionsByModule($moduleName, $module);
             $entity   = new ModuleEntity($moduleName, $services['rest'], $services['rpc']);
-            $entity->exchangeArray(array(
+            $entity->exchangeArray([
                 'versions'        => $versions,
                 'default_version' => $this->getModuleDefaultVersion($module),
-            ));
+            ]);
 
             $this->modules[$entity->getName()] = $entity;
         }
@@ -359,10 +359,10 @@ class ModuleModel
      */
     protected function getServicesByModule($module)
     {
-        $services = array(
+        $services = [
             'rest' => $this->discoverServicesByModule($module, $this->restConfig),
             'rpc'  => $this->discoverServicesByModule($module, $this->rpcConfig),
-        );
+        ];
         return $services;
     }
 
@@ -400,10 +400,10 @@ class ModuleModel
             $path = sprintf('%s/src/%s', $path, str_replace('\\', '/', $moduleName));
         }
         if (!file_exists($path)) {
-            return array(1);
+            return [1];
         }
 
-        $versions  = array();
+        $versions  = [];
         foreach (Glob::glob($path . DIRECTORY_SEPARATOR . 'V*') as $dir) {
             if (preg_match('/\\V(?P<version>\d+)$/', $dir, $matches)) {
                 $versions[] = (int) $matches['version'];
@@ -411,7 +411,7 @@ class ModuleModel
         }
 
         if (empty($versions)) {
-            return array(1);
+            return [1];
         }
 
         sort($versions);
@@ -427,7 +427,7 @@ class ModuleModel
      */
     protected function discoverServicesByModule($module, array $config)
     {
-        $services = array();
+        $services = [];
         foreach ($config as $controller) {
             if (strpos($controller, $module) === 0) {
                 $services[] = $controller;

--- a/src/Model/ModulePathSpec.php
+++ b/src/Model/ModulePathSpec.php
@@ -31,10 +31,10 @@ class ModulePathSpec
     /**
      * @var array
      */
-    protected $psrSpecs = array(
+    protected $psrSpecs = [
         'psr-0' => '%modulePath%/src/%moduleName%',
         'psr-4' => '%modulePath%/src'
-    );
+    ];
 
     /**
      * @var string
@@ -140,14 +140,14 @@ class ModulePathSpec
      */
     public function getModuleSourcePath($moduleName, $fullPath = true)
     {
-        $find    = array("%modulePath%", "%moduleName%");
+        $find    = ["%modulePath%", "%moduleName%"];
 
         $moduleName = str_replace('\\', '/', $moduleName);
 
         if (true === $fullPath) {
-            $replace = array($this->getModulePath($moduleName), $moduleName);
+            $replace = [$this->getModulePath($moduleName), $moduleName];
         } else {
-            $replace = array('', $moduleName);
+            $replace = ['', $moduleName];
         }
 
         return str_replace($find, $replace, $this->moduleSourcePathSpec);
@@ -163,8 +163,8 @@ class ModulePathSpec
      */
     public function getRestPath($moduleName, $version = 1, $serviceName = null)
     {
-        $find    = array("\\", "%serviceName%", "%version%");
-        $replace = array("/", $serviceName, $version);
+        $find    = ["\\", "%serviceName%", "%version%"];
+        $replace = ["/", $serviceName, $version];
 
         $path = $this->getModuleSourcePath($moduleName);
         $path .= str_replace($find, $replace, $this->restPathSpec);
@@ -186,8 +186,8 @@ class ModulePathSpec
      */
     public function getRpcPath($moduleName, $version = 1, $serviceName = null)
     {
-        $find    = array("\\", "%version%");
-        $replace = array("/", $version);
+        $find    = ["\\", "%version%"];
+        $replace = ["/", $version];
 
         $path = $this->getModuleSourcePath($moduleName);
         $path .= str_replace($find, $replace, $this->rpcPathSpec);

--- a/src/Model/ModuleResource.php
+++ b/src/Model/ModuleResource.php
@@ -80,9 +80,9 @@ class ModuleResource extends AbstractResourceListener
         }
 
         $metadata = new ModuleEntity($name);
-        $metadata->exchangeArray(array(
-            'versions' => array($version),
-        ));
+        $metadata->exchangeArray([
+            'versions' => [$version],
+        ]);
         return $metadata;
     }
 
@@ -107,7 +107,7 @@ class ModuleResource extends AbstractResourceListener
      * @param  array $params
      * @return array
      */
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         return $this->modules->getModules();
     }

--- a/src/Model/RestServiceEntity.php
+++ b/src/Model/RestServiceEntity.php
@@ -11,22 +11,22 @@ use ZF\Hal\Collection as HalCollection;
 
 class RestServiceEntity
 {
-    protected $acceptWhitelist = array(
+    protected $acceptWhitelist = [
         'application/json',
         'application/*+json',
-    );
+    ];
 
     protected $collectionClass;
 
-    protected $collectionHttpMethods = array('GET', 'POST');
+    protected $collectionHttpMethods = ['GET', 'POST'];
 
     protected $collectionName;
 
-    protected $collectionQueryWhitelist = array();
+    protected $collectionQueryWhitelist = [];
 
-    protected $contentTypeWhitelist = array(
+    protected $contentTypeWhitelist = [
         'application/json',
-    );
+    ];
 
     protected $controllerServiceName;
 
@@ -34,11 +34,11 @@ class RestServiceEntity
 
     protected $entityClass;
 
-    protected $entityHttpMethods = array('GET', 'PATCH', 'PUT', 'DELETE');
+    protected $entityHttpMethods = ['GET', 'PATCH', 'PUT', 'DELETE'];
 
     protected $entityIdentifierName = 'id';
 
-    protected $filters = array();
+    protected $filters = [];
 
     protected $hydratorName = 'Zend\Stdlib\Hydrator\ArraySerializable';
 
@@ -202,7 +202,7 @@ class RestServiceEntity
 
     public function getArrayCopy()
     {
-        $array = array(
+        $array = [
             'accept_whitelist'           => $this->acceptWhitelist,
             'collection_class'           => $this->collectionClass,
             'collection_http_methods'    => $this->collectionHttpMethods,
@@ -223,7 +223,7 @@ class RestServiceEntity
             'route_name'                 => $this->routeName,
             'selector'                   => $this->selector,
             'service_name'               => $this->serviceName,
-        );
+        ];
         if (null !== $this->inputFilters) {
             $array['input_filters'] = $this->inputFilters;
         }

--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -63,25 +63,25 @@ class RestServiceModel implements EventManagerAwareInterface
      *
      * @var array
      */
-    protected $restScalarUpdateOptions = array(
+    protected $restScalarUpdateOptions = [
         'collectionClass'          => 'collection_class',
         'collectionName'           => 'collection_name',
         'entityClass'              => 'entity_class',
         'routeIdentifierName'      => 'route_identifier_name',
         'pageSize'                 => 'page_size',
         'pageSizeParam'            => 'page_size_param',
-    );
+    ];
 
     /**
      * Allowed REST update options that are arrays
      *
      * @var array
      */
-    protected $restArrayUpdateOptions = array(
+    protected $restArrayUpdateOptions = [
         'collectionHttpMethods'    => 'collection_http_methods',
         'collectionQueryWhitelist' => 'collection_query_whitelist',
         'entityHttpMethods'        => 'entity_http_methods',
-    );
+    ];
 
     /**
      * @var FilterChain
@@ -128,10 +128,10 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     public function setEventManager(EventManagerInterface $events)
     {
-        $events->setIdentifiers(array(
+        $events->setIdentifiers([
             __CLASS__,
             get_class($this),
-        ));
+        ]);
         $this->events = $events;
         return $this;
     }
@@ -186,11 +186,11 @@ class RestServiceModel implements EventManagerAwareInterface
 
         // Trigger an event, allowing a listener to alter the entity and/or
         // curry a new one.
-        $eventResults = $this->getEventManager()->trigger(__FUNCTION__, $this, array(
+        $eventResults = $this->getEventManager()->trigger(__FUNCTION__, $this, [
             'entity' => $entity,
             'config' => $config,
             'fetch'  => $isAFetchOperation,
-        ), function ($r) {
+        ], function ($r) {
             return ($r instanceof RestServiceEntity);
         });
         if ($eventResults->stopped()) {
@@ -208,9 +208,9 @@ class RestServiceModel implements EventManagerAwareInterface
             if (preg_match($pattern, $controllerService, $matches)) {
                 $serviceName = $matches['service'];
             }
-            $entity->exchangeArray(array(
+            $entity->exchangeArray([
                 'service_name' => $serviceName,
-            ));
+            ]);
         }
 
         return $entity;
@@ -225,10 +225,10 @@ class RestServiceModel implements EventManagerAwareInterface
     {
         $config = $this->configResource->fetch(true);
         if (!isset($config['zf-rest'])) {
-            return array();
+            return [];
         }
 
-        $services = array();
+        $services = [];
         $pattern  = false;
 
         // Initialize pattern if a version was passed and it's valid
@@ -301,23 +301,23 @@ class RestServiceModel implements EventManagerAwareInterface
             ? $details->module
             : $this->module;
 
-        $entity->exchangeArray(array(
+        $entity->exchangeArray([
             'collection_class'        => $collectionClass,
             'controller_service_name' => $controllerService,
             'entity_class'            => $entityClass,
             'module'                  => $module,
             'resource_class'          => $resourceClass,
             'route_name'              => $routeName,
-            'accept_whitelist'        => array(
+            'accept_whitelist'        => [
                 $mediaType,
                 'application/hal+json',
                 'application/json',
-            ),
-            'content_type_whitelist'  => array(
+            ],
+            'content_type_whitelist'  => [
                 $mediaType,
                 'application/json',
-            ),
-        ));
+            ],
+        ]);
 
         $this->createRestConfig($entity, $controllerService, $resourceClass, $routeName);
         $this->createContentNegotiationConfig($entity, $controllerService);
@@ -421,13 +421,13 @@ class RestServiceModel implements EventManagerAwareInterface
             ));
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
                 'module'        => $module,
                 'resource'      => $serviceName,
                 'classfactory'  => $className,
                 'classresource' => $classResource,
                 'version'       => $this->moduleEntity->getLatestVersion(),
-        ));
+        ]);
         if (!$this->createClassFile($view, 'factory', $classPath)) {
             throw new Exception\RuntimeException(sprintf(
                 'Unable to create resource factory "%s"; unable to write file',
@@ -467,12 +467,12 @@ class RestServiceModel implements EventManagerAwareInterface
             ));
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
             'module'    => $module,
             'resource'  => $serviceName,
             'classname' => $className,
             'version'   => $this->moduleEntity->getLatestVersion(),
-        ));
+        ]);
         if (!$this->createClassFile($view, 'resource', $classPath)) {
             throw new Exception\RuntimeException(sprintf(
                 'Unable to create resource "%s"; unable to write file',
@@ -490,13 +490,13 @@ class RestServiceModel implements EventManagerAwareInterface
 
         $factoryClassName = $this->createFactoryClass($serviceName);
 
-        $this->configResource->patch(array(
-                'service_manager' => array(
-                        'factories' => array(
+        $this->configResource->patch([
+                'service_manager' => [
+                        'factories' => [
                                 $fullClassName => $factoryClassName,
-                        ),
-                ),
-        ), true);
+                        ],
+                ],
+        ], true);
 
         return $fullClassName;
     }
@@ -523,13 +523,13 @@ class RestServiceModel implements EventManagerAwareInterface
             ));
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
             'module'    => $module,
             'resource'  => $serviceName,
             'classname' => $className,
             'version'   => $this->moduleEntity->getLatestVersion(),
             'details'   => $details,
-        ));
+        ]);
         if (!$this->createClassFile($view, $template, $classPath)) {
             throw new Exception\RuntimeException(sprintf(
                 'Unable to create entity "%s"; unable to write file',
@@ -568,12 +568,12 @@ class RestServiceModel implements EventManagerAwareInterface
             ));
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
             'module'    => $module,
             'resource'  => $serviceName,
             'classname' => $className,
             'version'   => $this->moduleEntity->getLatestVersion(),
-        ));
+        ]);
         if (!$this->createClassFile($view, 'collection', $classPath)) {
             throw new Exception\RuntimeException(sprintf(
                 'Unable to create entity "%s"; unable to write file',
@@ -640,26 +640,26 @@ class RestServiceModel implements EventManagerAwareInterface
             ), 409);
         }
 
-        $config = array(
-            'router' => array(
-                'routes' => array(
-                    $routeName => array(
+        $config = [
+            'router' => [
+                'routes' => [
+                    $routeName => [
                         'type' => 'Segment',
-                        'options' => array(
+                        'options' => [
                             'route' => sprintf('%s[/:%s]', $route, $routeIdentifier),
-                            'defaults' => array(
+                            'defaults' => [
                                 'controller' => $controllerService,
-                            ),
-                        ),
-                    ),
-                )
-            ),
-            'zf-versioning' => array(
-                'uri' => array(
+                            ],
+                        ],
+                    ],
+                ]
+            ],
+            'zf-versioning' => [
+                'uri' => [
                     $routeName
-                )
-            )
-        );
+                ]
+            ]
+        ];
         $this->configResource->patch($config, true);
 
         return $routeName;
@@ -692,8 +692,8 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     public function createRestConfig(RestServiceEntity $details, $controllerService, $resourceClass, $routeName)
     {
-        $config = array('zf-rest' => array(
-            $controllerService => array(
+        $config = ['zf-rest' => [
+            $controllerService => [
                 'listener'                   => $resourceClass,
                 'route_name'                 => $routeName,
                 'route_identifier_name'      => $details->routeIdentifierName,
@@ -706,8 +706,8 @@ class RestServiceModel implements EventManagerAwareInterface
                 'entity_class'               => $details->entityClass,
                 'collection_class'           => $details->collectionClass,
                 'service_name'               => $details->serviceName,
-            ),
-        ));
+            ],
+        ]];
         $this->configResource->patch($config, true);
     }
 
@@ -720,20 +720,20 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     public function createContentNegotiationConfig(RestServiceEntity $details, $controllerService)
     {
-        $config = array(
-            'controllers' => array(
+        $config = [
+            'controllers' => [
                 $controllerService => $details->selector,
-            ),
-        );
+            ],
+        ];
         $whitelist = $details->acceptWhitelist;
         if (!empty($whitelist)) {
-            $config['accept_whitelist'] = array($controllerService => $whitelist);
+            $config['accept_whitelist'] = [$controllerService => $whitelist];
         }
         $whitelist = $details->contentTypeWhitelist;
         if (!empty($whitelist)) {
-            $config['content_type_whitelist'] = array($controllerService => $whitelist);
+            $config['content_type_whitelist'] = [$controllerService => $whitelist];
         }
-        $config = array('zf-content-negotiation' => $config);
+        $config = ['zf-content-negotiation' => $config];
         $this->configResource->patch($config, true);
     }
 
@@ -747,19 +747,19 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     public function createHalConfig(RestServiceEntity $details, $entityClass, $collectionClass, $routeName)
     {
-        $config = array('zf-hal' => array('metadata_map' => array(
-            $entityClass => array(
+        $config = ['zf-hal' => ['metadata_map' => [
+            $entityClass => [
                 'entity_identifier_name' => $details->entityIdentifierName,
                 'route_name'             => $routeName,
                 'route_identifier_name'  => $details->routeIdentifierName,
-            ),
-            $collectionClass => array(
+            ],
+            $collectionClass => [
                 'entity_identifier_name' => $details->entityIdentifierName,
                 'route_name'             => $routeName,
                 'route_identifier_name'  => $details->routeIdentifierName,
                 'is_collection'          => true,
-            ),
-        )));
+            ],
+        ]]];
         if (isset($details->hydratorName) && $details->hydratorName) {
             $config['zf-hal']['metadata_map'][$entityClass]['hydrator'] = $details->hydratorName;
         }
@@ -785,11 +785,11 @@ class RestServiceModel implements EventManagerAwareInterface
                 $route
             ), 409);
         }
-        $config    = array('router' => array('routes' => array(
-            $routeName => array('options' => array(
+        $config    = ['router' => ['routes' => [
+            $routeName => ['options' => [
                 'route' => $route,
-            ))
-        )));
+            ]]
+        ]]];
         $this->configResource->patch($config, true);
     }
 
@@ -801,7 +801,7 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     public function updateRestConfig(RestServiceEntity $original, RestServiceEntity $update)
     {
-        $patch = array();
+        $patch = [];
         foreach ($this->restScalarUpdateOptions as $property => $configKey) {
             if (!$update->$property) {
                 continue;
@@ -813,9 +813,9 @@ class RestServiceModel implements EventManagerAwareInterface
             goto updateArrayOptions;
         }
 
-        $config = array('zf-rest' => array(
+        $config = ['zf-rest' => [
             $original->controllerServiceName => $patch,
-        ));
+        ]];
         $this->configResource->patch($config, true);
 
         updateArrayOptions:
@@ -880,35 +880,35 @@ class RestServiceModel implements EventManagerAwareInterface
 
         // Do we have a new entity class?
         if (!isset($halConfig[$entityClass])) {
-            $data = array($entityClass => array(
+            $data = [$entityClass => [
                 'entity_identifier_name' => $update->entityIdentifierName ?: $original->entityIdentifierName,
                 'route_name'             => $update->routeName            ?: $original->routeName,
                 'route_identifier_name'  => $update->routeIdentifierName  ?: $original->routeIdentifierName,
-            ));
+            ]];
             $hydratorName = $update->hydratorName ?: $original->hydratorName;
             if ($hydratorName) {
                 $data[$entityClass]['hydrator'] = $hydratorName;
             }
-            $data = array('zf-hal' => array('metadata_map' => $data));
+            $data = ['zf-hal' => ['metadata_map' => $data]];
             $this->configResource->patch($data, true);
             $entityUpdated = true;
         }
 
         // Do we have a new collection class?
         if (!isset($halConfig[$collectionClass])) {
-            $data = array($collectionClass => array(
+            $data = [$collectionClass => [
                 'entity_identifier_name' => $update->entityIdentifierName ?: $original->entityIdentifierName,
                 'route_name'             => $update->routeName            ?: $original->routeName,
                 'route_identifier_name'  => $update->routeIdentifierName  ?: $original->routeIdentifierName,
                 'is_collection'          => true,
-            ));
-            $data = array('zf-hal' => array('metadata_map' => $data));
+            ]];
+            $data = ['zf-hal' => ['metadata_map' => $data]];
             $this->configResource->patch($data, true);
             $collectionUpdated = true;
         }
 
-        $entityUpdate     = array();
-        $collectionUpdate = array();
+        $entityUpdate     = [];
+        $collectionUpdate = [];
         if ((! $entityUpdated && ! $collectionUpdated)
             && $update->routeIdentifierName
             && $update->routeIdentifierName !== $original->routeIdentifierName
@@ -969,7 +969,7 @@ class RestServiceModel implements EventManagerAwareInterface
         }
 
         $route = $entity->routeName;
-        $key   = array('router', 'routes', $route);
+        $key   = ['router', 'routes', $route];
         $this->configResource->deleteKey($key);
     }
 
@@ -982,7 +982,7 @@ class RestServiceModel implements EventManagerAwareInterface
     public function deleteRestConfig(RestServiceEntity $entity)
     {
         $controllerService = $entity->controllerServiceName;
-        $key = array('zf-rest', $controllerService);
+        $key = ['zf-rest', $controllerService];
         $this->configResource->deleteKey($key);
     }
 
@@ -995,7 +995,7 @@ class RestServiceModel implements EventManagerAwareInterface
     {
         $controller = $entity->controllerServiceName;
 
-        $key = array('zf-content-negotiation', 'controllers', $controller);
+        $key = ['zf-content-negotiation', 'controllers', $controller];
         $this->configResource->deleteKey($key);
 
         $key[1] = 'accept_whitelist';
@@ -1013,7 +1013,7 @@ class RestServiceModel implements EventManagerAwareInterface
     public function deleteContentValidationConfig(RestServiceEntity $entity)
     {
         $controllerService = $entity->controllerServiceName;
-        $key = array('zf-content-validation', $controllerService);
+        $key = ['zf-content-validation', $controllerService];
         $this->configResource->deleteKey($key);
     }
 
@@ -1024,7 +1024,7 @@ class RestServiceModel implements EventManagerAwareInterface
      */
     public function deleteHalConfig(RestServiceEntity $entity)
     {
-        $key = array('zf-hal', 'metadata_map');
+        $key = ['zf-hal', 'metadata_map'];
         $entityClass = $entity->entityClass;
         array_push($key, $entityClass);
         $this->configResource->deleteKey($key);
@@ -1042,7 +1042,7 @@ class RestServiceModel implements EventManagerAwareInterface
     public function deleteAuthorizationConfig(RestServiceEntity $entity)
     {
         $controllerService = $entity->controllerServiceName;
-        $key = array('zf-mvc-auth', 'authorization', $controllerService);
+        $key = ['zf-mvc-auth', 'authorization', $controllerService];
         $this->configResource->deleteKey($key);
     }
 
@@ -1078,7 +1078,7 @@ class RestServiceModel implements EventManagerAwareInterface
             return true;
         });
 
-        $key = array('zf-versioning', 'uri');
+        $key = ['zf-versioning', 'uri'];
         $this->configResource->patchKey($key, $versioning);
     }
 
@@ -1090,8 +1090,8 @@ class RestServiceModel implements EventManagerAwareInterface
     public function deleteServiceManagerConfig(RestServiceEntity $entity)
     {
         $resourceClass = $entity->resourceClass;
-        foreach (array('invokables', 'factories') as $serviceType) {
-            $key = array('service_manager', $serviceType, $resourceClass);
+        foreach (['invokables', 'factories'] as $serviceType) {
+            $key = ['service_manager', $serviceType, $resourceClass];
             $this->configResource->deleteKey($key);
         }
     }
@@ -1152,9 +1152,9 @@ class RestServiceModel implements EventManagerAwareInterface
     {
         $template = sprintf('code-connected/rest-', $type);
         $path     = sprintf('%s/../../view/code-connected/rest-%s.phtml', __DIR__, $type);
-        $resolver = new Resolver\TemplateMapResolver(array(
+        $resolver = new Resolver\TemplateMapResolver([
             $template => $path,
-        ));
+        ]);
         $renderer->setResolver($resolver);
         return $template;
     }
@@ -1215,9 +1215,9 @@ class RestServiceModel implements EventManagerAwareInterface
         ) {
             return;
         }
-        $metadata->exchangeArray(array(
+        $metadata->exchangeArray([
             'route_match' => $config['router']['routes'][$routeName]['options']['route'],
-        ));
+        ]);
     }
 
     /**
@@ -1238,25 +1238,25 @@ class RestServiceModel implements EventManagerAwareInterface
         if (isset($config['controllers'])
             && isset($config['controllers'][$controllerServiceName])
         ) {
-            $metadata->exchangeArray(array(
+            $metadata->exchangeArray([
                 'selector' => $config['controllers'][$controllerServiceName],
-            ));
+            ]);
         }
 
         if (isset($config['accept_whitelist'])
             && isset($config['accept_whitelist'][$controllerServiceName])
         ) {
-            $metadata->exchangeArray(array(
+            $metadata->exchangeArray([
                 'accept_whitelist' => $config['accept_whitelist'][$controllerServiceName],
-            ));
+            ]);
         }
 
         if (isset($config['content_type_whitelist'])
             && isset($config['content_type_whitelist'][$controllerServiceName])
         ) {
-            $metadata->exchangeArray(array(
+            $metadata->exchangeArray([
                 'content_type_whitelist' => $config['content_type_whitelist'][$controllerServiceName],
-            ));
+            ]);
         }
     }
 
@@ -1279,7 +1279,7 @@ class RestServiceModel implements EventManagerAwareInterface
         $collectionClass = $this->deriveCollectionClass($controllerServiceName, $metadata, $config);
 
         $config = $config['zf-hal']['metadata_map'];
-        $merge  = array();
+        $merge  = [];
 
         if (isset($config[$entityClass])) {
             $merge['entity_class'] = $entityClass;
@@ -1403,7 +1403,7 @@ class RestServiceModel implements EventManagerAwareInterface
      * @param array|mixed $default
      * @return mixed
      */
-    protected function getConfigForSubkey($subKey, $default = array())
+    protected function getConfigForSubkey($subKey, $default = [])
     {
         $config = $this->configResource->fetch(true);
         $keys   = explode('.', $subKey);

--- a/src/Model/RestServiceResource.php
+++ b/src/Model/RestServiceResource.php
@@ -151,7 +151,7 @@ class RestServiceResource extends AbstractResourceListener
      * @param  array $params
      * @return RestServiceEntity[]
      */
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         $version  = $this->getEvent()->getQueryParam('version', null);
         $services = $this->getModel()->fetchAll($version ?: null);
@@ -265,37 +265,37 @@ class RestServiceResource extends AbstractResourceListener
             return;
         }
 
-        $collection = array();
+        $collection = [];
         $parentName = str_replace('\\', '-', $service->controllerServiceName);
         foreach ($inputFilters as $inputFilter) {
             $inputFilter['input_filter_name'] = str_replace('\\', '-', $inputFilter['input_filter_name']);
             $entity   = new HalEntity($inputFilter, $inputFilter['input_filter_name']);
             $links    = $entity->getLinks();
-            $links->add(Link::factory(array(
+            $links->add(Link::factory([
                 'rel' => 'self',
-                'route' => array(
+                'route' => [
                     'name' => 'zf-apigility/api/module/rest-service/input-filter',
-                    'params' => array(
+                    'params' => [
                         'name' => $this->moduleName,
                         'controller_service_name' => $parentName,
                         'input_filter_name' => $inputFilter['input_filter_name'],
-                    ),
-                ),
-            )));
+                    ],
+                ],
+            ]));
             $collection[] = $entity;
         }
 
         $collection = new HalCollection($collection);
         $collection->setCollectionName('input_filter');
         $collection->setCollectionRoute('zf-apigility/module/rest-service/input-filter');
-        $collection->setCollectionRouteParams(array(
+        $collection->setCollectionRouteParams([
             'name' => $service->module,
             'controller_service_name' => $service->controllerServiceName,
-        ));
+        ]);
 
-        $service->exchangeArray(array(
+        $service->exchangeArray([
             'input_filters' => $collection,
-        ));
+        ]);
     }
 
     /**
@@ -312,6 +312,6 @@ class RestServiceResource extends AbstractResourceListener
         }
         $entity = new HalEntity($documentation, 'documentation');
 
-        $service->exchangeArray(array('documentation' => $entity));
+        $service->exchangeArray(['documentation' => $entity]);
     }
 }

--- a/src/Model/RpcServiceEntity.php
+++ b/src/Model/RpcServiceEntity.php
@@ -12,20 +12,20 @@ use ZF\Hal\Collection as HalCollection;
 
 class RpcServiceEntity
 {
-    protected $acceptWhitelist = array(
+    protected $acceptWhitelist = [
         'application/json',
         'application/*+json',
-    );
+    ];
 
-    protected $contentTypeWhitelist = array(
+    protected $contentTypeWhitelist = [
         'application/json',
-    );
+    ];
 
     protected $controllerClass;
 
     protected $controllerServiceName;
 
-    protected $httpMethods = array('GET');
+    protected $httpMethods = ['GET'];
 
     protected $inputFilters;
 
@@ -143,7 +143,7 @@ class RpcServiceEntity
      */
     public function getArrayCopy()
     {
-        $array = array(
+        $array = [
             'accept_whitelist'        => $this->acceptWhitelist,
             'content_type_whitelist'  => $this->contentTypeWhitelist,
             'controller_service_name' => $this->controllerServiceName,
@@ -152,7 +152,7 @@ class RpcServiceEntity
             'route_name'              => $this->routeName,
             'selector'                => $this->selector,
             'service_name'            => $this->serviceName,
-        );
+        ];
         if (null !== $this->inputFilters) {
             $array['input_filters'] = $this->inputFilters;
         }

--- a/src/Model/RpcServiceModel.php
+++ b/src/Model/RpcServiceModel.php
@@ -67,7 +67,7 @@ class RpcServiceModel
      */
     public function fetch($controllerServiceName)
     {
-        $data   = array('controller_service_name' => $controllerServiceName);
+        $data   = ['controller_service_name' => $controllerServiceName];
         $config = $this->configResource->fetch(true);
 
         if (!isset($config['zf-rpc'][$controllerServiceName])) {
@@ -136,10 +136,10 @@ class RpcServiceModel
     {
         $config = $this->configResource->fetch(true);
         if (!isset($config['zf-rpc'])) {
-            return array();
+            return [];
         }
 
-        $services = array();
+        $services = [];
         $pattern  = false;
 
         // Initialize pattern if a version was passed and it's valid
@@ -256,17 +256,17 @@ class RpcServiceModel
             ), 409);
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
                 'module'       => $module,
                 'classname'    => $className,
                 'classfactory' => $classFactory,
                 'servicename'  => $serviceName,
                 'version'      => $version,
-        ));
+        ]);
 
-        $resolver = new Resolver\TemplateMapResolver(array(
+        $resolver = new Resolver\TemplateMapResolver([
                 'code-connected/rpc-controller' => __DIR__ . '/../../view/code-connected/rpc-factory.phtml'
-        ));
+        ]);
 
         $view->setTemplate('code-connected/rpc-controller');
         $renderer = new PhpRenderer();
@@ -312,16 +312,16 @@ class RpcServiceModel
             ), 409);
         }
 
-        $view = new ViewModel(array(
+        $view = new ViewModel([
             'module'      => $module,
             'classname'   => $className,
             'servicename' => $serviceName,
             'version'     => $version,
-        ));
+        ]);
 
-        $resolver = new Resolver\TemplateMapResolver(array(
+        $resolver = new Resolver\TemplateMapResolver([
             'code-connected/rpc-controller' => __DIR__ . '/../../view/code-connected/rpc-controller.phtml'
-        ));
+        ]);
 
         $view->setTemplate('code-connected/rpc-controller');
         $renderer = new PhpRenderer();
@@ -336,21 +336,21 @@ class RpcServiceModel
 
         $fullClassFactory = $this->createFactoryController($serviceName);
 
-        $this->configResource->patch(array(
-            'controllers' => array(
-                'factories' => array(
+        $this->configResource->patch([
+            'controllers' => [
+                'factories' => [
                     $controllerService => $fullClassFactory,
-                ),
-            ),
-        ), true);
+                ],
+            ],
+        ], true);
 
         $fullClassName = sprintf('%s\\V%s\\Rpc\\%s\\%s', $module, $version, $serviceName, $className);
 
-        return (object) array(
+        return (object) [
             'class'   => $fullClassName,
             'file'    => $classPath,
             'service' => $controllerService,
-        );
+        ];
     }
 
     /**
@@ -401,27 +401,27 @@ class RpcServiceModel
             ), 409);
         }
 
-        $config = array(
-            'router' => array(
-                'routes' => array(
-                    $routeName => array(
+        $config = [
+            'router' => [
+                'routes' => [
+                    $routeName => [
                         'type' => 'Segment',
-                        'options' => array(
+                        'options' => [
                             'route' => $route,
-                            'defaults' => array(
+                            'defaults' => [
                                 'controller' => $controllerService,
                                 'action'     => $action,
-                            ),
-                        ),
-                    ),
-                )
-            ),
-            'zf-versioning' => array(
-                'uri' => array(
+                            ],
+                        ],
+                    ],
+                ]
+            ],
+            'zf-versioning' => [
+                'uri' => [
                     $routeName
-                )
-            )
-        );
+                ]
+            ]
+        ];
 
         $this->configResource->patch($config, true);
         return $routeName;
@@ -441,16 +441,16 @@ class RpcServiceModel
         $serviceName,
         $controllerService,
         $routeName,
-        array $httpMethods = array('GET'),
+        array $httpMethods = ['GET'],
         $callable = null
     ) {
-        $config = array('zf-rpc' => array(
-            $controllerService => array(
+        $config = ['zf-rpc' => [
+            $controllerService => [
                 'service_name' => $serviceName,
                 'http_methods' => $httpMethods,
                 'route_name'   => $routeName,
-            ),
-        ));
+            ],
+        ]];
         if (null !== $callable) {
             $config[$controllerService]['callable'] = $callable;
         }
@@ -472,24 +472,24 @@ class RpcServiceModel
 
         $mediaType = $this->createMediaType();
 
-        $config = array('zf-content-negotiation' => array(
-            'controllers' => array(
+        $config = ['zf-content-negotiation' => [
+            'controllers' => [
                 $controllerService => $selector,
-            ),
-            'accept_whitelist' => array(
-                $controllerService => array(
+            ],
+            'accept_whitelist' => [
+                $controllerService => [
                     $mediaType,
                     'application/json',
                     'application/*+json',
-                ),
-            ),
-            'content_type_whitelist' => array(
-                $controllerService => array(
+                ],
+            ],
+            'content_type_whitelist' => [
+                $controllerService => [
                     $mediaType,
                     'application/json',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]];
         return $this->configResource->patch($config, true);
     }
 
@@ -560,7 +560,7 @@ class RpcServiceModel
      */
     public function updateContentNegotiationWhitelist($controllerService, $headerType, array $whitelist)
     {
-        if (!in_array($headerType, array('accept', 'content_type'))) {
+        if (!in_array($headerType, ['accept', 'content_type'])) {
             /** @todo define exception in Rpc namespace */
             throw new PatchException('Invalid content negotiation whitelist type provided', 422);
         }
@@ -584,7 +584,7 @@ class RpcServiceModel
             return;
         }
 
-        $key = array('router', 'routes', $routeName);
+        $key = ['router', 'routes', $routeName];
         $this->configResource->deleteKey($key);
     }
 
@@ -619,7 +619,7 @@ class RpcServiceModel
             return true;
         });
 
-        $key = array('zf-versioning', 'uri');
+        $key = ['zf-versioning', 'uri'];
         $this->configResource->patchKey($key, $versioning);
     }
 
@@ -630,8 +630,8 @@ class RpcServiceModel
      */
     public function deleteControllersConfig($serviceName)
     {
-        foreach (array('invokables', 'factories') as $serviceType) {
-            $key = array('controllers', $serviceType, $serviceName);
+        foreach (['invokables', 'factories'] as $serviceType) {
+            $key = ['controllers', $serviceType, $serviceName];
             $this->configResource->deleteKey($key);
         }
     }
@@ -643,7 +643,7 @@ class RpcServiceModel
      */
     public function deleteRpcConfig($serviceName)
     {
-        $key = array('zf-rpc', $serviceName);
+        $key = ['zf-rpc', $serviceName];
         $this->configResource->deleteKey($key);
     }
 
@@ -655,13 +655,13 @@ class RpcServiceModel
      */
     public function deleteContentNegotiationConfig($serviceName)
     {
-        $key = array('zf-content-negotiation', 'controllers', $serviceName);
+        $key = ['zf-content-negotiation', 'controllers', $serviceName];
         $this->configResource->deleteKey($key);
 
-        $key = array('zf-content-negotiation', 'accept_whitelist', $serviceName);
+        $key = ['zf-content-negotiation', 'accept_whitelist', $serviceName];
         $this->configResource->deleteKey($key);
 
-        $key = array('zf-content-negotiation', 'content_type_whitelist', $serviceName);
+        $key = ['zf-content-negotiation', 'content_type_whitelist', $serviceName];
         $this->configResource->deleteKey($key);
     }
 
@@ -672,7 +672,7 @@ class RpcServiceModel
      */
     public function deleteContentValidationConfig($serviceName)
     {
-        $key = array('zf-content-validation', $serviceName);
+        $key = ['zf-content-validation', $serviceName];
         $this->configResource->deleteKey($key);
     }
 
@@ -683,7 +683,7 @@ class RpcServiceModel
      */
     public function deleteAuthorizationConfig($serviceName)
     {
-        $key = array('zf-mvc-auth', 'authorization', $serviceName);
+        $key = ['zf-mvc-auth', 'authorization', $serviceName];
         $this->configResource->deleteKey($key);
     }
 

--- a/src/Model/RpcServiceModelFactory.php
+++ b/src/Model/RpcServiceModelFactory.php
@@ -22,7 +22,7 @@ class RpcServiceModelFactory
      *
      * @var array
      */
-    protected $models = array();
+    protected $models = [];
 
     /**
      * @var ModuleModel

--- a/src/Model/RpcServiceResource.php
+++ b/src/Model/RpcServiceResource.php
@@ -111,10 +111,10 @@ class RpcServiceResource extends AbstractResourceListener
             $data = (array) $data;
         }
 
-        $creationData = array(
-            'http_methods' => array('GET'),
+        $creationData = [
+            'http_methods' => ['GET'],
             'selector'     => null,
-        );
+        ];
 
         if (!isset($data['service_name'])
             || !is_string($data['service_name'])
@@ -192,7 +192,7 @@ class RpcServiceResource extends AbstractResourceListener
      * @param  array $params
      * @return RpcServiceEntity[]
      */
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         $version  = $this->getEvent()->getQueryParam('version', null);
         $services = $this->getModel()->fetchAll($version ?: null);
@@ -295,37 +295,37 @@ class RpcServiceResource extends AbstractResourceListener
             return;
         }
 
-        $collection = array();
+        $collection = [];
         $parentName = str_replace('\\', '-', $service->controllerServiceName);
         foreach ($inputFilters as $inputFilter) {
             $inputFilter['input_filter_name'] = str_replace('\\', '-', $inputFilter['input_filter_name']);
             $entity   = new HalEntity($inputFilter, $inputFilter['input_filter_name']);
             $links    = $entity->getLinks();
-            $links->add(Link::factory(array(
+            $links->add(Link::factory([
                 'rel' => 'self',
-                'route' => array(
+                'route' => [
                     'name' => 'zf-apigility/api/module/rpc-service/input-filter',
-                    'params' => array(
+                    'params' => [
                         'name' => $this->moduleName,
                         'controller_service_name' => $parentName,
                         'input_filter_name' => $inputFilter['input_filter_name'],
-                    ),
-                ),
-            )));
+                    ],
+                ],
+            ]));
             $collection[] = $entity;
         }
 
         $collection = new HalCollection($collection);
         $collection->setCollectionName('input_filter');
         $collection->setCollectionRoute('zf-apigility/module/rpc-service/input-filter');
-        $collection->setCollectionRouteParams(array(
+        $collection->setCollectionRouteParams([
             'name' => $this->moduleName,
             'controller_service_name' => $service->controllerServiceName,
-        ));
+        ]);
 
-        $service->exchangeArray(array(
+        $service->exchangeArray([
             'input_filters' => $collection,
-        ));
+        ]);
     }
 
     protected function injectDocumentation(RpcServiceEntity $service)
@@ -339,7 +339,7 @@ class RpcServiceResource extends AbstractResourceListener
         }
         $entity = new HalEntity($documentation, 'documentation');
 
-        $service->exchangeArray(array('documentation' => $entity));
+        $service->exchangeArray(['documentation' => $entity]);
     }
 
     /**
@@ -355,8 +355,8 @@ class RpcServiceResource extends AbstractResourceListener
         }
 
         $controller = $this->controllerManager->get($controllerServiceName);
-        $service->exchangeArray(array(
+        $service->exchangeArray([
             'controller_class' => get_class($controller),
-        ));
+        ]);
     }
 }

--- a/src/Model/ValidatorMetadataModel.php
+++ b/src/Model/ValidatorMetadataModel.php
@@ -16,7 +16,7 @@ class ValidatorMetadataModel
      *
      * @var array
      */
-    protected $defaults = array();
+    protected $defaults = [];
 
     /**
      * Unprocessed validator metadata configuration
@@ -36,7 +36,7 @@ class ValidatorMetadataModel
     /**
      * @param array $metadata
      */
-    public function __construct(array $metadata = array())
+    public function __construct(array $metadata = [])
     {
         if (isset($metadata['__all__'])) {
             $this->defaults = $metadata['__all__'];

--- a/src/Model/ValidatorMetadataModelFactory.php
+++ b/src/Model/ValidatorMetadataModelFactory.php
@@ -19,7 +19,7 @@ class ValidatorMetadataModelFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $services)
     {
-        $metadata = array();
+        $metadata = [];
         if ($services->has('Config')) {
             $config = $services->get('Config');
             if (isset($config['validator_metadata'])) {

--- a/src/Model/ValidatorsModel.php
+++ b/src/Model/ValidatorsModel.php
@@ -65,9 +65,9 @@ class ValidatorsModel extends AbstractPluginManagerModel
             if (is_array($value)) {
                 return;
             }
-            $value = array(
+            $value = [
                 'breakchainonfailure' => 'bool',
-            );
+            ];
         });
         $this->plugins = $plugins;
         return $this->plugins;

--- a/src/Model/VersioningModel.php
+++ b/src/Model/VersioningModel.php
@@ -90,7 +90,7 @@ class VersioningModel
             $path = $this->getModuleSourcePath($module);
         }
 
-        $versions  = array();
+        $versions  = [];
         foreach (Glob::glob($path . DIRECTORY_SEPARATOR . 'V*') as $dir) {
             if (preg_match('/\\V(?P<version>\d+)$/', $dir, $matches)) {
                 $versions[] = (int) $matches['version'];
@@ -110,11 +110,11 @@ class VersioningModel
     {
         $defaultVersion = (int) $defaultVersion;
 
-        $this->configResource->patch(array(
-            'zf-versioning' => array(
+        $this->configResource->patch([
+            'zf-versioning' => [
                 'default_version' => $defaultVersion
-            )
-        ), true);
+            ]
+        ], true);
 
         $config = $this->configResource->fetch(true);
 
@@ -185,30 +185,30 @@ class VersioningModel
         // update zf-hal.metadata_map
         if (isset($config['zf-hal']['metadata_map'])) {
             $newValues = $this->changeVersionArray($config['zf-hal']['metadata_map'], $previous, $version);
-            $this->configResource->patch(array(
-                'zf-hal' => array('metadata_map' => $newValues)
-            ), true);
+            $this->configResource->patch([
+                'zf-hal' => ['metadata_map' => $newValues]
+            ], true);
         }
 
         // update zf-rpc
         if (isset($config['zf-rpc'])) {
             $newValues = $this->changeVersionArray($config['zf-rpc'], $previous, $version);
-            $this->configResource->patch(array(
+            $this->configResource->patch([
                 'zf-rpc' => $newValues
-            ), true);
+            ], true);
         }
 
         // update zf-rest
         if (isset($config['zf-rest'])) {
             $newValues = $this->changeVersionArray($config['zf-rest'], $previous, $version);
-            $this->configResource->patch(array(
+            $this->configResource->patch([
                 'zf-rest' => $newValues
-            ), true);
+            ], true);
         }
 
         // update zf-content-negotiation
         if (isset($config['zf-content-negotiation'])) {
-            foreach (array('controllers', 'accept_whitelist', 'content_type_whitelist') as $key) {
+            foreach (['controllers', 'accept_whitelist', 'content_type_whitelist'] as $key) {
                 if (isset($config['zf-content-negotiation'][$key])) {
                     $newValues = $this->changeVersionArray(
                         $config['zf-content-negotiation'][$key],
@@ -217,7 +217,7 @@ class VersioningModel
                     );
 
                     // change version in mediatype
-                    if (in_array($key, array('accept_whitelist', 'content_type_whitelist'))) {
+                    if (in_array($key, ['accept_whitelist', 'content_type_whitelist'])) {
                         foreach ($newValues as $k => $v) {
                             foreach ($v as $index => $mediatype) {
                                 if (strstr($mediatype, '.v' . $previous . '+')) {
@@ -231,9 +231,9 @@ class VersioningModel
                         }
                     }
 
-                    $this->configResource->patch(array(
-                        'zf-content-negotiation' => array($key => $newValues)
-                    ), true);
+                    $this->configResource->patch([
+                        'zf-content-negotiation' => [$key => $newValues]
+                    ], true);
                 }
             }
         }
@@ -241,48 +241,48 @@ class VersioningModel
         // update zf-mvc-auth
         if (isset($config['zf-mvc-auth']['authorization'])) {
             $newValues = $this->changeVersionArray($config['zf-mvc-auth']['authorization'], $previous, $version);
-            $this->configResource->patch(array(
-                'zf-mvc-auth' => array('authorization' => $newValues)
-            ), true);
+            $this->configResource->patch([
+                'zf-mvc-auth' => ['authorization' => $newValues]
+            ], true);
         }
 
         // update zf-content-validation and input_filter_specs
         if (isset($config['zf-content-validation'])) {
             $newValues = $this->changeVersionArray($config['zf-content-validation'], $previous, $version);
-            $this->configResource->patch(array(
+            $this->configResource->patch([
                 'zf-content-validation' => $newValues
-            ), true);
+            ], true);
         }
 
         if (isset($config['input_filter_specs'])) {
             $newValues = $this->changeVersionArray($config['input_filter_specs'], $previous, $version);
-            $this->configResource->patch(array(
+            $this->configResource->patch([
                 'input_filter_specs' => $newValues
-            ), true);
+            ], true);
         }
 
         // update zf-apigility
         if (isset($config['zf-apigility']['db-connected'])) {
             $newValues = $this->changeVersionArray($config['zf-apigility']['db-connected'], $previous, $version);
-            $this->configResource->patch(array(
-                'zf-apigility' => array('db-connected' => $newValues)
-            ), true);
+            $this->configResource->patch([
+                'zf-apigility' => ['db-connected' => $newValues]
+            ], true);
         }
 
         // update service_manager
         if (isset($config['service_manager'])) {
             $newValues = $this->changeVersionArray($config['service_manager'], $previous, $version);
-            $this->configResource->patch(array(
+            $this->configResource->patch([
                 'service_manager' => $newValues
-            ), true);
+            ], true);
         }
 
         // update controllers
         if (isset($config['controllers'])) {
             $newValues = $this->changeVersionArray($config['controllers'], $previous, $version);
-            $this->configResource->patch(array(
+            $this->configResource->patch([
                 'controllers' => $newValues
-            ), true);
+            ], true);
         }
 
         return true;
@@ -311,7 +311,7 @@ class VersioningModel
      */
     protected function changeVersionArray($data, $previous, $version)
     {
-        $result = array();
+        $result = [];
         foreach ($data as $key => $value) {
             $newKey = $this->changeVersionNamespace($key, $previous, $version);
             if (is_array($value)) {

--- a/src/Model/VersioningModelFactory.php
+++ b/src/Model/VersioningModelFactory.php
@@ -21,7 +21,7 @@ class VersioningModelFactory
      *
      * @var array
      */
-    protected $models = array();
+    protected $models = [];
 
     /**
      * @var ModuleUtils

--- a/test/Controller/AuthenticationControllerTest.php
+++ b/test/Controller/AuthenticationControllerTest.php
@@ -47,7 +47,7 @@ class AuthenticationControllerTest extends TestCase
         $this->plugins->setService('params', new Params());
         $this->controller->setPluginManager($this->plugins);
 
-        $this->routeMatch = new RouteMatch(array());
+        $this->routeMatch = new RouteMatch([]);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/authentication');
         $this->event = new MvcEvent();
         $this->event->setRouteMatch($this->routeMatch);
@@ -70,9 +70,9 @@ class AuthenticationControllerTest extends TestCase
 
     public function invalidRequestMethods()
     {
-        return array(
-            array('patch')
-        );
+        return [
+            ['patch']
+        ];
     }
 
     /**
@@ -99,9 +99,9 @@ class AuthenticationControllerTest extends TestCase
         $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.apigility.v2+json');
         $this->controller->setRequest($request);
 
-        $params = array(
+        $params = [
             'authentication_adapter' => 'testbasic'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->event->setRouteMatch($this->routeMatch);
 
@@ -139,29 +139,29 @@ class AuthenticationControllerTest extends TestCase
      */
     public function postRequestData()
     {
-        $data = array(
-            array(
-                array(
+        $data = [
+            [
+                [
                     'name'     => 'test',
                     'type'     => 'basic',
                     'realm'    => 'api',
                     'htpasswd' => __DIR__ . '/TestAsset/Auth2/config/autoload/htpasswd'
-                ),
-            ),
-            array(
-                array(
+                ],
+            ],
+            [
+                [
                     'name'           => 'test2',
                     'type'           => 'digest',
                     'realm'          => 'api',
                     'nonce_timeout'  => '3600',
                     'digest_domains' => '/',
                     'htdigest'       => __DIR__ . '/TestAsset/Auth2/config/autoload/htdigest'
-                ),
-            )
-        );
+                ],
+            ]
+        ];
         if (extension_loaded('pdo_sqlite')) {
-            $data[] = array(
-                array(
+            $data[] = [
+                [
                     'name'            => 'test3',
                     'type'            => 'oauth2',
                     'oauth2_type'     => 'pdo',
@@ -170,12 +170,12 @@ class AuthenticationControllerTest extends TestCase
                     'oauth2_username' => null,
                     'oauth2_password' => null,
                     'oauth2_options'  => null
-                )
-            );
+                ]
+            ];
         }
         if (extension_loaded('mongo')) {
-            $data[] = array(
-                array(
+            $data[] = [
+                [
                     'name'                => 'test4',
                     'type'                => 'oauth2',
                     'oauth2_type'         => 'mongo',
@@ -184,8 +184,8 @@ class AuthenticationControllerTest extends TestCase
                     'oauth2_database'     => 'zf-apigility-admin-test',
                     'oauth2_locator_name' => null,
                     'oauth2_options'      => null
-                )
-            );
+                ]
+            ];
         }
         return $data;
     }
@@ -231,9 +231,9 @@ class AuthenticationControllerTest extends TestCase
         $parameters->setBodyParams($postData);
         $this->event->setParam('ZFContentNegotiationParameterData', $parameters);
 
-        $params = array(
+        $params = [
             'authentication_adapter' => 'testbasic'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->event->setRouteMatch($this->routeMatch);
 
@@ -258,9 +258,9 @@ class AuthenticationControllerTest extends TestCase
         $request->getHeaders()->addHeaderLine('Content-Type', 'application/json');
         $this->controller->setRequest($request);
 
-        $params = array(
+        $params = [
             'authentication_adapter' => 'testbasic'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->event->setRouteMatch($this->routeMatch);
 
@@ -278,9 +278,9 @@ class AuthenticationControllerTest extends TestCase
         $request->getQuery()->set('version', 1);
         $this->controller->setRequest($request);
 
-        $params = array(
+        $params = [
             'name' => 'Status'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/module/authentication');
         $this->event->setRouteMatch($this->routeMatch);
@@ -303,9 +303,9 @@ class AuthenticationControllerTest extends TestCase
         $request->getQuery()->set('version', 1);
         $this->controller->setRequest($request);
 
-        $params = array(
+        $params = [
             'name' => 'Status2'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/module/authentication');
         $this->event->setRouteMatch($this->routeMatch);
@@ -324,14 +324,14 @@ class AuthenticationControllerTest extends TestCase
         $this->controller->setRequest($request);
 
         $parameters = new ParameterDataContainer();
-        $parameters->setBodyParams(array(
+        $parameters->setBodyParams([
             'authentication' => 'testoauth2pdo'
-        ));
+        ]);
         $this->event->setParam('ZFContentNegotiationParameterData', $parameters);
 
-        $params = array(
+        $params = [
             'name' => 'Foo'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/module/authentication');
         $this->event->setRouteMatch($this->routeMatch);
@@ -351,14 +351,14 @@ class AuthenticationControllerTest extends TestCase
         $this->controller->setRequest($request);
 
         $parameters = new ParameterDataContainer();
-        $parameters->setBodyParams(array(
+        $parameters->setBodyParams([
             'authentication' => 'testoauth2mongo'
-        ));
+        ]);
         $this->event->setParam('ZFContentNegotiationParameterData', $parameters);
 
-        $params = array(
+        $params = [
             'name' => 'Status'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/module/authentication');
         $this->event->setRouteMatch($this->routeMatch);
@@ -377,9 +377,9 @@ class AuthenticationControllerTest extends TestCase
         $request->getQuery()->set('version', 1);
         $this->controller->setRequest($request);
 
-        $params = array(
+        $params = [
             'name' => 'Status'
-        );
+        ];
         $this->routeMatch = new RouteMatch($params);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/module/authentication');
         $this->event->setRouteMatch($this->routeMatch);

--- a/test/Controller/AuthenticationTypeControllerTest.php
+++ b/test/Controller/AuthenticationTypeControllerTest.php
@@ -24,7 +24,7 @@ class AuthenticationTypeControllerTest extends TestCase
 
         $this->controller = $this->getController($this->localFile, $this->globalFile);
 
-        $this->routeMatch = new RouteMatch(array());
+        $this->routeMatch = new RouteMatch([]);
         $this->routeMatch->setMatchedRouteName('zf-apigility/api/authentication-type');
         $this->event = new MvcEvent();
         $this->event->setRouteMatch($this->routeMatch);
@@ -39,9 +39,9 @@ class AuthenticationTypeControllerTest extends TestCase
 
         /* Register old authentication adapter types */
         if (isset($config['zf-oauth2'])) {
-            $authListener->addAuthenticationTypes(array('oauth2'));
+            $authListener->addAuthenticationTypes(['oauth2']);
         } elseif (isset($config['zf-mvc-auth']['authentication']['http'])) {
-            $types = array();
+            $types = [];
             if (isset($config['zf-mvc-auth']['authentication']['http']['htpasswd'])) {
                 $types[] = 'basic';
             }
@@ -59,14 +59,14 @@ class AuthenticationTypeControllerTest extends TestCase
                 }
                 if (false !== stristr($adapterConfig['adapter'], 'http')) {
                     if (isset($adapterConfig['options']['htpasswd'])) {
-                        $authListener->addAuthenticationTypes(array($adapter . '-' . 'basic'));
+                        $authListener->addAuthenticationTypes([$adapter . '-' . 'basic']);
                     }
                     if (isset($adapterConfig['options']['htdigest'])) {
-                        $authListener->addAuthenticationTypes(array($adapter . '-' . 'digest'));
+                        $authListener->addAuthenticationTypes([$adapter . '-' . 'digest']);
                     }
                     continue;
                 }
-                $authListener->addAuthenticationTypes(array($adapter));
+                $authListener->addAuthenticationTypes([$adapter]);
             }
         }
 
@@ -81,9 +81,9 @@ class AuthenticationTypeControllerTest extends TestCase
 
     public function invalidRequestMethods()
     {
-        return array(
-            array('post', 'put', 'patch', 'delete')
-        );
+        return [
+            ['post', 'put', 'patch', 'delete']
+        ];
     }
 
     /**
@@ -135,104 +135,104 @@ class AuthenticationTypeControllerTest extends TestCase
 
     public function getOldAuthConfig()
     {
-        return array(
-            'basic' => array(
-                array(
-                    'zf-mvc-auth' => array(
-                        'authentication' => array(
-                            'http' => array(
-                                'accept_schemes' => array('basic'),
+        return [
+            'basic' => [
+                [
+                    'zf-mvc-auth' => [
+                        'authentication' => [
+                            'http' => [
+                                'accept_schemes' => ['basic'],
                                 'realm' => 'My Web Site',
-                            ),
-                        ),
-                    ),
-                ),
-                array(
-                    'zf-mvc-auth' => array(
-                        'authentication' => array(
-                            'http' => array(
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'zf-mvc-auth' => [
+                        'authentication' => [
+                            'http' => [
                                 'htpasswd' => __DIR__ . '/TestAsset/Auth2/config/autoload/htpasswd',
-                            ),
-                        ),
-                    ),
-                ),
-                array('basic'),
-            ),
-            'digest' => array(
-                array(
-                    'zf-mvc-auth' => array(
-                        'authentication' => array(
-                            'http' => array(
-                                'accept_schemes' => array('digest'),
+                            ],
+                        ],
+                    ],
+                ],
+                ['basic'],
+            ],
+            'digest' => [
+                [
+                    'zf-mvc-auth' => [
+                        'authentication' => [
+                            'http' => [
+                                'accept_schemes' => ['digest'],
                                 'realm' => 'My Web Site',
                                 'domain_digest' => 'domain.com',
                                 'nonce_timeout' => 3600,
-                            ),
-                        ),
-                    ),
-                ),
-                array(
-                    'zf-mvc-auth' => array(
-                        'authentication' => array(
-                            'http' => array(
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'zf-mvc-auth' => [
+                        'authentication' => [
+                            'http' => [
                                 'htdigest' => __DIR__ . '/TestAsset/Auth2/config/autoload/htdigest',
-                            ),
-                        ),
-                    ),
-                ),
-                array('digest'),
-            ),
-            'oauth2-pdo' => array(
-                array(
-                    'router' => array(
-                        'routes' => array(
-                            'oauth' => array(
-                                'options' => array(
+                            ],
+                        ],
+                    ],
+                ],
+                ['digest'],
+            ],
+            'oauth2-pdo' => [
+                [
+                    'router' => [
+                        'routes' => [
+                            'oauth' => [
+                                'options' => [
                                     'route' => '/oauth',
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-                array(
-                    'zf-oauth2' => array(
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'zf-oauth2' => [
                         'storage' => 'ZF\\OAuth2\\Adapter\\PdoAdapter',
-                        'db' => array(
+                        'db' => [
                             'dsn_type'  => 'PDO',
                             'dsn'       => 'sqlite:/' . __DIR__ . '/TestAsset/Auth2/config/autoload/db.sqlite',
                             'username'  => null,
                             'password'  => null,
-                        ),
-                    ),
-                ),
-                array('oauth2'),
-            ),
-            'oauth2-mongo' => array(
-                array(
-                    'router' => array(
-                        'routes' => array(
-                            'oauth' => array(
-                                'options' => array(
+                        ],
+                    ],
+                ],
+                ['oauth2'],
+            ],
+            'oauth2-mongo' => [
+                [
+                    'router' => [
+                        'routes' => [
+                            'oauth' => [
+                                'options' => [
                                     'route' => '/oauth',
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-                array(
-                    'zf-oauth2' => array(
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'zf-oauth2' => [
                         'storage' => 'ZF\\OAuth2\\Adapter\\MongoAdapter',
-                        'mongo' => array(
+                        'mongo' => [
                             'dsn_type'     => 'Mongo',
                             'dsn'          => 'mongodb://localhost',
                             'database'     => 'zf-apigility-admin-test',
                             'locator_name' => 'MongoDB',
-                        ),
-                    ),
-                ),
-                array('oauth2'),
-            ),
-        );
+                        ],
+                    ],
+                ],
+                ['oauth2'],
+            ],
+        ];
     }
 
     /**
@@ -250,7 +250,7 @@ class AuthenticationTypeControllerTest extends TestCase
         $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.apigility.v2+json');
         $controller->setRequest($request);
 
-        $routeMatch = new RouteMatch(array());
+        $routeMatch = new RouteMatch([]);
         $routeMatch->setMatchedRouteName('zf-apigility/api/authentication-type');
         $event = new MvcEvent();
         $event->setRouteMatch($routeMatch);

--- a/test/Controller/ConfigControllerTest.php
+++ b/test/Controller/ConfigControllerTest.php
@@ -22,7 +22,7 @@ class ConfigControllerTest extends TestCase
         file_put_contents($this->file, '<' . "?php\nreturn array();");
 
         $this->writer         = new TestAsset\ConfigWriter();
-        $this->configResource = new ConfigResource(array(), $this->file, $this->writer);
+        $this->configResource = new ConfigResource([], $this->file, $this->writer);
         $this->controller     = new ConfigController($this->configResource);
 
         $this->plugins = new ControllerPluginManager();
@@ -37,11 +37,11 @@ class ConfigControllerTest extends TestCase
 
     public function invalidRequestMethods()
     {
-        return array(
-            array('post'),
-            array('put'),
-            array('delete'),
-        );
+        return [
+            ['post'],
+            ['put'],
+            ['delete'],
+        ];
     }
 
     /**
@@ -60,13 +60,13 @@ class ConfigControllerTest extends TestCase
 
     public function testProcessGetRequestWithZfCampusMediaTypeReturnsFullConfiguration()
     {
-        $config = array(
+        $config = [
             'foo' => 'FOO',
-            'bar' => array(
+            'bar' => [
                 'baz' => 'bat',
-            ),
+            ],
             'baz' => 'BAZ',
-        );
+        ];
         $configResource = new ConfigResource($config, $this->file, $this->writer);
         $controller     = new ConfigController($configResource);
         $controller->setPluginManager($this->plugins);
@@ -84,13 +84,13 @@ class ConfigControllerTest extends TestCase
 
     public function testProcessGetRequestWithGenericJsonMediaTypeReturnsFlattenedConfiguration()
     {
-        $config = array(
+        $config = [
             'foo' => 'FOO',
-            'bar' => array(
+            'bar' => [
                 'baz' => 'bat',
-            ),
+            ],
             'baz' => 'BAZ',
-        );
+        ];
         $configResource = new ConfigResource($config, $this->file, $this->writer);
         $controller     = new ConfigController($configResource);
         $controller->setPluginManager($this->plugins);
@@ -103,35 +103,35 @@ class ConfigControllerTest extends TestCase
         $result = $controller->processAction();
         $this->assertInternalType('array', $result);
 
-        $expected = array(
+        $expected = [
             'foo'     => 'FOO',
             'bar.baz' => 'bat',
             'baz'     => 'BAZ',
-        );
+        ];
         $this->assertEquals($expected, $result);
     }
 
     public function testProcessPatchRequestWithZfCampusMediaTypeReturnsUpdatedConfigurationKeys()
     {
-        $config = array(
+        $config = [
             'foo' => 'FOO',
-            'bar' => array(
+            'bar' => [
                 'baz' => 'bat',
-            ),
+            ],
             'baz' => 'BAZ',
-        );
+        ];
         $configResource = new ConfigResource($config, $this->file, $this->writer);
         $controller     = new ConfigController($configResource);
         $controller->setPluginManager($this->plugins);
 
         $request = new Request();
         $request->setMethod('patch');
-        $request->setContent(json_encode(array(
-            'bar' => array(
+        $request->setContent(json_encode([
+            'bar' => [
                 'baz' => 'UPDATED',
-            ),
+            ],
             'baz' => 'UPDATED',
-        )));
+        ]));
         $request->getHeaders()->addHeaderLine('Content-Type', 'application/vnd.zfcampus.v1.config+json');
         $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.zfcampus.v1.config+json');
         $controller->setRequest($request);
@@ -139,44 +139,44 @@ class ConfigControllerTest extends TestCase
         $result = $controller->processAction();
         $this->assertInternalType('array', $result);
 
-        $expected = array(
-            'bar' => array(
+        $expected = [
+            'bar' => [
                 'baz' => 'UPDATED',
-            ),
+            ],
             'baz' => 'UPDATED',
-        );
+        ];
         $this->assertEquals($expected, $result);
     }
 
     public function testProcessPatchRequestWithGenericJsonMediaTypeReturnsUpdatedConfigurationKeys()
     {
-        $config = array(
+        $config = [
             'foo' => 'FOO',
-            'bar' => array(
+            'bar' => [
                 'baz' => 'bat',
-            ),
+            ],
             'baz' => 'BAZ',
-        );
+        ];
         $configResource = new ConfigResource($config, $this->file, $this->writer);
         $controller     = new ConfigController($configResource);
         $controller->setPluginManager($this->plugins);
 
         $request = new Request();
         $request->setMethod('patch');
-        $request->setPost(new Parameters(array(
+        $request->setPost(new Parameters([
             'bar.baz' => 'UPDATED',
             'baz' => 'UPDATED',
-        )));
+        ]));
         $request->getHeaders()->addHeaderLine('Content-Type', 'application/json');
         $controller->setRequest($request);
 
         $result = $controller->processAction();
         $this->assertInternalType('array', $result);
 
-        $expected = array(
+        $expected = [
             'bar.baz' => 'UPDATED',
             'baz' => 'UPDATED',
-        );
+        ];
         $this->assertEquals($expected, $result);
     }
 }

--- a/test/Controller/InputFilterControllerTest.php
+++ b/test/Controller/InputFilterControllerTest.php
@@ -23,9 +23,9 @@ class InputFilterControllerTest extends TestCase
     public function setUp()
     {
         require_once __DIR__ . '/../Model/TestAsset/module/InputFilter/Module.php';
-        $modules = array(
+        $modules = [
             'InputFilter' => new \InputFilter\Module()
-        );
+        ];
 
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                                     ->disableOriginalConstructor()
@@ -61,10 +61,10 @@ class InputFilterControllerTest extends TestCase
 
         $module     = 'InputFilter';
         $controller = 'InputFilter\V1\Rest\Foo\Controller';
-        $params = array(
+        $params = [
             'name' => $module,
             'controller_service_name' => $controller
-        );
+        ];
         $routeMatch = new RouteMatch($params);
         $routeMatch->setMatchedRouteName('zf-apigility-admin/api/module/rest-service/rest_input_filter');
         $event = new MvcEvent();
@@ -98,11 +98,11 @@ class InputFilterControllerTest extends TestCase
         $module     = 'InputFilter';
         $controller = 'InputFilter\V1\Rest\Foo\Controller';
         $validator  = 'InputFilter\V1\Rest\Foo\Validator';
-        $params = array(
+        $params = [
             'name' => $module,
             'controller_service_name' => $controller,
             'input_filter_name' => $validator,
-        );
+        ];
         $routeMatch = new RouteMatch($params);
         $routeMatch->setMatchedRouteName('zf-apigility-admin/api/module/rest-service/rest_input_filter');
         $event = new MvcEvent();
@@ -125,22 +125,22 @@ class InputFilterControllerTest extends TestCase
 
     public function testAddInputFilter()
     {
-        $inputFilter = array(
-            array(
+        $inputFilter = [
+            [
                 'name' => 'bar',
-                'validators' => array(
-                    array(
+                'validators' => [
+                    [
                         'name' => 'NotEmpty',
-                        'options' => array(
+                        'options' => [
                             'type' => 127,
-                        ),
-                    ),
-                    array(
+                        ],
+                    ],
+                    [
                         'name' => 'Digits',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $request = new Request();
         $request->setMethod('put');
@@ -150,10 +150,10 @@ class InputFilterControllerTest extends TestCase
 
         $module     = 'InputFilter';
         $controller = 'InputFilter\V1\Rest\Foo\Controller';
-        $params = array(
+        $params = [
             'name' => $module,
             'controller_service_name' => $controller
-        );
+        ];
         $routeMatch = new RouteMatch($params);
         $routeMatch->setMatchedRouteName('zf-apigility-admin/api/module/rest-service/rest_input_filter');
         $event = new MvcEvent();
@@ -194,11 +194,11 @@ class InputFilterControllerTest extends TestCase
         $module     = 'InputFilter';
         $controller = 'InputFilter\V1\Rest\Foo\Controller';
         $validator  = 'InputFilter\V1\Rest\Foo\Validator';
-        $params = array(
+        $params = [
             'name' => $module,
             'controller_service_name' => $controller,
             'input_filter_name' => $validator,
-        );
+        ];
         $routeMatch = new RouteMatch($params);
         $routeMatch->setMatchedRouteName('zf-apigility-admin/api/module/rest-service/rest_input_filter');
         $event = new MvcEvent();

--- a/test/Controller/ModuleCreationControllerTest.php
+++ b/test/Controller/ModuleCreationControllerTest.php
@@ -21,23 +21,23 @@ class ModuleCreationControllerTest extends TestCase
 {
     public function setUp()
     {
-        $this->moduleManager  = new ModuleManager(array());
+        $this->moduleManager  = new ModuleManager([]);
         $this->moduleResource = new ModuleModel(
             $this->moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
         $this->controller     = new ModuleCreationController($this->moduleResource);
     }
 
     public function invalidRequestMethods()
     {
-        return array(
-            array('get'),
-            array('patch'),
-            array('post'),
-            array('delete'),
-        );
+        return [
+            ['get'],
+            ['patch'],
+            ['post'],
+            ['delete'],
+        ];
     }
 
     /**
@@ -76,12 +76,12 @@ class ModuleCreationControllerTest extends TestCase
                                ->getMock();
         $moduleManager->expects($this->any())
                       ->method('getLoadedModules')
-                      ->will($this->returnValue(array('Foo' => new \Foo\Module)));
+                      ->will($this->returnValue(['Foo' => new \Foo\Module]));
 
         $moduleResource = new ModuleModel(
             $moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
         $controller     = new ModuleCreationController($moduleResource);
 
@@ -118,7 +118,7 @@ class ModuleCreationControllerTest extends TestCase
 
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.','..'));
+        $files = array_diff(scandir($dir), ['.','..']);
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? $this->removeDir("$dir/$file") : unlink("$dir/$file");
         }

--- a/test/Controller/PackageControllerTest.php
+++ b/test/Controller/PackageControllerTest.php
@@ -31,11 +31,11 @@ class PackageControllerTest extends TestCase
 
     public function invalidRequestMethods()
     {
-        return array(
-            array('patch'),
-            array('put'),
-            array('delete'),
-        );
+        return [
+            ['patch'],
+            ['put'],
+            ['delete'],
+        ];
     }
 
     /**

--- a/test/Controller/SourceControllerTest.php
+++ b/test/Controller/SourceControllerTest.php
@@ -19,23 +19,23 @@ class SourceControllerTest extends TestCase
 {
     public function setUp()
     {
-        $this->moduleManager  = new ModuleManager(array());
+        $this->moduleManager  = new ModuleManager([]);
         $this->moduleResource = new ModuleModel(
             $this->moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
         $this->controller     = new SourceController($this->moduleResource);
     }
 
     public function invalidRequestMethods()
     {
-        return array(
-            array('put'),
-            array('patch'),
-            array('post'),
-            array('delete'),
-        );
+        return [
+            ['put'],
+            ['patch'],
+            ['post'],
+            ['delete'],
+        ];
     }
 
     /**
@@ -59,9 +59,9 @@ class SourceControllerTest extends TestCase
                                ->getMock();
         $moduleManager->expects($this->any())
                       ->method('getLoadedModules')
-                      ->will($this->returnValue(array('ZFTest\Apigility\Admin\Model\TestAsset\Bar' => new BarModule)));
+                      ->will($this->returnValue(['ZFTest\Apigility\Admin\Model\TestAsset\Bar' => new BarModule]));
 
-        $moduleResource = new ModuleModel($moduleManager, array(), array());
+        $moduleResource = new ModuleModel($moduleManager, [], []);
         $controller     = new SourceController($moduleResource);
 
         $request = new Request();

--- a/test/InputFilter/Authentication/BasicInputFilterTest.php
+++ b/test/InputFilter/Authentication/BasicInputFilterTest.php
@@ -25,49 +25,49 @@ class BasicInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory;
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\Authentication\BasicInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'basic-only' => array(
-                array('accept_schemes' => array('basic'), 'realm' => 'My Realm')
-            ),
-            'basic-and-digest' => array(
-                array('accept_schemes' => array('digest', 'basic'), 'realm' => 'My Realm')
-            ),
-        );
+        return [
+            'basic-only' => [
+                ['accept_schemes' => ['basic'], 'realm' => 'My Realm']
+            ],
+            'basic-and-digest' => [
+                ['accept_schemes' => ['digest', 'basic'], 'realm' => 'My Realm']
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'empty' => array(
-                array(),
-                array(
+        return [
+            'empty' => [
+                [],
+                [
                     'accept_schemes',
                     'realm',
                     'htpasswd',
-                ),
-            ),
-            'empty-data' => array(
-                array('accept_schemes' => '', 'realm' => '', 'htpasswd' => ''),
-                array(
+                ],
+            ],
+            'empty-data' => [
+                ['accept_schemes' => '', 'realm' => '', 'htpasswd' => ''],
+                [
                     'accept_schemes',
                     'realm',
                     'htpasswd',
-                ),
-            ),
-            'invalid-htpasswd' => array(
-                array('accept_schemes' => array('basic'), 'realm' => 'api', 'htpasswd' => '/foo/bar/baz/bat.htpasswd'),
-                array(
+                ],
+            ],
+            'invalid-htpasswd' => [
+                ['accept_schemes' => ['basic'], 'realm' => 'api', 'htpasswd' => '/foo/bar/baz/bat.htpasswd'],
+                [
                     'htpasswd',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/Authentication/DigestInputFilterTest.php
+++ b/test/InputFilter/Authentication/DigestInputFilterTest.php
@@ -25,64 +25,64 @@ class DigestInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\Authentication\DigestInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'valid' => array(
-                array(
-                    'accept_schemes' => array('digest'),
+        return [
+            'valid' => [
+                [
+                    'accept_schemes' => ['digest'],
                     'digest_domains' => 'foo.local',
                     'realm' => 'My Realm',
                     'htdigest' => 'tmp/file.htpasswd',
                     'nonce_timeout' => 3600
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'no-data' => array(
-                array(),
-                array(
+        return [
+            'no-data' => [
+                [],
+                [
                     'accept_schemes',
                     'digest_domains',
                     'realm',
                     'htdigest',
                     'nonce_timeout',
-                ),
-            ),
-            'nonce-is-not-a-digit' => array(
-                array(
-                    'accept_schemes' => array('digest'),
+                ],
+            ],
+            'nonce-is-not-a-digit' => [
+                [
+                    'accept_schemes' => ['digest'],
                     'digest_domains' => 'foo.local',
                     'realm' => 'My Realm',
                     'htdigest' => '%HTDIGEST%',
                     'nonce_timeout' => 'foo',
-                ),
-                array(
+                ],
+                [
                     'nonce_timeout',
-                ),
-            ),
-            'invalid-htdigest' => array(
-                array(
-                    'accept_schemes' => array('digest'),
+                ],
+            ],
+            'invalid-htdigest' => [
+                [
+                    'accept_schemes' => ['digest'],
                     'digest_domains' => 'foo.local',
                     'realm' => 'My Realm',
                     'htdigest' => '/foo/bar/baz/bat.htpasswd',
                     'nonce_timeout' => 3600,
-                ),
-                array(
+                ],
+                [
                     'htdigest',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/Authentication/OAuth2InputFilterTest.php
+++ b/test/InputFilter/Authentication/OAuth2InputFilterTest.php
@@ -15,75 +15,75 @@ class OAuth2InputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory;
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\Authentication\OAuth2InputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'minimal' => array(
-                array(
+        return [
+            'minimal' => [
+                [
                     'dsn' => 'sqlite://:memory:',
                     'dsn_type' => 'PDO',
                     'route_match' => '/foo',
-                ),
-            ),
-            'full' => array(
-                array(
+                ],
+            ],
+            'full' => [
+                [
                     'dsn' => 'sqlite://:memory:',
                     'dsn_type' => 'PDO',
                     'password' => 'foobar',
                     'route_match' => '/foo',
                     'username' => 'barfoo',
-                ),
-            ),
-            'mongo-without-dsn' => array(
-                array(
+                ],
+            ],
+            'mongo-without-dsn' => [
+                [
                     'dsn_type' => 'Mongo',
                     'database' => 'oauth2',
                     'route_match' => '/oauth2',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'empty' => array(
-                array(),
-                array(
+        return [
+            'empty' => [
+                [],
+                [
                     'dsn',
                     'dsn_type',
                     'route_match',
-                ),
-            ),
-            'empty-values' => array(
-                array(
+                ],
+            ],
+            'empty-values' => [
+                [
                     'dsn' => '',
                     'dsn_type' => '',
                     'password' => '',
                     'route_match' => '',
                     'username' => '',
-                ),
-                array(
+                ],
+                [
                     'dsn',
                     'dsn_type',
                     'route_match',
-                ),
-            ),
-            'mongo-without-database' => array(
-                array(
+                ],
+            ],
+            'mongo-without-database' => [
+                [
                     'dsn_type' => 'Mongo',
                     'route_match' => '/oauth2',
-                ),
-                array(
+                ],
+                [
                     'database',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/AuthorizationInputFilterTest.php
+++ b/test/InputFilter/AuthorizationInputFilterTest.php
@@ -13,52 +13,52 @@ class AuthorizationInputFilterTest extends TestCase
 {
     public function dataProviderIsValid()
     {
-        return array(
-            'empty' => array(
-                array(),
-            ),
-            'valid' => array(
-                array(
-                    'Foo\V1\Rest\Bar\Controller::__entity__' => array('POST' => true, 'GET' => false),
-                    'Foo\V1\Rpc\Boom\Controller::boom' => array('GET' => true, 'DELETE' => false, 'PATCH' => true),
-                ),
-            ),
-        );
+        return [
+            'empty' => [
+                [],
+            ],
+            'valid' => [
+                [
+                    'Foo\V1\Rest\Bar\Controller::__entity__' => ['POST' => true, 'GET' => false],
+                    'Foo\V1\Rpc\Boom\Controller::boom' => ['GET' => true, 'DELETE' => false, 'PATCH' => true],
+                ],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'invalid-controller-name' => array(
-                array(
-                    'Foo\V1\Rest\Bar\Controller' => array(),
-                ),
-                array(
-                    'Foo\V1\Rest\Bar\Controller' => array(
+        return [
+            'invalid-controller-name' => [
+                [
+                    'Foo\V1\Rest\Bar\Controller' => [],
+                ],
+                [
+                    'Foo\V1\Rest\Bar\Controller' => [
                         'Class service name is invalid, must be serviceName::method,'
                         . ' serviceName::__collection__, or serviceName::__entity__',
-                    ),
-                ),
-            ),
-            'values-not-array' => array(
-                array(
+                    ],
+                ],
+            ],
+            'values-not-array' => [
+                [
                     'Foo\V1\Rest\Bar\Controller::__entity__' => 'GET=true',
-                ),
-                array(
-                    'Foo\V1\Rest\Bar\Controller::__entity__' => array(
+                ],
+                [
+                    'Foo\V1\Rest\Bar\Controller::__entity__' => [
                         'Values for each controller must be an http method keyed array of true/false values',
-                    ),
-                ),
-            ),
-            'invalid-http-method' => array(
-                array(
-                    'Foo\V1\Rest\Bar\Controller::__entity__' => array('MYMETHOD' => true),
-                ),
-                array(
-                    'Foo\V1\Rest\Bar\Controller::__entity__' => array('Invalid HTTP method (MYMETHOD) provided.'),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+            'invalid-http-method' => [
+                [
+                    'Foo\V1\Rest\Bar\Controller::__entity__' => ['MYMETHOD' => true],
+                ],
+                [
+                    'Foo\V1\Rest\Bar\Controller::__entity__' => ['Invalid HTTP method (MYMETHOD) provided.'],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/ContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/ContentNegotiationInputFilterTest.php
@@ -13,52 +13,52 @@ class ContentNegotiationInputFilterTest extends TestCase
 {
     public function dataProviderIsValid()
     {
-        return array(
-            'valid' => array(array('selectors' =>
-                array(
-                    'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                ),
-            )),
-        );
+        return [
+            'valid' => [['selectors' =>
+                [
+                    'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                ],
+            ]],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'class-does-not-exist' => array(
-                array('selectors' => array(
-                    'Zend\View\Model\ViewMode' => array('text/html', 'application/xhtml+xml'),
-                )),
-                array('selectors' => array(
+        return [
+            'class-does-not-exist' => [
+                ['selectors' => [
+                    'Zend\View\Model\ViewMode' => ['text/html', 'application/xhtml+xml'],
+                ]],
+                ['selectors' => [
                     'classNotFound' => 'Class name (Zend\View\Model\ViewMode) does not exist',
-                )),
-            ),
-            'class-is-not-view-model' => array(
-                array('selectors' => array(
-                    __CLASS__ => array('text/html', 'application/xhtml+xml'),
-                )),
-                array('selectors' => array(
+                ]],
+            ],
+            'class-is-not-view-model' => [
+                ['selectors' => [
+                    __CLASS__ => ['text/html', 'application/xhtml+xml'],
+                ]],
+                ['selectors' => [
                     'invalidViewModel' => 'Class name (' . __CLASS__ . ') is invalid;'
                     . ' must be a valid Zend\View\Model\ModelInterface instance',
-                )),
-            ),
-            'media-types-not-array' => array(
-                array('selectors' => array(
+                ]],
+            ],
+            'media-types-not-array' => [
+                ['selectors' => [
                     'Zend\View\Model\ViewModel' => 'foo',
-                )),
-                array('selectors' => array(
+                ]],
+                ['selectors' => [
                     'invalidMediaTypes' => 'Values for the media-types must be provided as an indexed array',
-                )),
-            ),
-            'invalid-media-type' => array(
-                array('selectors' => array(
-                    'Zend\View\Model\ViewModel' => array('texthtml', 'application/xhtml+xml'),
-                )),
-                array('selectors' => array(
+                ]],
+            ],
+            'invalid-media-type' => [
+                ['selectors' => [
+                    'Zend\View\Model\ViewModel' => ['texthtml', 'application/xhtml+xml'],
+                ]],
+                ['selectors' => [
                     'invalidMediaType' => 'Invalid media type (texthtml) provided',
-                )),
-            ),
-        );
+                ]],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -13,105 +13,105 @@ class CreateContentNegotiationInputFilterTest extends TestCase
 {
     public function dataProviderIsValid()
     {
-        return array(
-            'content-name-only' => array(
-                array(
+        return [
+            'content-name-only' => [
+                [
                     'content_name' => 'test',
-                ),
-            ),
-            'content-name-and-selectors' => array(
-                array(
+                ],
+            ],
+            'content-name-and-selectors' => [
+                [
                     'content_name' => 'test',
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    ),
-                ),
-            ),
-        );
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'missing-content-name' => array(
-                array(
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    ),
-                ),
-                array(
-                    'content_name' => array(
+        return [
+            'missing-content-name' => [
+                [
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ],
+                ],
+                [
+                    'content_name' => [
                         'isEmpty' => 'Value is required and can\'t be empty'
-                    ),
-                ),
-            ),
-            'null-content-name' => array(
-                array(
+                    ],
+                ],
+            ],
+            'null-content-name' => [
+                [
                     'content_name' => null,
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    ),
-                ),
-                array('content_name' => array(
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ],
+                ],
+                ['content_name' => [
                     'isEmpty' => 'Value is required and can\'t be empty',
-                )),
-            ),
-            'bool-content-name' => array(
-                array(
+                ]],
+            ],
+            'bool-content-name' => [
+                [
                     'content_name' => true,
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    ),
-                ),
-                array('content_name' => array(
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ],
+                ],
+                ['content_name' => [
                     'invalidType' => 'Value must be a string; received boolean',
-                )),
-            ),
-            'int-content-name' => array(
-                array(
+                ]],
+            ],
+            'int-content-name' => [
+                [
                     'content_name' => 1,
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    )
-                ),
-                array('content_name' => array(
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ]
+                ],
+                ['content_name' => [
                     'invalidType' => 'Value must be a string; received integer',
-                )),
-            ),
-            'float-content-name' => array(
-                array(
+                ]],
+            ],
+            'float-content-name' => [
+                [
                     'content_name' => 1.1,
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    )
-                ),
-                array('content_name' => array(
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ]
+                ],
+                ['content_name' => [
                     'invalidType' => 'Value must be a string; received double',
-                )),
-            ),
-            'array-content-name' => array(
-                array(
-                    'content_name' => array('content_name'),
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    )
-                ),
-                array('content_name' => array(
+                ]],
+            ],
+            'array-content-name' => [
+                [
+                    'content_name' => ['content_name'],
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ]
+                ],
+                ['content_name' => [
                     'invalidType' => 'Value must be a string; received array',
-                )),
-            ),
-            'object-content-name' => array(
-                array(
-                    'content_name' => (object) array('content_name'),
-                    'selectors' => array(
-                        'Zend\View\Model\ViewModel' => array('text/html', 'application/xhtml+xml'),
-                    ),
-                ),
-                array('content_name' => array(
+                ]],
+            ],
+            'object-content-name' => [
+                [
+                    'content_name' => (object) ['content_name'],
+                    'selectors' => [
+                        'Zend\View\Model\ViewModel' => ['text/html', 'application/xhtml+xml'],
+                    ],
+                ],
+                ['content_name' => [
                     'invalidType' => 'Value must be a string; received stdClass',
-                )),
-            ),
-        );
+                ]],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/DbAdapterInputFilterTest.php
+++ b/test/InputFilter/DbAdapterInputFilterTest.php
@@ -14,49 +14,49 @@ class DbAdapterInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\DbAdapterInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'valid' => array(
-                array(
+        return [
+            'valid' => [
+                [
                     'adapter_name' => 'Db\Status',
                     'database' => '/path/to/foobar',
                     'driver' => 'pdo_sqlite',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'missing-adapter-name' => array(
-                array(
+        return [
+            'missing-adapter-name' => [
+                [
                     'database' => '/path/to/foobar',
                     'driver' => 'pdo_sqlite',
-                ),
-                array('adapter_name'),
-            ),
-            'missing-database' => array(
-                array(
+                ],
+                ['adapter_name'],
+            ],
+            'missing-database' => [
+                [
                     'adapter_name' => 'Db\Status',
                     'driver' => 'pdo_sqlite',
-                ),
-                array('database'),
-            ),
-            'missing-driver' => array(
-                array(
+                ],
+                ['database'],
+            ],
+            'missing-driver' => [
+                [
                     'adapter_name' => 'Db\Status',
                     'database' => '/path/to/foobar',
-                ),
-                array('driver'),
-            ),
-        );
+                ],
+                ['driver'],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/DocumentationInputFilterTest.php
+++ b/test/InputFilter/DocumentationInputFilterTest.php
@@ -10,191 +10,191 @@ class DocumentationInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\DocumentationInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'full-rpc' => array(
-                array(
+        return [
+            'full-rpc' => [
+                [
                     'description' => 'Foobar',
-                    'GET' => array(
+                    'GET' => [
                         'description' => 'another one',
                         'request' => 'request doc',
                         'response' => 'response doc',
-                    ),
-                    'POST' => array(
+                    ],
+                    'POST' => [
                         'description' => 'another one',
                         'request' => 'request doc',
                         'response' => 'response doc',
-                    ),
-                    'PUT' => array(
+                    ],
+                    'PUT' => [
                         'description' => 'another one',
                         'request' => 'request doc',
                         'response' => 'response doc',
-                    ),
-                    'PATCH' => array(
+                    ],
+                    'PATCH' => [
                         'description' => 'another one',
                         'request' => 'request doc',
                         'response' => 'response doc',
-                    ),
-                    'DELETE' => array(
+                    ],
+                    'DELETE' => [
                         'description' => 'another one',
                         'request' => 'request doc',
                         'response' => 'response doc',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
             // full REST
-            'full-rest' => array(
-                array(
+            'full-rest' => [
+                [
                     'description' => 'Foobar',
-                    'collection' => array(
-                        'GET' => array(
+                    'collection' => [
+                        'GET' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'POST' => array(
+                        ],
+                        'POST' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'PUT' => array(
+                        ],
+                        'PUT' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'PATCH' => array(
+                        ],
+                        'PATCH' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'DELETE' => array(
+                        ],
+                        'DELETE' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                    ),
-                    'entity' => array(
-                        'GET' => array(
+                        ],
+                    ],
+                    'entity' => [
+                        'GET' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'POST' => array(
+                        ],
+                        'POST' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'PUT' => array(
+                        ],
+                        'PUT' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'PATCH' => array(
+                        ],
+                        'PATCH' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                        'DELETE' => array(
+                        ],
+                        'DELETE' => [
                             'description' => 'another one',
                             'request' => 'request doc',
                             'response' => 'response doc',
-                        ),
-                    ),
-                ),
-            ),
-            'empty' => array(
-                array(),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+            'empty' => [
+                [],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'invalid-top-level-keys' => array(
-                array('description' => 'foobar', 'Foobar' => 'baz'),
-                array(
-                    'Foobar' => array(
+        return [
+            'invalid-top-level-keys' => [
+                ['description' => 'foobar', 'Foobar' => 'baz'],
+                [
+                    'Foobar' => [
                         'An invalid key was encountered in the top position for "Foobar";'
                         . ' must be one of an HTTP method, collection, entity, or description'
-                    ),
-                ),
-            ),
-            'collection-or-entity-with-top-level-http-methods' => array(
-                array('description' => 'foobar', 'GET' => array('description' => 'foobar'), 'entity' => array()),
-                array(
-                    'GET' => array(
+                    ],
+                ],
+            ],
+            'collection-or-entity-with-top-level-http-methods' => [
+                ['description' => 'foobar', 'GET' => ['description' => 'foobar'], 'entity' => []],
+                [
+                    'GET' => [
                         'HTTP methods cannot be present when "collection" or "entity" is also present;'
                         . ' please verify data for "GET"'
-                    ),
-                ),
-            ),
-            'http-method-with-bad-format' => array(
-                array('description' => 'foobar', 'GET' => array('description' => 'foobar', 'Foo' => 'bar')),
-                array(
-                    'Foo' => array(
+                    ],
+                ],
+            ],
+            'http-method-with-bad-format' => [
+                ['description' => 'foobar', 'GET' => ['description' => 'foobar', 'Foo' => 'bar']],
+                [
+                    'Foo' => [
                         'Documentable elements must be any or all of description, request or response;'
                         . ' please verify "Foo"'
-                    ),
-                ),
-            ),
-            'http-method-not-strings' => array(
-                array('description' => 'foobar', 'GET' => array('description' => 'foobar', 'request' => 500)),
-                array(
-                    'request' => array('Documentable elements must be strings; please verify "request"'),
-                ),
-            ),
-            'http-method-not-strings-in-entity' => array(
-                array(
+                    ],
+                ],
+            ],
+            'http-method-not-strings' => [
+                ['description' => 'foobar', 'GET' => ['description' => 'foobar', 'request' => 500]],
+                [
+                    'request' => ['Documentable elements must be strings; please verify "request"'],
+                ],
+            ],
+            'http-method-not-strings-in-entity' => [
+                [
                     'description' => 'foobar',
-                    'entity' => array(
-                        'GET' => array('description' => 'foobar', 'response' => 500)
-                    )
-                ),
-                array(
-                    'response' => array('Documentable elements must be strings; please verify "response"'),
-                ),
-            ),
-            'description-is-not-a-string' => array(
-                array('description' => 5),
-                array(
-                    'description' => array(
+                    'entity' => [
+                        'GET' => ['description' => 'foobar', 'response' => 500]
+                    ]
+                ],
+                [
+                    'response' => ['Documentable elements must be strings; please verify "response"'],
+                ],
+            ],
+            'description-is-not-a-string' => [
+                ['description' => 5],
+                [
+                    'description' => [
                         'Description must be provided as a string; please verify description for "description"'
-                    ),
-                ),
-            ),
-            'description-is-not-a-string-in-entity-or-collection' => array(
-                array('collection' => array('description' => 5)),
-                array(
-                    'collection' => array(
+                    ],
+                ],
+            ],
+            'description-is-not-a-string-in-entity-or-collection' => [
+                ['collection' => ['description' => 5]],
+                [
+                    'collection' => [
                         'Description must be provided as a string; please verify description for "description"'
-                    ),
-                ),
-            ),
-            'collection-or-entity-not-an-array' => array(
-                array('collection' => 5),
-                array(
-                    'collection' => array(
+                    ],
+                ],
+            ],
+            'collection-or-entity-not-an-array' => [
+                ['collection' => 5],
+                [
+                    'collection' => [
                         'Collections and entities methods must be an array of HTTP methods;'
                         . ' received invalid entry for "collection"'
-                    ),
-                ),
-            ),
-            'collection-or-entity-using-wrong-key' => array(
-                array('collection' => array('Foo' => 'bar')),
-                array(
-                    'collection' => array(
+                    ],
+                ],
+            ],
+            'collection-or-entity-using-wrong-key' => [
+                ['collection' => ['Foo' => 'bar']],
+                [
+                    'collection' => [
                         'Key must be description or an HTTP indexed list; please verify documentation for "Foo"'
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/InputFilterInputFilterTest.php
+++ b/test/InputFilter/InputFilterInputFilterTest.php
@@ -15,59 +15,59 @@ class InputFilterInputFilterTest extends TestCase
 
     public function dataProviderIsValid()
     {
-        return array(
-            array(
-                array(
-                    array(
+        return [
+            [
+                [
+                    [
                         'name' => 'myfilter',
                         'required' => true,
-                        'filters' => array(
-                            array(
+                        'filters' => [
+                            [
                                 'name' => 'Zend\Filter\Boolean',
-                                'options' => array('casting' => false),
-                            )
-                        ),
-                        'validators' => array(),
+                                'options' => ['casting' => false],
+                            ]
+                        ],
+                        'validators' => [],
                         'allow_empty' => true,
                         'continue_if_empty' => false,
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            array(
-                array('foobar' => 'baz'),
-                array(
+        return [
+            [
+                ['foobar' => 'baz'],
+                [
                     'inputFilter' => 'Zend\InputFilter\Factory::createInput expects'
                     . ' an array or Traversable; received "string"',
-                ),
-            ),
-            array(
-                array(
-                    array(
+                ],
+            ],
+            [
+                [
+                    [
                         'name' => 'myfilter',
                         'required' => true,
-                        'filters' => array(
-                            array(
+                        'filters' => [
+                            [
                                 'name' => 'Zend\Filter\Bool',
-                                'options' => array('casting' => false),
-                            )
-                        ),
-                        'validators' => array(),
+                                'options' => ['casting' => false],
+                            ]
+                        ],
+                        'validators' => [],
                         'allow_empty' => true,
                         'continue_if_empty' => false,
-                    )
-                ),
-                array(
+                    ]
+                ],
+                [
                     'inputFilter' => 'Zend\Filter\FilterPluginManager::get was unable'
                     . ' to fetch or create an instance for Zend\Filter\Bool'
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/ModuleInputFilterTest.php
+++ b/test/InputFilter/ModuleInputFilterTest.php
@@ -14,43 +14,43 @@ class ModuleInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\ModuleInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'singular-namespace' => array(
-                array('name' => 'Foo'),
-            ),
-            'underscore_namespace' => array(
-                array('name' => 'My_Status'),
-            ),
-        );
+        return [
+            'singular-namespace' => [
+                ['name' => 'Foo'],
+            ],
+            'underscore_namespace' => [
+                ['name' => 'My_Status'],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'missing-name' => array(
-                array(),
-                array('name'),
-            ),
-            'empty-name' => array(
-                array('name' => ''),
-                array('name'),
-            ),
-            'underscore-only' => array(
-                array('name' => '_'),
-                array('name'),
-            ),
-            'namespace-separator' => array(
-                array('name' => 'My\Status'),
-                array('name'),
-            ),
-        );
+        return [
+            'missing-name' => [
+                [],
+                ['name'],
+            ],
+            'empty-name' => [
+                ['name' => ''],
+                ['name'],
+            ],
+            'underscore-only' => [
+                ['name' => '_'],
+                ['name'],
+            ],
+            'namespace-separator' => [
+                ['name' => 'My\Status'],
+                ['name'],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -14,39 +14,39 @@ class PatchInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\RestService\PatchInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValidTrue()
     {
-        return array(
-            'all-inputs-present' => array(array(
-                'accept_whitelist' => array (
+        return [
+            'all-inputs-present' => [[
+                'accept_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/hal+json',
                     2 => 'application/json',
-                ),
+                ],
                 'collection_class' => 'Zend\Paginator\Paginator',
-                'collection_http_methods' => array (
+                'collection_http_methods' =>  [
                     0 => 'GET',
                     1 => 'POST',
-                ),
+                ],
                 'collection_name' => 'foo_bar',
-                'collection_query_whitelist' => array (
-                ),
-                'content_type_whitelist' => array (
+                'collection_query_whitelist' =>  [
+                ],
+                'content_type_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/json',
-                ),
+                ],
                 'entity_class' => 'StdClass',
-                'entity_http_methods' => array (
+                'entity_http_methods' =>  [
                     0 => 'GET',
                     1 => 'PATCH',
                     2 => 'PUT',
                     3 => 'DELETE',
-                ),
+                ],
                 'entity_identifier_name' => 'id',
                 'hydrator_name' => 'Zend\\Stdlib\\Hydrator\\ArraySerializable',
                 'page_size' => 25,
@@ -56,32 +56,32 @@ class PatchInputFilterTest extends TestCase
                 'route_match' => '/foo_bar[/:foo_bar_id]',
                 'selector' => 'HalJson',
                 'service_name' => 'Baz_Bat',
-            )),
-            'page_size-negative' => array(array(
-                'accept_whitelist' => array (
+            ]],
+            'page_size-negative' => [[
+                'accept_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/hal+json',
                     2 => 'application/json',
-                ),
+                ],
                 'collection_class' => 'Zend\Paginator\Paginator',
-                'collection_http_methods' => array (
+                'collection_http_methods' =>  [
                     0 => 'GET',
                     1 => 'POST',
-                ),
+                ],
                 'collection_name' => 'foo_bar',
-                'collection_query_whitelist' => array (
-                ),
-                'content_type_whitelist' => array (
+                'collection_query_whitelist' =>  [
+                ],
+                'content_type_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/json',
-                ),
+                ],
                 'entity_class' => 'StdClass',
-                'entity_http_methods' => array (
+                'entity_http_methods' =>  [
                     0 => 'GET',
                     1 => 'PATCH',
                     2 => 'PUT',
                     3 => 'DELETE',
-                ),
+                ],
                 'entity_identifier_name' => 'id',
                 'hydrator_name' => 'Zend\\Stdlib\\Hydrator\\ArraySerializable',
                 'page_size' => -1,
@@ -91,71 +91,71 @@ class PatchInputFilterTest extends TestCase
                 'route_match' => '/foo_bar[/:foo_bar_id]',
                 'selector' => 'HalJson',
                 'service_name' => 'Baz_Bat',
-            )),
-        );
+            ]],
+        ];
     }
 
     public function dataProviderIsValidFalse()
     {
-        return array(
-            'missing-service-name' => array(array(
-                'accept_whitelist' => array (
+        return [
+            'missing-service-name' => [[
+                'accept_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/hal+json',
                     2 => 'application/json',
-                ),
+                ],
                 'collection_class' => null,
-                'collection_http_methods' => array (
+                'collection_http_methods' =>  [
                     0 => 'GET',
                     1 => 'POST',
-                ),
-                'collection_query_whitelist' => array (
-                ),
-                'content_type_whitelist' => array (
+                ],
+                'collection_query_whitelist' =>  [
+                ],
+                'content_type_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/json',
-                ),
+                ],
                 'entity_class' => null,
-                'entity_http_methods' => array (
+                'entity_http_methods' =>  [
                     0 => 'GET',
                     1 => 'PATCH',
                     2 => 'PUT',
                     3 => 'DELETE',
-                ),
+                ],
                 'hydrator_name' => null,
                 'page_size' => null,
                 'page_size_param' => null,
                 'resource_class' => null,
                 'route_match' => null,
                 'selector' => null,
-            ), array(
+            ], [
                 'service_name',
-            )),
-            'empty-inputs' => array(array(
-                'accept_whitelist' => array (
+            ]],
+            'empty-inputs' => [[
+                'accept_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/hal+json',
                     2 => 'application/json',
-                ),
+                ],
                 'collection_class' => null,
-                'collection_http_methods' => array (
+                'collection_http_methods' =>  [
                     0 => 'GET',
                     1 => 'POST',
-                ),
+                ],
                 'collection_name' => null,
-                'collection_query_whitelist' => array (
-                ),
-                'content_type_whitelist' => array (
+                'collection_query_whitelist' =>  [
+                ],
+                'content_type_whitelist' =>  [
                     0 => 'application/vnd.foo_bar.v1+json',
                     1 => 'application/json',
-                ),
+                ],
                 'entity_class' => null,
-                'entity_http_methods' => array (
+                'entity_http_methods' =>  [
                     0 => 'GET',
                     1 => 'PATCH',
                     2 => 'PUT',
                     3 => 'DELETE',
-                ),
+                ],
                 'entity_identifier_name' => null,
                 'hydrator_name' => null,
                 'page_size' => null,
@@ -165,7 +165,7 @@ class PatchInputFilterTest extends TestCase
                 'route_match' => null,
                 'selector' => null,
                 'service_name' => 'Foo_Bar',
-            ), array(
+            ], [
                 'collection_class',
                 'collection_name',
                 'entity_class',
@@ -174,8 +174,8 @@ class PatchInputFilterTest extends TestCase
                 // 'resource_class', // Resource class is allowed to be empty
                 'route_identifier_name',
                 'route_match',
-            )),
-        );
+            ]],
+        ];
     }
 
     /**

--- a/test/InputFilter/RestService/PostInputFilterTest.php
+++ b/test/InputFilter/RestService/PostInputFilterTest.php
@@ -15,48 +15,48 @@ class PostInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\RestService\PostInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'code-connected' => array(array('service_name' => 'Foo')),
-            'db-connected'   => array(array('adapter_name' => 'Status', 'table_name' => 'foo')),
-        );
+        return [
+            'code-connected' => [['service_name' => 'Foo']],
+            'db-connected'   => [['adapter_name' => 'Status', 'table_name' => 'foo']],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
+        return [
             // no values
-            'empty' => array(
-                array(),
-                array('service_name'),
-            ),
+            'empty' => [
+                [],
+                ['service_name'],
+            ],
             // invalid service_name
-            'invalid-service-name' => array(
-                array('service_name' => '_'),
-                array('service_name'),
-            ),
+            'invalid-service-name' => [
+                ['service_name' => '_'],
+                ['service_name'],
+            ],
             // adapter without table
-            'valid-adapter-missing-table' => array(
-                array('adapter_name' => 'Foo'),
-                array('table_name'),
-            ),
+            'valid-adapter-missing-table' => [
+                ['adapter_name' => 'Foo'],
+                ['table_name'],
+            ],
             // table without adapter
-            'missing-adapter-valid-table' => array(
-                array('table_name' => 'Foo'),
-                array('adapter_name'),
-            ),
+            'missing-adapter-valid-table' => [
+                ['table_name' => 'Foo'],
+                ['adapter_name'],
+            ],
             // both present
-            'conflict' => array(
-                array('service_name' => 'Foo', 'adapter_name' => 'bar'),
-                array('service_name'),
-            )
-        );
+            'conflict' => [
+                ['service_name' => 'Foo', 'adapter_name' => 'bar'],
+                ['service_name'],
+            ]
+        ];
     }
 
     /**

--- a/test/InputFilter/RpcService/PatchInputFilterTest.php
+++ b/test/InputFilter/RpcService/PatchInputFilterTest.php
@@ -10,75 +10,75 @@ class PatchInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\RpcService\PatchInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     'service_name' => 'Foo',
                     'route_match' => '/foo',
                     'controller_class' => 'FooBar\V1\Rpc\Foo\FooController',
-                    'accept_whitelist' => array(
+                    'accept_whitelist' => [
                         'application/vnd.foo.v1+json',
                         'application/hal+json',
                         'application/json'
-                    ),
-                    'content_type_whitelist' => array(
+                    ],
+                    'content_type_whitelist' => [
                         'application/vnd.foo.v1+json',
                         'application/json'
-                    ),
+                    ],
                     'selector' => 'HalJson',
-                    'http_methods' => array('GET', 'POST', 'PATCH'),
-                )
-            )
-        );
+                    'http_methods' => ['GET', 'POST', 'PATCH'],
+                ]
+            ]
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'missing-service-name' => array(
-                array(
+        return [
+            'missing-service-name' => [
+                [
                     'route_match' => '/foo',
                     'controller_class' => 'FooBar\V1\Rpc\Foo\FooController',
-                    'accept_whitelist' => array(
+                    'accept_whitelist' => [
                         'application/vnd.foo.v1+json',
                         'application/hal+json',
                         'application/json'
-                    ),
-                    'content_type_whitelist' => array(
+                    ],
+                    'content_type_whitelist' => [
                         'application/vnd.foo.v1+json',
                         'application/json'
-                    ),
+                    ],
                     'selector' => 'HalJson',
-                    'http_methods' => array('GET', 'POST', 'PATCH'),
-                ),
-                array('service_name'),
-            ),
-            'null-values' => array(
-                array(
+                    'http_methods' => ['GET', 'POST', 'PATCH'],
+                ],
+                ['service_name'],
+            ],
+            'null-values' => [
+                [
                     'service_name' => 'Foo',
                     'route_match' => null,
                     'controller_class' => null,
-                    'accept_whitelist' => array(
+                    'accept_whitelist' => [
                         'application/vnd.foo.v1+json',
                         'application/hal+json', 'application/json'
-                    ),
-                    'content_type_whitelist' => array(
+                    ],
+                    'content_type_whitelist' => [
                         'application/vnd.foo.v1+json',
                         'application/json'
-                    ),
+                    ],
                     'selector' => null,
-                    'http_methods' => array('GET', 'POST', 'PATCH')
-                ),
-                array('route_match', 'controller_class'),
-            ),
-        );
+                    'http_methods' => ['GET', 'POST', 'PATCH']
+                ],
+                ['route_match', 'controller_class'],
+            ],
+        ];
     }
 
     /**

--- a/test/InputFilter/RpcService/PostInputFilterTest.php
+++ b/test/InputFilter/RpcService/PostInputFilterTest.php
@@ -10,44 +10,44 @@ class PostInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\RpcService\PostInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'singular-service-name' => array(
-                array('service_name' => 'Foo', 'route_match' => '/bar'),
-            ),
-            'compound-service-name' => array(
-                array('service_name' => 'Foo_Bar', 'route_match' => '/bar'),
-            ),
-        );
+        return [
+            'singular-service-name' => [
+                ['service_name' => 'Foo', 'route_match' => '/bar'],
+            ],
+            'compound-service-name' => [
+                ['service_name' => 'Foo_Bar', 'route_match' => '/bar'],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'empty' => array(
-                array(),
-                array('service_name', 'route_match'),
-            ),
-            'missing-service-name' => array(
-                array('route_match' => '/bar'),
-                array('service_name'),
-            ),
-            'missing-route-match' => array(
-                array('service_name' => 'Foo_Bar'),
-                array('route_match'),
-            ),
-            'namespaced-service-name' => array(
-                array('service_name' => 'Foo\Bar', 'route_match' => '/bar'),
-                array('service_name'),
-            ),
+        return [
+            'empty' => [
+                [],
+                ['service_name', 'route_match'],
+            ],
+            'missing-service-name' => [
+                ['route_match' => '/bar'],
+                ['service_name'],
+            ],
+            'missing-route-match' => [
+                ['service_name' => 'Foo_Bar'],
+                ['route_match'],
+            ],
+            'namespaced-service-name' => [
+                ['service_name' => 'Foo\Bar', 'route_match' => '/bar'],
+                ['service_name'],
+            ],
 
-        );
+        ];
     }
 
     /**

--- a/test/InputFilter/Validator/ModuleNameTest.php
+++ b/test/InputFilter/Validator/ModuleNameTest.php
@@ -13,20 +13,20 @@ class ModuleNameTest extends TestCase
 {
     public function validModuleNames()
     {
-        return array(
-            'string' => array('test'),
-            'string-with-underscores' => array('test_test'),
-            'string-with-digits' => array('test0'),
-        );
+        return [
+            'string' => ['test'],
+            'string-with-underscores' => ['test_test'],
+            'string-with-digits' => ['test0'],
+        ];
     }
 
     public function invalidModuleNames()
     {
-        return array(
-            'eval' => array('eval'),
-            'Eval' => array('Eval'),
-            'digit-leading' => array('0test'),
-        );
+        return [
+            'eval' => ['eval'],
+            'Eval' => ['Eval'],
+            'digit-leading' => ['0test'],
+        ];
     }
 
     /**

--- a/test/InputFilter/VersionInputFilterTest.php
+++ b/test/InputFilter/VersionInputFilterTest.php
@@ -14,59 +14,59 @@ class VersionInputFilterTest extends TestCase
     public function getInputFilter()
     {
         $factory = new Factory();
-        return $factory->createInputFilter(array(
+        return $factory->createInputFilter([
             'type' => 'ZF\Apigility\Admin\InputFilter\VersionInputFilter',
-        ));
+        ]);
     }
 
     public function dataProviderIsValid()
     {
-        return array(
-            'valid' => array(
-                array(
+        return [
+            'valid' => [
+                [
                     'module' => 'foo',
                     'version' => 5,
-                ),
-            ),
-            'version-with-alphas' => array(
-                array(
+                ],
+            ],
+            'version-with-alphas' => [
+                [
                     'module' => 'foo',
                     'version' => 'alpha',
-                ),
-            ),
-            'version-with-mixed' => array(
-                array(
+                ],
+            ],
+            'version-with-mixed' => [
+                [
                     'module' => 'foo',
                     'version' => 'alpha_1',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function dataProviderIsInvalid()
     {
-        return array(
-            'empty' => array(
-                array(),
-                array('module', 'version'),
-            ),
-            'missing-module' => array(
-                array('version' => 'foo'),
-                array('module'),
-            ),
-            'missing-version' => array(
-                array('module' => 'foo'),
-                array('version'),
-            ),
-            'version-with-spaces' => array(
-                array('module' => 'foo', 'version' => 'foo bar'),
-                array('version'),
-            ),
-            'version-with-dashes' => array(
-                array('module' => 'foo', 'version' => 'foo-bar'),
-                array('version'),
-            ),
-        );
+        return [
+            'empty' => [
+                [],
+                ['module', 'version'],
+            ],
+            'missing-module' => [
+                ['version' => 'foo'],
+                ['module'],
+            ],
+            'missing-version' => [
+                ['module' => 'foo'],
+                ['version'],
+            ],
+            'version-with-spaces' => [
+                ['module' => 'foo', 'version' => 'foo bar'],
+                ['version'],
+            ],
+            'version-with-dashes' => [
+                ['module' => 'foo', 'version' => 'foo-bar'],
+                ['version'],
+            ],
+        ];
     }
 
     /**

--- a/test/Listener/CryptFilterListenerTest.php
+++ b/test/Listener/CryptFilterListenerTest.php
@@ -83,7 +83,7 @@ class CryptFilterListenerTest extends TestCase
     {
         $this->initRequestMethod();
         $this->initRouteMatch();
-        $this->event->setParam('ZFContentNegotiationParameterData', array('foo' => 'bar'));
+        $this->event->setParam('ZFContentNegotiationParameterData', ['foo' => 'bar']);
         $this->assertNull($this->listener->onRoute($this->event));
     }
 
@@ -91,24 +91,24 @@ class CryptFilterListenerTest extends TestCase
     {
         $this->initRequestMethod();
         $this->initRouteMatch();
-        $this->event->setParam('ZFContentNegotiationParameterData', array('filters' => array()));
+        $this->event->setParam('ZFContentNegotiationParameterData', ['filters' => []]);
         $this->assertTrue($this->listener->onRoute($this->event));
     }
 
     public function testUpdatesParameterDataIfAnyCompressionOrEncryptionFiltersDetected()
     {
-        $filters = array(
-            array(
+        $filters = [
+            [
                 'name' => 'Zend\Filter\Encrypt\BlockCipher',
-            ),
-            array(
+            ],
+            [
                 'name' => 'Zend\Filter\Compress\Gz',
-            ),
-        );
+            ],
+        ];
 
         $this->initRequestMethod();
         $this->initRouteMatch();
-        $this->event->setParam('ZFContentNegotiationParameterData', array('filters' => $filters));
+        $this->event->setParam('ZFContentNegotiationParameterData', ['filters' => $filters]);
         $this->assertTrue($this->listener->onRoute($this->event));
         $data = $this->event->getParam('ZFContentNegotiationParameterData');
         $filters = $data['filters'];

--- a/test/Model/AuthenticationEntityTest.php
+++ b/test/Model/AuthenticationEntityTest.php
@@ -49,22 +49,22 @@ class AuthenticationEntityTest extends TestCase
 
     public function testCanSetBasicParametersDuringInstantiation()
     {
-        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_BASIC, 'zendcon', array(
+        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_BASIC, 'zendcon', [
             'htpasswd' => __DIR__ . '/htpasswd',
             'htdigest' => __DIR__ . '/htdigest',
-        ));
+        ]);
         $this->assertAttributeEquals(__DIR__ . '/htpasswd', 'htpasswd', $entity);
         $this->assertAttributeEmpty('htdigest', $entity);
     }
 
     public function testCanSetDigestParametersDuringInstantiation()
     {
-        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_DIGEST, 'zendcon', array(
+        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_DIGEST, 'zendcon', [
             'htpasswd'       => __DIR__ . '/htpasswd',
             'htdigest'       => __DIR__ . '/htdigest',
             'nonce_timeout'  => 3600,
             'digest_domains' => '/api',
-        ));
+        ]);
         $this->assertAttributeEmpty('htpasswd', $entity);
         $this->assertAttributeEquals(__DIR__ . '/htdigest', 'htdigest', $entity);
         $this->assertAttributeEquals(3600, 'nonceTimeout', $entity);
@@ -73,12 +73,12 @@ class AuthenticationEntityTest extends TestCase
 
     public function testCanSetOAuth2ParametersDuringInstantiation()
     {
-        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_OAUTH2, array(
+        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_OAUTH2, [
             'dsn'         => 'sqlite::memory:',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        ));
+        ]);
         $this->assertAttributeEmpty('htpasswd', $entity);
         $this->assertAttributeEmpty('htdigest', $entity);
         $this->assertAttributeEmpty('realm', $entity);
@@ -90,51 +90,51 @@ class AuthenticationEntityTest extends TestCase
 
     public function testSerializationOfBasicAuthReturnsOnlyKeysSpecificToType()
     {
-        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_BASIC, 'zendcon', array(
+        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_BASIC, 'zendcon', [
             'htpasswd' => __DIR__ . '/htpasswd',
             'htdigest' => __DIR__ . '/htdigest',
-        ));
-        $this->assertEquals(array(
+        ]);
+        $this->assertEquals([
             'type'           => 'http_basic',
-            'accept_schemes' => array('basic'),
+            'accept_schemes' => ['basic'],
             'realm'          => 'zendcon',
             'htpasswd'       => __DIR__ . '/htpasswd',
-        ), $entity->getArrayCopy());
+        ], $entity->getArrayCopy());
     }
 
     public function testSerializationOfDigestAuthReturnsOnlyKeysSpecificToType()
     {
-        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_DIGEST, 'zendcon', array(
+        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_DIGEST, 'zendcon', [
             'htpasswd'       => __DIR__ . '/htpasswd',
             'htdigest'       => __DIR__ . '/htdigest',
             'nonce_timeout'  => 3600,
             'digest_domains' => '/api',
-        ));
-        $this->assertEquals(array(
+        ]);
+        $this->assertEquals([
             'type'           => 'http_digest',
-            'accept_schemes' => array('digest'),
+            'accept_schemes' => ['digest'],
             'realm'          => 'zendcon',
             'htdigest'       => __DIR__ . '/htdigest',
             'nonce_timeout'  => 3600,
             'digest_domains' => '/api',
-        ), $entity->getArrayCopy());
+        ], $entity->getArrayCopy());
     }
 
     public function testSerializationOfOauth2AuthReturnsOnlyKeysSpecificToType()
     {
-        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_OAUTH2, array(
+        $entity = new AuthenticationEntity(AuthenticationEntity::TYPE_OAUTH2, [
             'dsn'         => 'sqlite::memory:',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        ));
-        $this->assertEquals(array(
+        ]);
+        $this->assertEquals([
             'type'        => 'oauth2',
             'dsn_type'    => 'PDO',
             'dsn'         => 'sqlite::memory:',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        ), $entity->getArrayCopy());
+        ], $entity->getArrayCopy());
     }
 }

--- a/test/Model/AuthenticationModelTest.php
+++ b/test/Model/AuthenticationModelTest.php
@@ -76,7 +76,7 @@ class AuthenticationModelTest extends TestCase
 
         $moduleEntity->expects($this->any())
                      ->method('getVersions')
-                     ->will($this->returnValue(array(1,2)));
+                     ->will($this->returnValue([1,2]));
 
         $moduleModel = $this->getMockBuilder('ZF\Apigility\Admin\Model\ModuleModel')
                             ->disableOriginalConstructor()
@@ -84,7 +84,7 @@ class AuthenticationModelTest extends TestCase
 
         $moduleModel->expects($this->any())
                     ->method('getModules')
-                    ->will($this->returnValue(array('Foo' => $moduleEntity)));
+                    ->will($this->returnValue(['Foo' => $moduleEntity]));
 
         return new AuthenticationModel($globalConfig, $localConfig, $moduleModel);
     }
@@ -115,53 +115,53 @@ class AuthenticationModelTest extends TestCase
 
     public function testCreatesBothGlobalAndLocalConfigWhenNoneExistedPreviously()
     {
-        $toCreate = array(
-            'accept_schemes' => array('basic'),
+        $toCreate = [
+            'accept_schemes' => ['basic'],
             'realm'          => 'zendcon',
             'htpasswd'       => __DIR__ . '/htpasswd',
-        );
+        ];
 
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
         $global = include $this->globalConfigPath;
-        $this->assertAuthenticationConfigEquals('http', array(
-            'accept_schemes' => array('basic'),
+        $this->assertAuthenticationConfigEquals('http', [
+            'accept_schemes' => ['basic'],
             'realm'          => 'zendcon',
-        ), $global);
+        ], $global);
 
         $local  = include $this->localConfigPath;
-        $this->assertAuthenticationConfigEquals('http', array(
+        $this->assertAuthenticationConfigEquals('http', [
             'htpasswd'       => __DIR__ . '/htpasswd',
-        ), $local);
+        ], $local);
     }
 
     public function testCanRetrieveAuthenticationConfig()
     {
-        $globalSeedConfig = array(
-            'zf-mvc-auth' => array(
-                'authentication' => array(
-                    'http' => array(
-                        'accept_schemes' => array('basic'),
+        $globalSeedConfig = [
+            'zf-mvc-auth' => [
+                'authentication' => [
+                    'http' => [
+                        'accept_schemes' => ['basic'],
                         'realm'          => 'zendcon',
-                    ),
-                ),
-            ),
-        );
-        $localSeedConfig = array(
-            'zf-mvc-auth' => array(
-                'authentication' => array(
-                    'http' => array(
+                    ],
+                ],
+            ],
+        ];
+        $localSeedConfig = [
+            'zf-mvc-auth' => [
+                'authentication' => [
+                    'http' => [
                         'htpasswd' => __DIR__ . '/htpasswd',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $model  = $this->createModelFromConfigArrays($globalSeedConfig, $localSeedConfig);
         $entity = $model->fetch();
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\AuthenticationEntity', $entity);
         $expected = array_merge(
-            array('type' => 'http_basic'),
+            ['type' => 'http_basic'],
             $globalSeedConfig['zf-mvc-auth']['authentication']['http'],
             $localSeedConfig['zf-mvc-auth']['authentication']['http']
         );
@@ -170,44 +170,44 @@ class AuthenticationModelTest extends TestCase
 
     public function testUpdatesGlobalAndLocalConfigWhenUpdating()
     {
-        $toCreate = array(
-            'accept_schemes' => array('basic'),
+        $toCreate = [
+            'accept_schemes' => ['basic'],
             'realm'          => 'zendcon',
             'htpasswd'       => __DIR__ . '/htpasswd',
-        );
-        $model = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
-        $newConfig = array(
+        $newConfig = [
             'realm'    => 'api',
             'htpasswd' => sys_get_temp_dir() . '/htpasswd',
-        );
+        ];
         $entity = $model->update($newConfig);
 
         // Ensure the entity returned from the update is what we expect
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\AuthenticationEntity', $entity);
-        $expected = array_merge(array('type' => 'http_basic'), $toCreate, $newConfig);
+        $expected = array_merge(['type' => 'http_basic'], $toCreate, $newConfig);
         $this->assertEquals($expected, $entity->getArrayCopy());
 
         // Ensure fetching the entity after an update will return what we expect
         $config = include $this->globalConfigPath;
-        $this->assertAuthenticationConfigEquals('http', array(
-            'accept_schemes' => array('basic'),
+        $this->assertAuthenticationConfigEquals('http', [
+            'accept_schemes' => ['basic'],
             'realm'          => 'api',
-        ), $config);
+        ], $config);
 
         $config = include $this->localConfigPath;
-        $this->assertAuthenticationConfigEquals('http', array('htpasswd' => sys_get_temp_dir() . '/htpasswd'), $config);
+        $this->assertAuthenticationConfigEquals('http', ['htpasswd' => sys_get_temp_dir() . '/htpasswd'], $config);
     }
 
     public function testRemoveDeletesConfigurationFromBothLocalAndGlobalConfigFiles()
     {
-        $toCreate = array(
-            'accept_schemes' => array('basic'),
+        $toCreate = [
+            'accept_schemes' => ['basic'],
             'realm'          => 'zendcon',
             'htpasswd'       => __DIR__ . '/htpasswd',
-        );
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
         $model->remove();
@@ -219,14 +219,14 @@ class AuthenticationModelTest extends TestCase
 
     public function testCreatingOAuth2ConfigurationWritesToEachConfigFile()
     {
-        $toCreate = array(
+        $toCreate = [
             'dsn'         => 'sqlite::memory:',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        );
+        ];
 
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
         $global = include $this->globalConfigPath;
@@ -242,15 +242,15 @@ class AuthenticationModelTest extends TestCase
         );
 
         $local  = include $this->localConfigPath;
-        $this->assertEquals(array(
+        $this->assertEquals([
             'storage' => 'ZF\OAuth2\Adapter\PdoAdapter',
-            'db' => array(
+            'db' => [
                 'dsn_type'    => 'PDO',
                 'dsn'         => 'sqlite::memory:',
                 'username'    => 'me',
                 'password'    => 'too',
-            ),
-        ), $local['zf-oauth2']);
+            ],
+        ], $local['zf-oauth2']);
     }
 
     public function testCreatingOAuth2ConfigurationWritesToEachConfigFileForMongo()
@@ -259,14 +259,14 @@ class AuthenticationModelTest extends TestCase
             $this->markTestSkipped('mongo extension must be loaded to run this test');
         }
 
-        $toCreate = array(
+        $toCreate = [
             'dsn'         => 'mongodb://localhost:27017',
             'database'    => 'apigilityTest',
             'dsn_type'    => 'Mongo',
             'route_match' => '/api/oauth',
-        );
+        ];
 
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
         $global = include $this->globalConfigPath;
@@ -282,28 +282,28 @@ class AuthenticationModelTest extends TestCase
         );
 
         $local  = include $this->localConfigPath;
-        $this->assertEquals(array(
+        $this->assertEquals([
             'storage' => 'ZF\OAuth2\Adapter\MongoAdapter',
-            'mongo' => array(
+            'mongo' => [
                 'dsn_type'    => 'Mongo',
                 'dsn'         => 'mongodb://localhost:27017',
                 'username'    => null,
                 'password'    => null,
                 'database'    => 'apigilityTest',
-            ),
-        ), $local['zf-oauth2']);
+            ],
+        ], $local['zf-oauth2']);
     }
 
     public function testRemovingOAuth2ConfigurationRemovesConfigurationFromEachFile()
     {
-        $toCreate = array(
+        $toCreate = [
             'dsn'         => 'sqlite::memory:',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        );
+        ];
 
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
         $model->remove();
@@ -326,13 +326,13 @@ class AuthenticationModelTest extends TestCase
             $this->markTestSkipped('mongo extension must be loaded to run this test');
         }
 
-        $toCreate = array(
+        $toCreate = [
             'dsn_type'    => 'mongo',
             'dsn'         => 'mongodb://localhost:27017/apigility',
             'route_match' => '/api/oauth',
-        );
+        ];
 
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create($toCreate);
 
         $model->remove();
@@ -355,13 +355,13 @@ class AuthenticationModelTest extends TestCase
             $this->markTestSkipped('mongo extension must be loaded to run this test');
         }
 
-        $toCreate = array(
+        $toCreate = [
             'dsn'         => 'mongodb:300.300.300.300',
             'database'    => 'wrong',
             'route_match' => '/api/oauth',
             'dsn_type'    => 'Mongo'
-        );
-        $model = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model = $this->createModelFromConfigArrays([], []);
 
         $this->setExpectedException('ZF\Apigility\Admin\Exception\InvalidArgumentException', 'DSN', 422);
         $model->create($toCreate);
@@ -372,13 +372,13 @@ class AuthenticationModelTest extends TestCase
      */
     public function testAttemptingToCreateOAuth2ConfigurationWithInvalidDsnRaisesException()
     {
-        $toCreate = array(
+        $toCreate = [
             'dsn'         => 'sqlite:/tmp/' . uniqid() . '/.db',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        );
-        $model = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model = $this->createModelFromConfigArrays([], []);
 
         $this->setExpectedException('ZF\Apigility\Admin\Exception\InvalidArgumentException', 'DSN', 422);
         $model->create($toCreate);
@@ -389,18 +389,18 @@ class AuthenticationModelTest extends TestCase
      */
     public function testAttemptingToUpdateOAuth2ConfigurationWithInvalidDsnRaisesException()
     {
-        $toCreate = array(
+        $toCreate = [
             'dsn'         => 'sqlite::memory:',
             'username'    => 'me',
             'password'    => 'too',
             'route_match' => '/api/oauth',
-        );
-        $model = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model = $this->createModelFromConfigArrays([], []);
 
         $model->create($toCreate);
-        $newConfig = array(
+        $newConfig = [
             'dsn' => 'sqlite:/tmp/' . uniqid() . '/.db',
-        );
+        ];
 
         $this->setExpectedException('ZF\Apigility\Admin\Exception\InvalidArgumentException', 'DSN', 422);
         $entity = $model->update($newConfig);
@@ -409,88 +409,88 @@ class AuthenticationModelTest extends TestCase
 
     public function getAuthAdapters()
     {
-        return array(
-            array(
-                array( // global
-                    'zf-mvc-auth' => array(
-                        'authentication' => array(
-                            'map' => array(
+        return [
+            [
+                [ // global
+                    'zf-mvc-auth' => [
+                        'authentication' => [
+                            'map' => [
                                 'Status\V1' => 'test1',
                                 'Status\V2' => 'test2',
                                 'Foo'       => 'test3',
                                 'Bar'       => 'test4'
-                            )
-                        )
-                    ),
-                    'router' => array(
-                        'routes' => array(
-                            'oauth' => array(
+                            ]
+                        ]
+                    ],
+                    'router' => [
+                        'routes' => [
+                            'oauth' => [
                                 'type' => 'regex',
-                                'options' => array(
+                                'options' => [
                                     'regex' => '(?P<oauth>(/oauth_mongo|/oauth_pdo))',
                                     'spec' => '%oauth%'
-                                )
-                            )
-                        )
-                    )
-                ),
-                array( // local
-                    'zf-mvc-auth' => array(
-                        'authentication' => array(
-                            'adapters' => array(
-                                'test1' => array(
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                [ // local
+                    'zf-mvc-auth' => [
+                        'authentication' => [
+                            'adapters' => [
+                                'test1' => [
                                     'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
-                                    'options' => array(
-                                        'accept_schemes' => array('basic'),
+                                    'options' => [
+                                        'accept_schemes' => ['basic'],
                                         'realm' => 'api',
                                         'htpasswd' => 'data/htpasswd'
-                                    )
-                                ),
-                                'test2' => array(
+                                    ]
+                                ],
+                                'test2' => [
                                     'adapter' => 'ZF\MvcAuth\Authentication\HttpAdapter',
-                                    'options' => array(
-                                        'accept_schemes' => array('digest'),
+                                    'options' => [
+                                        'accept_schemes' => ['digest'],
                                         'realm' => 'api',
                                         'digest_domains' => 'domain.com',
                                         'nonce_timeout' => 3600,
                                         'htdigest' => 'data/htpasswd',
 
-                                    )
-                                ),
-                                'test3' => array(
+                                    ]
+                                ],
+                                'test3' => [
                                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
-                                    'storage' => array(
+                                    'storage' => [
                                         'adapter' => 'pdo',
                                         'route' => '/oauth_pdo',
                                         'dsn' => 'mysql:host=localhost;dbname=oauth2',
                                         'username' => 'test',
                                         'password' => 'test',
-                                        'options' => array(
+                                        'options' => [
                                             1002 => 'SET NAMES utf8'
-                                        )
-                                    )
-                                ),
-                                'test4' => array(
+                                        ]
+                                    ]
+                                ],
+                                'test4' => [
                                     'adapter' => 'ZF\MvcAuth\Authentication\OAuth2Adapter',
-                                    'storage' => array(
+                                    'storage' => [
                                         'adapter' => 'mongo',
                                         'route' => '/oauth_mongo',
                                         'locator_name' => 'SomeServiceName',
                                         'dsn' => 'mongodb://localhost',
                                         'database' => 'oauth2',
-                                        'options' => array(
+                                        'options' => [
                                             'username' => 'username',
                                             'password' => 'password',
                                             'connectTimeoutMS' => 500,
-                                        )
-                                    )
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-        );
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
     }
 
     /**
@@ -546,22 +546,22 @@ class AuthenticationModelTest extends TestCase
 
     public function getDataForAuthAdapters()
     {
-        return array(
-            array(
+        return [
+            [
                 'name' => 'test10',
                 'type' => 'basic',
                 'realm' => 'api',
                 'htpasswd' => __DIR__ . '/TestAsset/htpasswd'
-            ),
-            array(
+            ],
+            [
                 'name'           => 'test11',
                 'type'           => 'digest',
                 'realm'          => 'api',
                 'digest_domains' => 'domain.com',
                 'nonce_timeout'  => 3600,
                 'htdigest'       => __DIR__ . '/TestAsset/htdigest'
-            ),
-            array(
+            ],
+            [
                 'name'            => 'test12',
                 'type'            => 'oauth2',
                 'oauth2_type'     => 'pdo',
@@ -569,11 +569,11 @@ class AuthenticationModelTest extends TestCase
                 'oauth2_route'    => '/oauth12',
                 'oauth2_username' => null,
                 'oauth2_password' => null,
-                'oauth2_options'  => array(
+                'oauth2_options'  => [
                     'foo' => 'bar'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'name'                => 'test13',
                 'type'                => 'oauth2',
                 'oauth2_type'         => 'mongo',
@@ -581,11 +581,11 @@ class AuthenticationModelTest extends TestCase
                 'oauth2_database'     => 'zf-apigility-admin-test',
                 'oauth2_route'        => '/oauth13',
                 'oauth2_locator_name' => null,
-                'oauth2_options'  => array(
+                'oauth2_options'  => [
                     'foo' => 'bar'
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     /**
@@ -664,7 +664,7 @@ class AuthenticationModelTest extends TestCase
      */
     public function testGetAuthenticationMap($global, $local)
     {
-        $model = $this->createModelFromConfigArrays($global, array());
+        $model = $this->createModelFromConfigArrays($global, []);
 
         $result = $model->getAuthenticationMap('Status', 1);
         $this->assertEquals($global['zf-mvc-auth']['authentication']['map']['Status\V1'], $result);
@@ -741,54 +741,54 @@ class AuthenticationModelTest extends TestCase
 
     public function getOldAuthenticationConfig()
     {
-        return array(
-            'http_basic' => array(
-                'zf-mvc-auth' => array(
-                    'authentication' => array(
-                        'http' => array(
-                            'accept_schemes' => array('basic'),
+        return [
+            'http_basic' => [
+                'zf-mvc-auth' => [
+                    'authentication' => [
+                        'http' => [
+                            'accept_schemes' => ['basic'],
                             'realm' => 'My Web Site',
                             'htpasswd' => __DIR__ . '/TestAsset/htpasswd'
-                        )
-                    )
-                )
-            ),
-            'http_digest' => array(
-                'zf-mvc-auth' => array(
-                    'authentication' => array(
-                        'http' => array(
-                            'accept_schemes' => array('digest'),
+                        ]
+                    ]
+                ]
+            ],
+            'http_digest' => [
+                'zf-mvc-auth' => [
+                    'authentication' => [
+                        'http' => [
+                            'accept_schemes' => ['digest'],
                             'realm' => 'My Web Site',
                             'digest_domains' => 'domain.com',
                             'nonce_timeout' => 3600,
                             'htdigest' => __DIR__ . '/TestAsset/htdigest'
-                        )
-                    )
-                )
-            ),
-            'oauth2_pdo' => array(
-                'zf-oauth2' => array(
+                        ]
+                    ]
+                ]
+            ],
+            'oauth2_pdo' => [
+                'zf-oauth2' => [
                     'storage' => 'ZF\\OAuth2\\Adapter\\PdoAdapter',
-                    'db' => array(
+                    'db' => [
                         'dsn_type'  => 'PDO',
                         'dsn'       => 'sqlite:/' . __DIR__ . '/TestAsset/db.sqlite',
                         'username'  => null,
                         'password'  => null
-                    )
-                )
-            ),
-            'oauth2_mongo' => array(
-                'zf-oauth2' => array(
+                    ]
+                ]
+            ],
+            'oauth2_mongo' => [
+                'zf-oauth2' => [
                     'storage' => 'ZF\\OAuth2\\Adapter\\MongoAdapter',
-                    'mongo' => array(
+                    'mongo' => [
                         'dsn_type'     => 'Mongo',
                         'dsn'          => 'mongodb://localhost',
                         'database'     => 'zf-apigility-admin-test',
                         'locator_name' => 'MongoDB'
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
     }
 
     /**
@@ -797,17 +797,17 @@ class AuthenticationModelTest extends TestCase
      */
     public function testTransformAuthPerApis()
     {
-        $global = array(
-            'router' => array(
-                'routes' => array(
-                    'oauth' => array(
-                        'options' => array(
+        $global = [
+            'router' => [
+                'routes' => [
+                    'oauth' => [
+                        'options' => [
                             'route' => '/oauth'
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
         foreach ($this->getOldAuthenticationConfig() as $name => $local) {
             $model = $this->createModelFromConfigArrays($global, $local);

--- a/test/Model/AuthorizationEntityTest.php
+++ b/test/Model/AuthorizationEntityTest.php
@@ -13,36 +13,36 @@ class AuthorizationEntityTest extends TestCase
 {
     protected function getSeedValuesForEntity()
     {
-        return array(
-            'Foo\V1\Rest\Session\Controller::__entity__' => array(
+        return [
+            'Foo\V1\Rest\Session\Controller::__entity__' => [
                 'GET' => true,
                 'POST' => true,
                 'PATCH' => true,
                 'PUT' => false,
                 'DELETE' => false,
-            ),
-            'Foo\V1\Rest\Session\Controller::__collection__' => array(
+            ],
+            'Foo\V1\Rest\Session\Controller::__collection__' => [
                 'GET' => true,
                 'POST' => false,
                 'PATCH' => false,
                 'PUT' => false,
                 'DELETE' => false,
-            ),
-            'Foo\V1\Rpc\Message\Controller::message' => array(
+            ],
+            'Foo\V1\Rpc\Message\Controller::message' => [
                 'GET' => true,
                 'POST' => true,
                 'PATCH' => false,
                 'PUT' => false,
                 'DELETE' => false,
-            ),
-            'Foo\V1\Rpc\Message\Controller::translate' => array(
+            ],
+            'Foo\V1\Rpc\Message\Controller::translate' => [
                 'GET' => true,
                 'POST' => true,
                 'PATCH' => false,
                 'PUT' => false,
                 'DELETE' => false,
-            ),
-        );
+            ],
+        ];
     }
 
     public function testEntityIsIterable()
@@ -57,7 +57,7 @@ class AuthorizationEntityTest extends TestCase
         $values = $this->getSeedValuesForEntity();
         $entity = new AuthorizationEntity($values);
 
-        $keys = array();
+        $keys = [];
         foreach ($entity as $key => $value) {
             $keys[] = $key;
         }
@@ -70,7 +70,7 @@ class AuthorizationEntityTest extends TestCase
         $values = $this->getSeedValuesForEntity();
         $entity = new AuthorizationEntity($values);
 
-        $keys = array();
+        $keys = [];
         foreach ($entity as $key => $value) {
             $keys[] = $key;
         }
@@ -81,22 +81,22 @@ class AuthorizationEntityTest extends TestCase
     public function testCanAddARestServiceAtATime()
     {
         $entity = new AuthorizationEntity();
-        $entity->addRestService('Foo\V1\Rest\Session\Controller', AuthorizationEntity::TYPE_ENTITY, array(
+        $entity->addRestService('Foo\V1\Rest\Session\Controller', AuthorizationEntity::TYPE_ENTITY, [
             'GET' => true,
             'POST' => true,
             'PATCH' => true,
             'PUT' => false,
             'DELETE' => false,
-        ));
-        $entity->addRestService('Foo\V1\Rest\Session\Controller', AuthorizationEntity::TYPE_COLLECTION, array(
+        ]);
+        $entity->addRestService('Foo\V1\Rest\Session\Controller', AuthorizationEntity::TYPE_COLLECTION, [
             'GET' => true,
             'POST' => false,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ));
+        ]);
 
-        $keys = array();
+        $keys = [];
         foreach ($entity as $key => $value) {
             $keys[] = $key;
         }
@@ -107,22 +107,22 @@ class AuthorizationEntityTest extends TestCase
     public function testCanAddAnRpcServiceAtATime()
     {
         $entity = new AuthorizationEntity();
-        $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'message', array(
+        $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'message', [
             'GET' => true,
             'POST' => true,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ));
-        $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'translate', array(
+        ]);
+        $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'translate', [
             'GET' => true,
             'POST' => true,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ));
+        ]);
 
-        $keys = array();
+        $keys = [];
         foreach ($entity as $key => $value) {
             $keys[] = $key;
         }
@@ -133,22 +133,22 @@ class AuthorizationEntityTest extends TestCase
     public function testCanRetrieveNamedServices()
     {
         $entity = new AuthorizationEntity();
-        $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'message', array(
+        $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'message', [
             'GET' => true,
             'POST' => true,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ));
+        ]);
         $this->assertTrue($entity->has('Foo\V1\Rpc\Message\Controller::message'));
         $privileges = $entity->get('Foo\V1\Rpc\Message\Controller::message');
-        $this->assertEquals(array(
+        $this->assertEquals([
             'GET' => true,
             'POST' => true,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ), $privileges);
+        ], $privileges);
     }
 
     public function testAddingARestServiceWithoutHttpMethodsProvidesDefaults()
@@ -157,13 +157,13 @@ class AuthorizationEntityTest extends TestCase
         $entity->addRestService('Foo\V1\Rest\Session\Controller', AuthorizationEntity::TYPE_ENTITY);
         $this->assertTrue($entity->has('Foo\V1\Rest\Session\Controller::__entity__'));
         $privileges = $entity->get('Foo\V1\Rest\Session\Controller::__entity__');
-        $this->assertEquals(array(
+        $this->assertEquals([
             'GET' => false,
             'POST' => false,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ), $privileges);
+        ], $privileges);
     }
 
     public function testAddingAnRpcServiceWithoutHttpMethodsProvidesDefaults()
@@ -172,12 +172,12 @@ class AuthorizationEntityTest extends TestCase
         $entity->addRpcService('Foo\V1\Rpc\Message\Controller', 'message');
         $this->assertTrue($entity->has('Foo\V1\Rpc\Message\Controller::message'));
         $privileges = $entity->get('Foo\V1\Rpc\Message\Controller::message');
-        $this->assertEquals(array(
+        $this->assertEquals([
             'GET' => false,
             'POST' => false,
             'PATCH' => false,
             'PUT' => false,
             'DELETE' => false,
-        ), $privileges);
+        ], $privileges);
     }
 }

--- a/test/Model/AuthorizationModelTest.php
+++ b/test/Model/AuthorizationModelTest.php
@@ -29,7 +29,7 @@ class AuthorizationModelTest extends TestCase
      */
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -57,12 +57,12 @@ class AuthorizationModelTest extends TestCase
         $this->module = $module;
         $this->cleanUpAssets();
 
-        $modules = array(
+        $modules = [
             'FooConf'            => new FooConf\Module(),
             'AuthConf'           => new AuthConf\Module(),
             'AuthConfDefaults'   => new AuthConfDefaults\Module(),
             'AuthConfWithConfig' => new AuthConfWithConfig\Module(),
-        );
+        ];
 
         $this->moduleEntity  = new ModuleEntity($this->module);
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
@@ -90,13 +90,13 @@ class AuthorizationModelTest extends TestCase
 
     public function assertDefaultPrivileges(array $privileges)
     {
-        $this->assertEquals(array(
+        $this->assertEquals([
             'GET' => false,
             'POST' => false,
             'PUT' => false,
             'PATCH' => false,
             'DELETE' => false,
-        ), $privileges);
+        ], $privileges);
     }
 
     protected function mapConfigToPayload(array $config)
@@ -124,7 +124,7 @@ class AuthorizationModelTest extends TestCase
 
     protected function mapEntityToConfig(AuthorizationEntity $entity)
     {
-        $normalized = array();
+        $normalized = [];
         foreach ($entity->getArrayCopy() as $spec => $privileges) {
             preg_match('/^(?P<service>[^:]+)(::(?P<action>.*))?$/', $spec, $matches);
             if (!isset($matches['action'])) {
@@ -153,15 +153,15 @@ class AuthorizationModelTest extends TestCase
         $entity = $this->model->fetch();
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\AuthorizationEntity', $entity);
         $this->assertEquals(6, count($entity));
-        $expected = array(
+        $expected = [
             'AuthConf\V1\Rest\Foo\Controller::__entity__',
             'AuthConf\V1\Rest\Foo\Controller::__collection__',
             'AuthConf\V1\Rest\Bar\Controller::__entity__',
             'AuthConf\V1\Rest\Bar\Controller::__collection__',
             'AuthConf\V1\Rpc\Baz\Controller::baz',
             'AuthConf\V1\Rpc\Bat\Controller::bat',
-        );
-        $actual = array();
+        ];
+        $actual = [];
         foreach ($entity as $serviceName => $privileges) {
             $actual[] = $serviceName;
             $this->assertDefaultPrivileges($privileges);
@@ -184,7 +184,7 @@ class AuthorizationModelTest extends TestCase
         $entity = $this->model->fetch(2); // <- VERSION!
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\AuthorizationEntity', $entity);
         $this->assertEquals(9, count($entity));
-        $expected = array(
+        $expected = [
             'AuthConf\V2\Rest\Foo\Controller::__entity__',
             'AuthConf\V2\Rest\Foo\Controller::__collection__',
             'AuthConf\V2\Rest\Bar\Controller::__entity__',
@@ -194,8 +194,8 @@ class AuthorizationModelTest extends TestCase
             'AuthConf\V2\Rpc\Baz\Controller::baz',
             'AuthConf\V2\Rpc\Bat\Controller::bat',
             'AuthConf\V2\Rpc\New\Controller::new',
-        );
-        $actual = array();
+        ];
+        $actual = [];
         foreach ($entity as $serviceName => $privileges) {
             $actual[] = $serviceName;
             $this->assertDefaultPrivileges($privileges);

--- a/test/Model/ContentNegotiationResourceTest.php
+++ b/test/Model/ContentNegotiationResourceTest.php
@@ -63,13 +63,13 @@ class ContentNegotiationResourceTest extends TestCase
 
     public function testCreateShouldAcceptContentNameAndReturnNewEntity()
     {
-        $data = array('content_name' => 'Test');
-        $resource = $this->createResourceFromConfigArray(array());
+        $data = ['content_name' => 'Test'];
+        $resource = $this->createResourceFromConfigArray([]);
         $createFilter = new CreateContentNegotiationInputFilter();
         $createFilter->setData($data);
         $resource->setInputFilter($createFilter);
 
-        $entity = $resource->create(array());
+        $entity = $resource->create([]);
 
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
         $this->assertEquals('Test', $entity->name);
@@ -77,25 +77,25 @@ class ContentNegotiationResourceTest extends TestCase
 
     public function testUpdateShouldAcceptContentNameAndSelectorsAndReturnUpdatedEntity()
     {
-        $data = array('content_name' => 'Test');
-        $resource = $this->createResourceFromConfigArray(array());
+        $data = ['content_name' => 'Test'];
+        $resource = $this->createResourceFromConfigArray([]);
         $createFilter = new CreateContentNegotiationInputFilter();
         $createFilter->setData($data);
         $resource->setInputFilter($createFilter);
 
-        $entity = $resource->create(array());
+        $entity = $resource->create([]);
 
-        $data = array('selectors' => array(
-            'Zend\View\Model\ViewModel' => array(
+        $data = ['selectors' => [
+            'Zend\View\Model\ViewModel' => [
                 'text/html',
                 'application/xhtml+xml',
-            ),
-        ));
+            ],
+        ]];
         $updateFilter = new ContentNegotiationInputFilter();
         $updateFilter->setData($data);
         $resource->setInputFilter($updateFilter);
 
-        $entity = $resource->patch('Test', array());
+        $entity = $resource->patch('Test', []);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ContentNegotiationEntity', $entity);
         $this->assertEquals('Test', $entity->name);
         $this->assertEquals($data['selectors'], $entity->config);

--- a/test/Model/ContentNegotiationTest.php
+++ b/test/Model/ContentNegotiationTest.php
@@ -84,13 +84,13 @@ class ContentNegotiationTest extends TestCase
 
     public function testCreateContentNegotiation()
     {
-        $toCreate = array(
-            'ZF\ContentNegotiation\JsonModel' => array(
+        $toCreate = [
+            'ZF\ContentNegotiation\JsonModel' => [
                 'application/json',
                 'application/*+json',
-            ),
-        );
-        $model = $this->createModelFromConfigArray(array());
+            ],
+        ];
+        $model = $this->createModelFromConfigArray([]);
         $model->create('Json', $toCreate);
 
         $global = include $this->globalConfigPath;
@@ -99,20 +99,20 @@ class ContentNegotiationTest extends TestCase
 
     public function testUpdateContentNegotiation()
     {
-        $toCreate = array(
-           'ZF\ContentNegotiation\JsonModel' => array(
+        $toCreate = [
+           'ZF\ContentNegotiation\JsonModel' => [
                 'application/json',
                 'application/*+json',
-            ),
-        );
-        $model = $this->createModelFromConfigArray(array());
+            ],
+        ];
+        $model = $this->createModelFromConfigArray([]);
         $model->create('Json', $toCreate);
 
-        $toUpdate = array(
-            'ZF\ContentNegotiation\JsonModel' => array(
+        $toUpdate = [
+            'ZF\ContentNegotiation\JsonModel' => [
                 'application/json',
-            ),
-        );
+            ],
+        ];
         $model->update('Json', $toUpdate);
         $global = include $this->globalConfigPath;
         $this->assertContentConfigEquals($toUpdate, 'Json', $global);
@@ -120,13 +120,13 @@ class ContentNegotiationTest extends TestCase
 
     public function testRemoveContentNegotiation()
     {
-        $toCreate = array(
-           'ZF\ContentNegotiation\JsonModel' => array(
+        $toCreate = [
+           'ZF\ContentNegotiation\JsonModel' => [
                 'application/json',
                 'application/*+json',
-            ),
-        );
-        $model = $this->createModelFromConfigArray(array());
+            ],
+        ];
+        $model = $this->createModelFromConfigArray([]);
         $model->create('Json', $toCreate);
 
         $model->remove('Json');
@@ -136,20 +136,20 @@ class ContentNegotiationTest extends TestCase
 
     public function testFetchAllContentNegotiation()
     {
-        $toCreate = array(
-            'ZF\ContentNegotiation\JsonModel' => array(
+        $toCreate = [
+            'ZF\ContentNegotiation\JsonModel' => [
                 'application/json',
                 'application/*+json',
-            ),
-        );
-        $model = $this->createModelFromConfigArray(array());
+            ],
+        ];
+        $model = $this->createModelFromConfigArray([]);
         $model->create('Json', $toCreate);
 
-        $toCreate2 = array(
-            'ZF\ContentNegotiation\FooModel' => array(
+        $toCreate2 = [
+            'ZF\ContentNegotiation\FooModel' => [
                 'application/foo',
-            ),
-        );
+            ],
+        ];
         $model->create('Foo', $toCreate2);
 
         $global = include $this->globalConfigPath;
@@ -165,13 +165,13 @@ class ContentNegotiationTest extends TestCase
 
     public function testFetchContentNegotiation()
     {
-        $toCreate = array(
-            'ZF\ContentNegotiation\JsonModel' => array(
+        $toCreate = [
+            'ZF\ContentNegotiation\JsonModel' => [
                 'application/json',
                 'application/*+json',
-            ),
-        );
-        $model = $this->createModelFromConfigArray(array());
+            ],
+        ];
+        $model = $this->createModelFromConfigArray([]);
         $model->create('Json', $toCreate);
 
         $content = $model->fetch('Json');

--- a/test/Model/DbAdapterModelTest.php
+++ b/test/Model/DbAdapterModelTest.php
@@ -96,33 +96,33 @@ class DbAdapterModelTest extends TestCase
      */
     public function testCreatesBothGlobalAndLocalDbConfigWhenNoneExistedPreviously()
     {
-        $toCreate = array(
+        $toCreate = [
             'driver'   => 'Pdo_Sqlite',
             'database' => __FILE__,
             'dsn'      => '',
-        );
+        ];
 
-        $model = $this->createModelFromConfigArrays(array(), array());
+        $model = $this->createModelFromConfigArrays([], []);
         $model->create('Db\New', $toCreate);
 
         $global = include $this->globalConfigPath;
-        $this->assertDbConfigEquals(array(), 'Db\New', $global);
+        $this->assertDbConfigEquals([], 'Db\New', $global);
 
         $local  = include $this->localConfigPath;
-        $this->assertDbConfigEquals(array(
+        $this->assertDbConfigEquals([
             'driver'   => 'Pdo_Sqlite',
             'database' => __FILE__,
-        ), 'Db\New', $local);
+        ], 'Db\New', $local);
     }
 
     public function testCreateDoesNotCreateEmptyDsnEntry()
     {
-        $toCreate = array('driver' => 'Pdo_Sqlite', 'database' => __FILE__);
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $toCreate = ['driver' => 'Pdo_Sqlite', 'database' => __FILE__];
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create('Db\New', $toCreate);
 
         $global = include $this->globalConfigPath;
-        $this->assertDbConfigEquals(array(), 'Db\New', $global);
+        $this->assertDbConfigEquals([], 'Db\New', $global);
 
         $local  = include $this->localConfigPath;
         $this->assertDbConfigEquals($toCreate, 'Db\New', $local);
@@ -130,29 +130,29 @@ class DbAdapterModelTest extends TestCase
 
     public function testCreatesNewEntriesInBothGlobalAndLocalDbConfigWhenConfigExistedPreviously()
     {
-        $globalSeedConfig = array(
-            'db' => array(
-                'adapters' => array(
-                    'Db\Old' => array(),
-                ),
-            ),
-        );
-        $localSeedConfig = array(
-            'db' => array(
-                'adapters' => array(
-                    'Db\Old' => array(
+        $globalSeedConfig = [
+            'db' => [
+                'adapters' => [
+                    'Db\Old' => [],
+                ],
+            ],
+        ];
+        $localSeedConfig = [
+            'db' => [
+                'adapters' => [
+                    'Db\Old' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $model = $this->createModelFromConfigArrays($globalSeedConfig, $localSeedConfig);
-        $model->create('Db\New', array('driver' => 'Pdo_Sqlite', 'database' => __FILE__));
+        $model->create('Db\New', ['driver' => 'Pdo_Sqlite', 'database' => __FILE__]);
 
         $global = include $this->globalConfigPath;
-        $this->assertDbConfigEquals(array(), 'Db\Old', $global);
-        $this->assertDbConfigEquals(array(), 'Db\New', $global);
+        $this->assertDbConfigEquals([], 'Db\Old', $global);
+        $this->assertDbConfigEquals([], 'Db\New', $global);
 
         $local  = include $this->localConfigPath;
         $this->assertDbConfigEquals($localSeedConfig['db']['adapters']['Db\Old'], 'Db\Old', $local);
@@ -161,77 +161,77 @@ class DbAdapterModelTest extends TestCase
 
     public function testCanRetrieveListOfAllConfiguredAdapters()
     {
-        $globalSeedConfig = array(
-            'db' => array(
-                'adapters' => array(
-                    'Db\Old'   => array(),
-                    'Db\New'   => array(),
-                    'Db\Newer' => array(),
-                ),
-            ),
-        );
-        $localSeedConfig = array(
-            'db' => array(
-                'adapters' => array(
-                    'Db\Old' => array(
+        $globalSeedConfig = [
+            'db' => [
+                'adapters' => [
+                    'Db\Old'   => [],
+                    'Db\New'   => [],
+                    'Db\Newer' => [],
+                ],
+            ],
+        ];
+        $localSeedConfig = [
+            'db' => [
+                'adapters' => [
+                    'Db\Old' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                    'Db\New' => array(
+                    ],
+                    'Db\New' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                    'Db\Newer' => array(
+                    ],
+                    'Db\Newer' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $model        = $this->createModelFromConfigArrays($globalSeedConfig, $localSeedConfig);
         $adapters     = $model->fetchAll();
-        $adapterNames = array();
+        $adapterNames = [];
         foreach ($adapters as $adapter) {
             $this->assertInstanceOf('ZF\Apigility\Admin\Model\DbAdapterEntity', $adapter);
             $adapter = $adapter->getArrayCopy();
             $adapterNames[] = $adapter['adapter_name'];
         }
-        $this->assertEquals(array(
+        $this->assertEquals([
             'Db\Old',
             'Db\New',
             'Db\Newer',
-        ), $adapterNames);
+        ], $adapterNames);
     }
 
     public function testCanRetrieveIndividualAdapterDetails()
     {
-        $globalSeedConfig = array(
-            'db' => array(
-                'adapters' => array(
-                    'Db\Old'   => array(),
-                    'Db\New'   => array(),
-                    'Db\Newer' => array(),
-                ),
-            ),
-        );
-        $localSeedConfig = array(
-            'db' => array(
-                'adapters' => array(
-                    'Db\Old' => array(
+        $globalSeedConfig = [
+            'db' => [
+                'adapters' => [
+                    'Db\Old'   => [],
+                    'Db\New'   => [],
+                    'Db\Newer' => [],
+                ],
+            ],
+        ];
+        $localSeedConfig = [
+            'db' => [
+                'adapters' => [
+                    'Db\Old' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                    'Db\New' => array(
+                    ],
+                    'Db\New' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                    'Db\Newer' => array(
+                    ],
+                    'Db\Newer' => [
                         'driver'   => 'Pdo_Sqlite',
                         'database' => __FILE__,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $model       = $this->createModelFromConfigArrays($globalSeedConfig, $localSeedConfig);
         $adapter     = $model->fetch('Db\New');
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\DbAdapterEntity', $adapter);
@@ -243,22 +243,22 @@ class DbAdapterModelTest extends TestCase
 
     public function testUpdatesLocalDbConfigWhenUpdating()
     {
-        $toCreate = array('driver' => 'Pdo_Sqlite', 'database' => __FILE__);
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $toCreate = ['driver' => 'Pdo_Sqlite', 'database' => __FILE__];
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create('Db\New', $toCreate);
 
-        $newConfig = array(
+        $newConfig = [
             'driver'   => 'Pdo_Mysql',
             'database' => 'zf_apigility',
             'username' => 'username',
             'password' => 'password',
-        );
+        ];
         $entity = $model->update('Db\New', $newConfig);
 
         // Ensure the entity returned from the update is what we expect
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\DbAdapterEntity', $entity);
         $entity = $entity->getArrayCopy();
-        $expected = array_merge(array('adapter_name' => 'Db\New'), $newConfig);
+        $expected = array_merge(['adapter_name' => 'Db\New'], $newConfig);
         $this->assertEquals($expected, $entity);
 
         // Ensure fetching the entity after an update will return what we expect
@@ -268,8 +268,8 @@ class DbAdapterModelTest extends TestCase
 
     public function testRemoveDeletesConfigurationFromBothLocalAndGlobalConfigFiles()
     {
-        $toCreate = array('driver' => 'Pdo_Sqlite', 'database' => __FILE__);
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        $toCreate = ['driver' => 'Pdo_Sqlite', 'database' => __FILE__];
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create('Db\New', $toCreate);
 
         $model->remove('Db\New');
@@ -281,10 +281,10 @@ class DbAdapterModelTest extends TestCase
 
     public function postgresDbTypes()
     {
-        return array(
-            'pdo'    => array('Pdo_Pgsql'),
-            'native' => array('Pgsql'),
-        );
+        return [
+            'pdo'    => ['Pdo_Pgsql'],
+            'native' => ['Pgsql'],
+        ];
     }
 
     /**
@@ -293,14 +293,14 @@ class DbAdapterModelTest extends TestCase
      */
     public function testCreatingPostgresConfigDoesNotIncludeCharset($driver)
     {
-        $toCreate = array(
+        $toCreate = [
             'driver' => $driver,
             'database' => 'test',
             'username' => 'test',
             'password' => 'test',
             'charset' => 'UTF-8',
-        );
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create('Db\New', $toCreate);
 
         $local  = include $this->localConfigPath;
@@ -317,29 +317,29 @@ class DbAdapterModelTest extends TestCase
      */
     public function testUpdatingPostgresConfigDoesNotAllowCharset($driver)
     {
-        $toCreate = array(
+        $toCreate = [
             'driver' => $driver,
             'database' => 'test',
             'username' => 'test',
             'password' => 'test',
             'charset' => 'UTF-8',
-        );
-        $model    = $this->createModelFromConfigArrays(array(), array());
+        ];
+        $model    = $this->createModelFromConfigArrays([], []);
         $model->create('Db\New', $toCreate);
 
-        $newConfig = array(
+        $newConfig = [
             'driver'   => $driver,
             'database' => 'zf_apigility',
             'username' => 'test',
             'password' => 'test',
             'charset'  => 'latin-1',
-        );
+        ];
         $entity = $model->update('Db\New', $newConfig);
 
         // Ensure the entity returned from the update is what we expect
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\DbAdapterEntity', $entity);
         $entity = $entity->getArrayCopy();
-        $expected = array_merge(array('adapter_name' => 'Db\New'), $newConfig);
+        $expected = array_merge(['adapter_name' => 'Db\New'], $newConfig);
         unset($expected['charset']);
 
         $this->assertEquals($expected, $entity);

--- a/test/Model/DbConnectedRestServiceModelTest.php
+++ b/test/Model/DbConnectedRestServiceModelTest.php
@@ -30,7 +30,7 @@ class DbConnectedRestServiceModelTest extends TestCase
      */
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -58,11 +58,11 @@ class DbConnectedRestServiceModelTest extends TestCase
         $this->module = 'BarConf';
         $this->cleanUpAssets();
 
-        $modules = array(
+        $modules = [
             'BarConf' => new BarConf\Module()
-        );
+        ];
 
-        $this->moduleEntity  = new ModuleEntity($this->module, array(), array(), false);
+        $this->moduleEntity  = new ModuleEntity($this->module, [], [], false);
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                                     ->disableOriginalConstructor()
                                     ->getMock();
@@ -80,7 +80,7 @@ class DbConnectedRestServiceModelTest extends TestCase
             $this->resource->factory('BarConf')
         );
         $this->model    = new DbConnectedRestServiceModel($this->codeRest);
-        $this->codeRest->getEventManager()->attach('fetch', array($this->model, 'onFetch'));
+        $this->codeRest->getEventManager()->attach('fetch', [$this->model, 'onFetch']);
     }
 
     public function tearDown()
@@ -91,20 +91,20 @@ class DbConnectedRestServiceModelTest extends TestCase
     public function getCreationPayload()
     {
         $payload = new DbConnectedRestServiceEntity();
-        $payload->exchangeArray(array(
+        $payload->exchangeArray([
             'adapter_name'               => 'DB\Barbaz',
             'table_name'                 => 'barbaz',
             'hydrator_name'              => 'ObjectProperty',
             'entity_identifier_name'     => 'barbaz_id',
-            'resource_http_methods'      => array('GET', 'PATCH'),
-            'collection_http_methods'    => array('GET', 'POST'),
-            'collection_query_whitelist' => array('sort', 'filter'),
+            'resource_http_methods'      => ['GET', 'PATCH'],
+            'collection_http_methods'    => ['GET', 'POST'],
+            'collection_query_whitelist' => ['sort', 'filter'],
             'page_size'                  => 10,
             'page_size_param'            => 'p',
             'selector'                   => 'HalJson',
-            'accept_whitelist'           => array('application/json', 'application/*+json'),
-            'content_type_whitelist'     => array('application/json'),
-        ));
+            'accept_whitelist'           => ['application/json', 'application/*+json'],
+            'content_type_whitelist'     => ['application/json'],
+        ]);
         return $payload;
     }
 
@@ -198,22 +198,22 @@ class DbConnectedRestServiceModelTest extends TestCase
 
     public function testOnFetchWillRecastEntityToDbConnectedIfDbConnectedConfigurationExists()
     {
-        $originalData = array(
+        $originalData = [
             'controller_service_name' => 'BarConf\Rest\Barbaz\Controller',
             'resource_class'          => 'BarConf\Rest\Barbaz\BarbazResource',
             'route_name'              => 'bar-conf.rest.barbaz',
             'route_match'             => '/api/barbaz',
             'entity_class'            => 'BarConf\Rest\Barbaz\BarbazEntity',
-        );
+        ];
         $entity = new RestServiceEntity();
         $entity->exchangeArray($originalData);
-        $config = array( 'zf-apigility' => array('db-connected' => array(
-            'BarConf\Rest\Barbaz\BarbazResource' => array(
+        $config = [ 'zf-apigility' => ['db-connected' => [
+            'BarConf\Rest\Barbaz\BarbazResource' => [
                 'adapter_name'  => 'Db\Barbaz',
                 'table_name'    => 'barbaz',
                 'hydrator_name' => 'ObjectProperty',
-            ),
-        )));
+            ],
+        ]]];
 
         $event = new Event();
         $event->setParam('entity', $entity);
@@ -249,22 +249,22 @@ class DbConnectedRestServiceModelTest extends TestCase
      */
     public function testOnFetchWillRetainResourceClassIfEventFetchFlagIsFalse()
     {
-        $originalData = array(
+        $originalData = [
             'controller_service_name' => 'BarConf\Rest\Barbaz\Controller',
             'resource_class'          => 'BarConf\Rest\Barbaz\BarbazResource',
             'route_name'              => 'bar-conf.rest.barbaz',
             'route_match'             => '/api/barbaz',
             'entity_class'            => 'BarConf\Rest\Barbaz\BarbazEntity',
-        );
+        ];
         $entity = new RestServiceEntity();
         $entity->exchangeArray($originalData);
-        $config = array( 'zf-apigility' => array('db-connected' => array(
-            'BarConf\Rest\Barbaz\BarbazResource' => array(
+        $config = [ 'zf-apigility' => ['db-connected' => [
+            'BarConf\Rest\Barbaz\BarbazResource' => [
                 'adapter_name'  => 'Db\Barbaz',
                 'table_name'    => 'barbaz',
                 'hydrator_name' => 'ObjectProperty',
-            ),
-        )));
+            ],
+        ]]];
 
         $event = new Event();
         $event->setParam('entity', $entity);
@@ -284,11 +284,11 @@ class DbConnectedRestServiceModelTest extends TestCase
         $originalEntity = $this->getCreationPayload();
         $this->model->createService($originalEntity);
 
-        $newProps = array(
+        $newProps = [
             'table_service' => 'My\Custom\Table',
             'adapter_name'  => 'My\Db',
             'hydrator_name' => 'ClassMethods',
-        );
+        ];
         $originalEntity->exchangeArray($newProps);
         $result = $this->model->updateService($originalEntity);
 
@@ -304,11 +304,11 @@ class DbConnectedRestServiceModelTest extends TestCase
         $originalEntity = $this->getCreationPayload();
         $this->model->createService($originalEntity);
 
-        $newProps = array(
+        $newProps = [
             'table_service' => 'My\Custom\Table',
             'adapter_name'  => 'My\Db',
             'hydrator_name' => 'ClassMethods',
-        );
+        ];
         $originalEntity->exchangeArray($newProps);
         $result = $this->model->updateService($originalEntity);
 
@@ -339,10 +339,10 @@ class DbConnectedRestServiceModelTest extends TestCase
         $originalEntity = $this->getCreationPayload();
         $this->model->createService($originalEntity);
 
-        $newProps = array(
+        $newProps = [
             'entity_identifier_name' => 'id',
             'hydrator_name'          => 'Zend\\Stdlib\\Hydrator\\ClassMethods',
-        );
+        ];
         $originalEntity->exchangeArray($newProps);
         $result = $this->model->updateService($originalEntity);
 
@@ -384,7 +384,7 @@ class DbConnectedRestServiceModelTest extends TestCase
     public function testCreateServiceWithUnderscoreInNameNormalizesClassNamesToCamelCase()
     {
         $originalEntity = $this->getCreationPayload();
-        $originalEntity->exchangeArray(array('table_name' => 'bar_baz'));
+        $originalEntity->exchangeArray(['table_name' => 'bar_baz']);
 
         $result = $this->model->createService($originalEntity);
         $this->assertSame($originalEntity, $result);

--- a/test/Model/DoctrineAdapterEntityTest.php
+++ b/test/Model/DoctrineAdapterEntityTest.php
@@ -13,10 +13,10 @@ class DoctrineAdapterEntityTest extends TestCase
 {
     public function testCanRepresentAnOrmEntity()
     {
-        $config = array(
+        $config = [
             'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
-            'params' => array(),
-        );
+            'params' => [],
+        ];
         $entity = new DoctrineAdapterEntity('test', $config);
         $serialized = $entity->getArrayCopy();
 
@@ -26,9 +26,9 @@ class DoctrineAdapterEntityTest extends TestCase
 
     public function testCanRepresentAnOdmEntity()
     {
-        $config = array(
+        $config = [
             'connectionString' => 'mongodb://localhost:27017',
-        );
+        ];
         $entity = new DoctrineAdapterEntity('test', $config);
         $serialized = $entity->getArrayCopy();
 

--- a/test/Model/DoctrineAdapterModelTest.php
+++ b/test/Model/DoctrineAdapterModelTest.php
@@ -19,40 +19,40 @@ class DoctrineAdapterModelTest extends TestCase
 
     public function getGlobalConfig()
     {
-        return new ConfigResource(array(
-            'doctrine' => array(
-                'entitymanager' => array(
-                    'orm_default' => array(
-                    ),
-                ),
-                'documentationmanager' => array(
-                    'odm_default' => array(
-                    ),
-                ),
-            ),
-        ), 'php://temp', $this->getMockWriter());
+        return new ConfigResource([
+            'doctrine' => [
+                'entitymanager' => [
+                    'orm_default' => [
+                    ],
+                ],
+                'documentationmanager' => [
+                    'odm_default' => [
+                    ],
+                ],
+            ],
+        ], 'php://temp', $this->getMockWriter());
     }
 
     public function getLocalConfig()
     {
-        return new ConfigResource(array(
-            'doctrine' => array(
-                'connection' => array(
-                    'orm_default' => array(
+        return new ConfigResource([
+            'doctrine' => [
+                'connection' => [
+                    'orm_default' => [
                         'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
-                        'params' => array(),
-                    ),
-                    'odm_default' => array(
+                        'params' => [],
+                    ],
+                    'odm_default' => [
                         'connectionString' => 'mongodb://localhost:27017',
-                        'options' => array(),
-                    ),
-                    'odm_dbname' => array(
+                        'options' => [],
+                    ],
+                    'odm_dbname' => [
                         'dbname' => 'test',
-                        'options' => array(),
-                    ),
-                ),
-            ),
-        ), 'php://temp', $this->getMockWriter());
+                        'options' => [],
+                    ],
+                ],
+            ],
+        ], 'php://temp', $this->getMockWriter());
     }
 
     public function testFetchAllReturnsMixOfOrmAndOdmAdapters()

--- a/test/Model/DocumentationModelTest.php
+++ b/test/Model/DocumentationModelTest.php
@@ -23,8 +23,8 @@ class DocumentationModelTest extends \PHPUnit_Framework_TestCase
 
         $mockModuleUtils = $this->getMock(
             'ZF\Configuration\ModuleUtils',
-            array('getModuleConfigPath'),
-            array(),
+            ['getModuleConfigPath'],
+            [],
             '',
             false
         );

--- a/test/Model/InputFilterModelTest.php
+++ b/test/Model/InputFilterModelTest.php
@@ -16,9 +16,9 @@ class InputFilterModelTest extends TestCase
 {
     public function setUp()
     {
-        $modules = array(
+        $modules = [
             'InputFilter' => new \InputFilter\Module()
-        );
+        ];
 
 
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
@@ -61,18 +61,18 @@ class InputFilterModelTest extends TestCase
 
     public function testAddInputFilterExistingController()
     {
-        $inputFilter = array(
-            'bar' => array(
+        $inputFilter = [
+            'bar' => [
                 'name' => 'bar',
                 'required' => true,
                 'allow_empty' => true,
-                'validators' => array(
-                    array(
+                'validators' => [
+                    [
                         'name' => 'NotEmpty',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $result = $this->model->update('InputFilter', 'InputFilter\V1\Rest\Foo\Controller', $inputFilter);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\InputFilterEntity', $result);
         $this->assertEquals(
@@ -84,18 +84,18 @@ class InputFilterModelTest extends TestCase
 
     public function testAddInputFilterNewController()
     {
-        $inputfilter = array(
-            'bar' => array(
+        $inputfilter = [
+            'bar' => [
                 'name' => 'bar',
                 'required' => true,
                 'allow_empty' => true,
-                'validators' => array(
-                    array(
+                'validators' => [
+                    [
                         'name' => 'NotEmpty',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         // new controller
         $controller = 'InputFilter\V1\Rest\Bar\Controller';

--- a/test/Model/ModuleEntityTest.php
+++ b/test/Model/ModuleEntityTest.php
@@ -16,7 +16,7 @@ class ModuleEntityTest extends TestCase
         $moduleEntity = new ModuleEntity('Test\Foo');
         $this->assertSame(1, $moduleEntity->getDefaultVersion()); // initial state
 
-        $moduleEntity->exchangeArray(array('default_version' => 123));
+        $moduleEntity->exchangeArray(['default_version' => 123]);
         $this->assertSame(123, $moduleEntity->getDefaultVersion());
     }
 }

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -23,14 +23,14 @@ class ModuleModelTest extends TestCase
             unset($this->modulePath);
         }
 
-        $modules = array(
+        $modules = [
             'ZFTest\Apigility\Admin\Model\TestAsset\Foa' => new TestAsset\Foa\Module(),
             'ZFTest\Apigility\Admin\Model\TestAsset\Foo' => new TestAsset\Foo\Module(),
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar' => new TestAsset\Bar\Module(),
             'ZFTest\Apigility\Admin\Model\TestAsset\Baz' => new TestAsset\Baz\Module(),
             'ZFTest\Apigility\Admin\Model\TestAsset\Bat' => new TestAsset\Bat\Module(),
             'ZFTest\Apigility\Admin\Model\TestAsset\Bob' => new TestAsset\Bob\Module(),
-        );
+        ];
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                                     ->disableOriginalConstructor()
                                     ->getMock();
@@ -38,21 +38,21 @@ class ModuleModelTest extends TestCase
                             ->method('getLoadedModules')
                             ->will($this->returnValue($modules));
 
-        $restConfig           = array(
+        $restConfig           = [
             'ZFTest\Apigility\Admin\Model\TestAsset\Foo\Controller\Foo' => null, // this should never be returned
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Bar' => null,
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Baz' => null,
             'ZFTest\Apigility\Admin\Model\TestAsset\Bat\Controller\Bat' => null, // this should never be returned
-        );
+        ];
 
-        $rpcConfig          = array(
+        $rpcConfig          = [
             // controller => empty pairs
             'ZFTest\Apigility\Admin\Model\TestAsset\Foo\Controller\Act' => null, // this should never be returned
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Act' => null,
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Do'  => null,
             'ZFTest\Apigility\Admin\Model\TestAsset\Bat\Controller\Act' => null, // this should never be returned
             'ZFTest\Apigility\Admin\Model\TestAsset\Bob\Controller\Do'  => null,
-        );
+        ];
 
         $this->model         = new ModuleModel(
             $this->moduleManager,
@@ -71,11 +71,11 @@ class ModuleModelTest extends TestCase
 
     public function testEnabledModulesOnlyReturnsThoseThatImplementApigilityProviderInterface()
     {
-        $expected = array(
+        $expected = [
             'ZFTest\Apigility\Admin\Model\TestAsset\Bar',
             'ZFTest\Apigility\Admin\Model\TestAsset\Baz',
             'ZFTest\Apigility\Admin\Model\TestAsset\Bob',
-        );
+        ];
 
         $modules = $this->model->getModules();
 
@@ -83,7 +83,7 @@ class ModuleModelTest extends TestCase
         $this->assertEquals(count($expected), count($modules));
 
         // Test that each module name exists in the expected list
-        $moduleNames = array();
+        $moduleNames = [];
         foreach ($modules as $module) {
             $this->assertContains($module->getNamespace(), $expected);
             $moduleNames[] = $module->getNamespace();
@@ -96,10 +96,10 @@ class ModuleModelTest extends TestCase
 
     public function invalidModules()
     {
-        return array(
-            array('ZFTest\Apigility\Admin\Model\TestAsset\Foo'),
-            array('ZFTest\Apigility\Admin\Model\TestAsset\Bat'),
-        );
+        return [
+            ['ZFTest\Apigility\Admin\Model\TestAsset\Foo'],
+            ['ZFTest\Apigility\Admin\Model\TestAsset\Bat'],
+        ];
     }
 
     /**
@@ -113,22 +113,22 @@ class ModuleModelTest extends TestCase
     public function testEmptyArraysAreReturnedWhenGettingServicesForApigilityModulesWithNoServices()
     {
         $module = $this->model->getModule('ZFTest\Apigility\Admin\Model\TestAsset\Baz');
-        $this->assertEquals(array(), $module->getRestServices());
-        $this->assertEquals(array(), $module->getRpcServices());
+        $this->assertEquals([], $module->getRestServices());
+        $this->assertEquals([], $module->getRpcServices());
     }
 
     public function testRestAndRpcControllersAreDiscoveredWhenGettingServicesForApigilityModules()
     {
-        $expected = array(
-            'rest' => array(
+        $expected = [
+            'rest' => [
                 'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Bar',
                 'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Baz',
-            ),
-            'rpc' => array(
+            ],
+            'rpc' => [
                 'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Act',
                 'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Do',
-            ),
-        );
+            ],
+        ];
         $module = $this->model->getModule('ZFTest\Apigility\Admin\Model\TestAsset\Bar');
         $this->assertEquals($expected['rest'], $module->getRestServices());
         $this->assertEquals($expected['rpc'], $module->getRpcServices());
@@ -144,36 +144,36 @@ class ModuleModelTest extends TestCase
             $this->markTestSkipped('Running from a vendor directory.');
         }
 
-        $expected = array(
-            'ZFTest\Apigility\Admin\Model\TestAsset\Bar' => array(
+        $expected = [
+            'ZFTest\Apigility\Admin\Model\TestAsset\Bar' => [
                 'vendor' => false,
-                'rest' => array(
+                'rest' => [
                     'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Bar',
                     'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Baz',
-                ),
-                'rpc' => array(
+                ],
+                'rpc' => [
                     'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Act',
                     'ZFTest\Apigility\Admin\Model\TestAsset\Bar\Controller\Do',
-                ),
-            ),
-            'ZFTest\Apigility\Admin\Model\TestAsset\Baz' => array(
+                ],
+            ],
+            'ZFTest\Apigility\Admin\Model\TestAsset\Baz' => [
                 'vendor' => false,
-                'rest' => array(),
-                'rpc'  => array(),
-            ),
-            'ZFTest\Apigility\Admin\Model\TestAsset\Bob' => array(
+                'rest' => [],
+                'rpc'  => [],
+            ],
+            'ZFTest\Apigility\Admin\Model\TestAsset\Bob' => [
                 'vendor' => false,
-                'rest' => array(
-                ),
-                'rpc' => array(
+                'rest' => [
+                ],
+                'rpc' => [
                     'ZFTest\Apigility\Admin\Model\TestAsset\Bob\Controller\Do',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $modules = $this->model->getModules();
 
-        $unique  = array();
+        $unique  = [];
         foreach ($modules as $module) {
             $name = $module->getNamespace();
             $this->assertArrayHasKey(
@@ -397,7 +397,7 @@ class ModuleModelTest extends TestCase
      */
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -411,10 +411,10 @@ class ModuleModelTest extends TestCase
 
     public function testVendorModulesAreMarkedAccordingly()
     {
-        $modules = array(
+        $modules = [
             'Test\Foo' => new Test\Foo\Module(),
             'Test\Bar' => new Test\Foo\Module(),
-        );
+        ];
         $moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                               ->disableOriginalConstructor()
                               ->getMock();
@@ -424,8 +424,8 @@ class ModuleModelTest extends TestCase
 
         $model = new ModuleModel(
             $moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
 
         $modules = $model->getModules();
@@ -436,10 +436,10 @@ class ModuleModelTest extends TestCase
 
     public function testDefaultApiVersionIsSetProperly()
     {
-        $modules = array(
+        $modules = [
             'Test\Bar' => new Test\Bar\Module(),
             'Test\Foo' => new Test\Foo\Module(),
-        );
+        ];
         $moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                               ->disableOriginalConstructor()
                               ->getMock();
@@ -449,8 +449,8 @@ class ModuleModelTest extends TestCase
 
         $model = new ModuleModel(
             $moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
 
         $modules = $model->getModules();

--- a/test/Model/ModuleResourceTest.php
+++ b/test/Model/ModuleResourceTest.php
@@ -17,7 +17,7 @@ class ModuleResourceTest extends TestCase
 {
     public function setUp()
     {
-        $modules = array();
+        $modules = [];
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                                     ->disableOriginalConstructor()
                                     ->getMock();
@@ -34,8 +34,8 @@ class ModuleResourceTest extends TestCase
 
         $this->model = new ModuleModel(
             $this->moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
 
         $this->resource = new ModuleResource(
@@ -91,7 +91,7 @@ class ModuleResourceTest extends TestCase
      */
     public function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -106,35 +106,35 @@ class ModuleResourceTest extends TestCase
     public function testCreateReturnsModuleWithVersion1()
     {
         $moduleName = uniqid('Foo');
-        $module = $this->resource->create(array(
+        $module = $this->resource->create([
             'name' => $moduleName,
-        ));
+        ]);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $module);
-        $this->assertEquals(array(1), $module->getVersions());
+        $this->assertEquals([1], $module->getVersions());
     }
 
     public function testCreateReturnsModuleWithSpecifiedVersion()
     {
         $moduleName = uniqid('Foo');
-        $module = $this->resource->create(array(
+        $module = $this->resource->create([
             'name'    => $moduleName,
             'version' => '2'
-        ));
+        ]);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $module);
-        $this->assertEquals(array(2), $module->getVersions());
+        $this->assertEquals([2], $module->getVersions());
     }
 
     public function testFetchNewlyCreatedModuleInjectsVersion()
     {
         $moduleName = uniqid('Foo');
-        $module = $this->resource->create(array(
+        $module = $this->resource->create([
             'name'    => $moduleName,
-        ));
+        ]);
         $moduleClass = $module->getNamespace() . '\Module';
 
-        $modules = array(
+        $modules = [
             $moduleName => new $moduleClass,
-        );
+        ];
         $moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
             ->disableOriginalConstructor()
             ->getMock();
@@ -144,21 +144,21 @@ class ModuleResourceTest extends TestCase
 
         $model    = new ModuleModel(
             $moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
         $resource = new ModuleResource($model, new ModulePathSpec(new ModuleUtils($moduleManager)));
         $module   = $resource->fetch($moduleName);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $module);
-        $this->assertEquals(array(1), $module->getVersions());
+        $this->assertEquals([1], $module->getVersions());
     }
 
     public function testFetchModuleInjectsVersions()
     {
         $moduleName = uniqid('Foo');
-        $module = $this->resource->create(array(
+        $module = $this->resource->create([
             'name'    => $moduleName,
-        ));
+        ]);
         $moduleClass = $module->getNamespace() . '\Module';
 
         $r    = new ReflectionClass($moduleClass);
@@ -166,9 +166,9 @@ class ModuleResourceTest extends TestCase
         mkdir(sprintf('%s/V2', $path), 0775, true);
         mkdir(sprintf('%s/V3', $path), 0775, true);
 
-        $modules = array(
+        $modules = [
             $moduleName => new $moduleClass,
-        );
+        ];
         $moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
             ->disableOriginalConstructor()
             ->getMock();
@@ -178,12 +178,12 @@ class ModuleResourceTest extends TestCase
 
         $model    = new ModuleModel(
             $moduleManager,
-            array(),
-            array()
+            [],
+            []
         );
         $resource = new ModuleResource($model, new ModulePathSpec(new ModuleUtils($moduleManager)));
         $module   = $resource->fetch($moduleName);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $module);
-        $this->assertEquals(array(1, 2, 3), $module->getVersions());
+        $this->assertEquals([1, 2, 3], $module->getVersions());
     }
 }

--- a/test/Model/RestServiceModelTest.php
+++ b/test/Model/RestServiceModelTest.php
@@ -30,7 +30,7 @@ class RestServiceModelTest extends TestCase
      */
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -45,10 +45,10 @@ class RestServiceModelTest extends TestCase
     {
         $pathSpec = (empty($this->modules)) ? 'psr-0' : $this->modules->getPathSpec();
 
-        $modulePath = array(
+        $modulePath = [
             'psr-0' => '%s/src/%s/V*',
             'psr-4' => '%s/src/V*'
-        );
+        ];
 
         $basePath   = sprintf('%s/TestAsset/module/%s', __DIR__, $this->module);
         $configPath = $basePath . '/config';
@@ -73,12 +73,12 @@ class RestServiceModelTest extends TestCase
         $this->module = 'BarConf';
         $this->cleanUpAssets();
 
-        $modules = array(
+        $modules = [
             'BarConf' => new BarConf\Module(),
             'BazConf' => new BazConf\Module()
-        );
+        ];
 
-        $this->moduleEntity  = new ModuleEntity($this->module, array(), array(), false);
+        $this->moduleEntity  = new ModuleEntity($this->module, [], [], false);
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                                     ->disableOriginalConstructor()
                                     ->getMock();
@@ -105,21 +105,21 @@ class RestServiceModelTest extends TestCase
     public function getCreationPayload()
     {
         $payload = new NewRestServiceEntity();
-        $payload->exchangeArray(array(
+        $payload->exchangeArray([
             'service_name'               => 'foo',
             'route_match'                => '/api/foo',
             'route_identifier_name'      => 'foo_id',
             'collection_name'            => 'foo',
-            'entity_http_methods'        => array('GET', 'PATCH'),
-            'collection_http_methods'    => array('GET', 'POST'),
-            'collection_query_whitelist' => array('sort', 'filter'),
+            'entity_http_methods'        => ['GET', 'PATCH'],
+            'collection_http_methods'    => ['GET', 'POST'],
+            'collection_query_whitelist' => ['sort', 'filter'],
             'page_size'                  => 10,
             'page_size_param'            => 'p',
             'selector'                   => 'HalJson',
-            'accept_whitelist'           => array('application/json', 'application/*+json'),
-            'content_type_whitelist'     => array('application/json'),
+            'accept_whitelist'           => ['application/json', 'application/*+json'],
+            'content_type_whitelist'     => ['application/json'],
             'hydrator_name'              => 'Zend\Stdlib\Hydrator\ObjectProperty',
-        ));
+        ]);
 
         return $payload;
     }
@@ -128,7 +128,7 @@ class RestServiceModelTest extends TestCase
     {
         $this->setExpectedException('ZF\Rest\Exception\CreationException');
         $restServiceEntity = new NewRestServiceEntity();
-        $restServiceEntity->exchangeArray(array('servicename' => 'Foo Bar'));
+        $restServiceEntity->exchangeArray(['servicename' => 'Foo Bar']);
         $this->codeRest->createService($restServiceEntity);
     }
 
@@ -136,7 +136,7 @@ class RestServiceModelTest extends TestCase
     {
         $this->setExpectedException('ZF\Rest\Exception\CreationException');
         $restServiceEntity = new NewRestServiceEntity();
-        $restServiceEntity->exchangeArray(array('serivcename' => 'Foo:Bar'));
+        $restServiceEntity->exchangeArray(['serivcename' => 'Foo:Bar']);
         $this->codeRest->createService($restServiceEntity);
     }
 
@@ -144,7 +144,7 @@ class RestServiceModelTest extends TestCase
     {
         $this->setExpectedException('ZF\Rest\Exception\CreationException');
         $restServiceEntity = new NewRestServiceEntity();
-        $restServiceEntity->exchangeArray(array('servicename' => 'Foo/Bar'));
+        $restServiceEntity->exchangeArray(['servicename' => 'Foo/Bar']);
         $this->codeRest->createService($restServiceEntity);
     }
 
@@ -291,15 +291,15 @@ class RestServiceModelTest extends TestCase
         $routes = $config['router']['routes'];
 
         $this->assertArrayHasKey($routeName, $routes);
-        $expected = array(
+        $expected = [
             'type' => 'Segment',
-            'options' => array(
+            'options' => [
                 'route' => '/foo-bar[/:foo_bar_id]',
-                'defaults' => array(
+                'defaults' => [
                     'controller' => 'BarConf\Rest\FooBar\Controller',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         $this->assertEquals($expected, $routes[$routeName]);
     }
 
@@ -318,10 +318,10 @@ class RestServiceModelTest extends TestCase
     public function testCreateRestConfigWritesRestConfiguration()
     {
         $details = $this->getCreationPayload();
-        $details->exchangeArray(array(
+        $details->exchangeArray([
             'entity_class'     => 'BarConf\Rest\Foo\FooEntity',
             'collection_class' => 'BarConf\Rest\Foo\FooCollection',
-        ));
+        ]);
         $this->codeRest->createRestConfig(
             $details,
             'BarConf\Rest\Foo\Controller',
@@ -334,7 +334,7 @@ class RestServiceModelTest extends TestCase
         $this->assertArrayHasKey('BarConf\Rest\Foo\Controller', $config['zf-rest']);
         $config = $config['zf-rest']['BarConf\Rest\Foo\Controller'];
 
-        $expected = array(
+        $expected = [
             'service_name'               => 'foo',
             'listener'                   => 'BarConf\Rest\Foo\FooResource',
             'route_name'                 => 'bar-conf.rest.foo',
@@ -347,7 +347,7 @@ class RestServiceModelTest extends TestCase
             'page_size_param'            => $details->pageSizeParam,
             'entity_class'               => $details->entityClass,
             'collection_class'           => $details->collectionClass,
-        );
+        ];
         $this->assertEquals($expected, $config);
     }
 
@@ -361,19 +361,19 @@ class RestServiceModelTest extends TestCase
         $config = $config['zf-content-negotiation'];
 
         $this->assertArrayHasKey('controllers', $config);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'BarConf\Rest\Foo\Controller' => $details->selector,
-        ), $config['controllers']);
+        ], $config['controllers']);
 
         $this->assertArrayHasKey('accept_whitelist', $config);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'BarConf\Rest\Foo\Controller' => $details->acceptWhitelist,
-        ), $config['accept_whitelist'], var_export($config, 1));
+        ], $config['accept_whitelist'], var_export($config, 1));
 
         $this->assertArrayHasKey('content_type_whitelist', $config);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'BarConf\Rest\Foo\Controller' => $details->contentTypeWhitelist,
-        ), $config['content_type_whitelist'], var_export($config, 1));
+        ], $config['content_type_whitelist'], var_export($config, 1));
     }
 
     public function testCreateHalConfigWritesHalConfiguration()
@@ -392,20 +392,20 @@ class RestServiceModelTest extends TestCase
         $config = $config['zf-hal']['metadata_map'];
 
         $this->assertArrayHasKey('BarConf\Rest\Foo\FooEntity', $config);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'route_identifier_name'  => $details->routeIdentifierName,
             'route_name'             => 'bar-conf.rest.foo',
             'hydrator'               => 'Zend\Stdlib\Hydrator\ObjectProperty',
             'entity_identifier_name' => 'id',
-        ), $config['BarConf\Rest\Foo\FooEntity']);
+        ], $config['BarConf\Rest\Foo\FooEntity']);
 
         $this->assertArrayHasKey('BarConf\Rest\Foo\FooCollection', $config);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'route_identifier_name'  => $details->routeIdentifierName,
             'route_name'             => 'bar-conf.rest.foo',
             'is_collection'          => true,
             'entity_identifier_name' => 'id',
-        ), $config['BarConf\Rest\Foo\FooCollection']);
+        ], $config['BarConf\Rest\Foo\FooCollection']);
     }
 
     public function testCreateServiceReturnsRestServiceEntityOnSuccess()
@@ -422,11 +422,11 @@ class RestServiceModelTest extends TestCase
         $this->assertEquals('BarConf\V1\Rest\Foo\FooCollection', $result->collectionClass);
         $this->assertEquals('bar-conf.rest.foo', $result->routeName);
         $this->assertEquals(
-            array('application/vnd.bar-conf.v1+json', 'application/hal+json', 'application/json'),
+            ['application/vnd.bar-conf.v1+json', 'application/hal+json', 'application/json'],
             $result->acceptWhitelist
         );
         $this->assertEquals(
-            array('application/vnd.bar-conf.v1+json', 'application/json'),
+            ['application/vnd.bar-conf.v1+json', 'application/json'],
             $result->contentTypeWhitelist
         );
     }
@@ -434,17 +434,17 @@ class RestServiceModelTest extends TestCase
     public function testCreateServiceUsesDefaultContentNegotiation()
     {
         $payload = new NewRestServiceEntity();
-        $payload->exchangeArray(array(
+        $payload->exchangeArray([
             'service_name' => 'foo',
-        ));
+        ]);
         $result  = $this->codeRest->createService($payload);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RestServiceEntity', $result);
         $this->assertEquals(
-            array('application/vnd.bar-conf.v1+json', 'application/hal+json', 'application/json'),
+            ['application/vnd.bar-conf.v1+json', 'application/hal+json', 'application/json'],
             $result->acceptWhitelist
         );
         $this->assertEquals(
-            array('application/vnd.bar-conf.v1+json', 'application/json'),
+            ['application/vnd.bar-conf.v1+json', 'application/json'],
             $result->contentTypeWhitelist
         );
     }
@@ -471,10 +471,10 @@ class RestServiceModelTest extends TestCase
     public function testFetchServiceUsesEntityAndCollectionClassesDiscoveredInRestConfiguration()
     {
         $details = $this->getCreationPayload();
-        $details->exchangeArray(array(
+        $details->exchangeArray([
             'entity_class'     => 'ZFTest\Apigility\Admin\Model\TestAsset\Entity',
             'collection_class' => 'ZFTest\Apigility\Admin\Model\TestAsset\Collection',
-        ));
+        ]);
         $result  = $this->codeRest->createService($details);
 
         $service = $this->codeRest->fetch('BarConf\V1\Rest\Foo\Controller');
@@ -490,10 +490,10 @@ class RestServiceModelTest extends TestCase
         $original = $this->codeRest->createService($details);
 
         $patch = new RestServiceEntity();
-        $patch->exchangeArray(array(
+        $patch->exchangeArray([
             'controller_service_name' => 'BarConf\Rest\Foo\Controller',
             'route_match'             => '/api/bar/foo',
-        ));
+        ]);
 
         $this->codeRest->updateRoute($original, $patch);
 
@@ -512,15 +512,15 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'page_size'                  => 30,
             'page_size_param'            => 'r',
-            'collection_query_whitelist' => array('f', 's'),
-            'collection_http_methods'    => array('GET'),
-            'entity_http_methods'        => array('GET'),
+            'collection_query_whitelist' => ['f', 's'],
+            'collection_http_methods'    => ['GET'],
+            'entity_http_methods'        => ['GET'],
             'entity_class'               => 'ZFTest\Apigility\Admin\Model\TestAsset\Entity',
             'collection_class'           => 'ZFTest\Apigility\Admin\Model\TestAsset\Collection',
-        );
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -541,11 +541,11 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'selector'               => 'Json',
-            'accept_whitelist'       => array('application/json'),
-            'content_type_whitelist' => array('application/json'),
-        );
+            'accept_whitelist'       => ['application/json'],
+            'content_type_whitelist' => ['application/json'],
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -579,11 +579,11 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'hydrator_name'         => 'Zend\Stdlib\Hydrator\Reflection',
             'route_identifier_name' => 'custom_foo_id',
             'route_name'            => 'my/custom/route',
-        );
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -622,13 +622,13 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'entity_class'          => 'ZFTest\Apigility\Admin\Model\TestAsset\Entity',
             'collection_class'      => 'ZFTest\Apigility\Admin\Model\TestAsset\Collection',
             'hydrator_name'         => 'Zend\Stdlib\Hydrator\Reflection',
             'route_identifier_name' => 'custom_foo_id',
             'route_name'            => 'my/custom/route',
-        );
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -668,21 +668,21 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $updates = array(
+        $updates = [
             'route_match'                => '/api/bar/foo',
             'page_size'                  => 30,
             'page_size_param'            => 'r',
-            'collection_query_whitelist' => array('f', 's'),
-            'collection_http_methods'    => array('GET'),
-            'entity_http_methods'        => array('GET'),
+            'collection_query_whitelist' => ['f', 's'],
+            'collection_http_methods'    => ['GET'],
+            'entity_http_methods'        => ['GET'],
             'selector'                   => 'Json',
-            'accept_whitelist'           => array('application/json'),
-            'content_type_whitelist'     => array('application/json'),
-        );
+            'accept_whitelist'           => ['application/json'],
+            'content_type_whitelist'     => ['application/json'],
+        ];
         $patch = new RestServiceEntity();
-        $patch->exchangeArray(array_merge(array(
+        $patch->exchangeArray(array_merge([
             'controller_service_name'    => 'BarConf\V1\Rest\Foo\Controller',
-        ), $updates));
+        ], $updates));
 
         $updated = $this->codeRest->updateService($patch);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RestServiceEntity', $updated);
@@ -866,11 +866,11 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'hydrator_name'         => 'Zend\Stdlib\Hydrator\Reflection',
             'route_identifier_name' => 'custom_foo_id',
             'route_name'            => 'my/custom/route',
-        );
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -897,10 +897,10 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'hydrator_name'          => 'Zend\Stdlib\Hydrator\Reflection',
             'entity_identifier_name' => 'custom_foo_id',
-        );
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -941,10 +941,10 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
-            'collection_http_methods'    => array(),
-            'entity_http_methods'        => array(),
-        );
+        $options = [
+            'collection_http_methods'    => [],
+            'entity_http_methods'        => [],
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 
@@ -955,8 +955,8 @@ class RestServiceModelTest extends TestCase
         $this->assertArrayHasKey($original->controllerServiceName, $config['zf-rest']);
         $test = $config['zf-rest'][$original->controllerServiceName];
 
-        $this->assertEquals(array(), $test['collection_http_methods']);
-        $this->assertEquals(array(), $test['entity_http_methods']);
+        $this->assertEquals([], $test['collection_http_methods']);
+        $this->assertEquals([], $test['entity_http_methods']);
     }
 
     /**
@@ -967,9 +967,9 @@ class RestServiceModelTest extends TestCase
         $details  = $this->getCreationPayload();
         $original = $this->codeRest->createService($details);
 
-        $options = array(
+        $options = [
             'collection_name' => 'foo_bars',
-        );
+        ];
         $patch = new RestServiceEntity();
         $patch->exchangeArray($options);
 

--- a/test/Model/RestServiceResourceTest.php
+++ b/test/Model/RestServiceResourceTest.php
@@ -32,7 +32,7 @@ class RestServiceResourceTest extends TestCase
      */
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -59,11 +59,11 @@ class RestServiceResourceTest extends TestCase
         $this->module = 'BarConf';
         $this->cleanUpAssets();
 
-        $modules = array(
+        $modules = [
             'BarConf' => new BarConf\Module()
-        );
+        ];
 
-        $this->moduleEntity = new ModuleEntity($this->module, array(), array(), false);
+        $this->moduleEntity = new ModuleEntity($this->module, [], [], false);
 
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
                                     ->disableOriginalConstructor()
@@ -115,7 +115,7 @@ class RestServiceResourceTest extends TestCase
      */
     public function testCreateReturnsRestServiceEntityWithControllerServiceNamePopulated()
     {
-        $entity = $this->resource->create(array('service_name' => 'test'));
+        $entity = $this->resource->create(['service_name' => 'test']);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RestServiceEntity', $entity);
         $controllerServiceName = $entity->controllerServiceName;
         $this->assertNotEmpty($controllerServiceName);
@@ -131,7 +131,7 @@ class RestServiceResourceTest extends TestCase
         $modulePathSpec          = $this->modules;
         $writer                  = $this->writer;
         $configResourceFactory   = $this->configFactory;
-        $moduleModel             = new ModuleModel($moduleManager, array(), array());
+        $moduleModel             = new ModuleModel($moduleManager, [], []);
         $sharedEvents            = new SharedEventManager();
         $restServiceModelFactory = new RestServiceModelFactory(
             $modulePathSpec,
@@ -152,17 +152,17 @@ class RestServiceResourceTest extends TestCase
         $prop->setAccessible(true);
         $prop->setValue($resource, 'BarConf');
 
-        $entity = $resource->create(array(
+        $entity = $resource->create([
             'adapter_name' => 'Db\Test',
             'table_name'   => 'test',
-        ));
+        ]);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\DbConnectedRestServiceEntity', $entity);
 
         $id = $entity->controllerServiceName;
-        $updateData = array(
+        $updateData = [
             'entity_identifier_name' => 'test_id',
             'hydrator_name' => 'Zend\Stdlib\Hydrator\ObjectProperty',
-        );
+        ];
         $resource->patch($id, $updateData);
 
         $config = include __DIR__ . '/TestAsset/module/BarConf/config/module.config.php';

--- a/test/Model/RpcServiceModelTest.php
+++ b/test/Model/RpcServiceModelTest.php
@@ -29,7 +29,7 @@ class RpcServiceModelTest extends TestCase
      */
     protected function removeDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -45,10 +45,10 @@ class RpcServiceModelTest extends TestCase
     {
         $pathSpec = (empty($this->modulePathSpec)) ? 'psr-0' : $this->modulePathSpec->getPathSpec();
 
-        $modulePath = array(
+        $modulePath = [
             'psr-0' => '%s/src/%s/V*',
             'psr-4' => '%s/src/V*'
-        );
+        ];
 
         $basePath   = sprintf('%s/TestAsset/module/%s', __DIR__, $this->module);
         $configPath = $basePath . '/config';
@@ -63,10 +63,10 @@ class RpcServiceModelTest extends TestCase
         $this->module = 'FooConf';
         $this->cleanUpAssets();
 
-        $modules = array(
+        $modules = [
             'FooConf' => new FooConf\Module(),
             'BazConf' => new BazConf\Module()
-        );
+        ];
 
         $this->moduleEntity  = new ModuleEntity($this->module);
         $this->moduleManager = $this->getMockBuilder('Zend\ModuleManager\ModuleManager')
@@ -103,7 +103,7 @@ class RpcServiceModelTest extends TestCase
          * @todo define exception in Rpc namespace
          */
         $this->setExpectedException('ZF\Rest\Exception\CreationException');
-        $this->codeRpc->createService('Foo Bar', 'route', array());
+        $this->codeRpc->createService('Foo Bar', 'route', []);
     }
 
     public function testRejectSpacesInRpcServiceName2()
@@ -112,7 +112,7 @@ class RpcServiceModelTest extends TestCase
          * @todo define exception in Rpc namespace
         */
         $this->setExpectedException('ZF\Rest\Exception\CreationException');
-        $this->codeRpc->createService('Foo:Bar', 'route', array());
+        $this->codeRpc->createService('Foo:Bar', 'route', []);
     }
 
     public function testRejectSpacesInRpcServiceName3()
@@ -121,7 +121,7 @@ class RpcServiceModelTest extends TestCase
          * @todo define exception in Rpc namespace
         */
         $this->setExpectedException('ZF\Rest\Exception\CreationException');
-        $this->codeRpc->createService('Foo/Bar', 'route', array());
+        $this->codeRpc->createService('Foo/Bar', 'route', []);
     }
 
     /**
@@ -181,11 +181,11 @@ class RpcServiceModelTest extends TestCase
 
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
         $config     = include $configFile;
-        $expected = array(
-            'controllers' => array('factories' => array(
+        $expected = [
+            'controllers' => ['factories' => [
                 $controllerService => $className . 'Factory',
-            )),
-        );
+            ]],
+        ];
         $this->assertEquals($expected, $config);
     }
 
@@ -242,11 +242,11 @@ class RpcServiceModelTest extends TestCase
 
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
         $config     = include $configFile;
-        $expected = array(
-            'controllers' => array('factories' => array(
+        $expected = [
+            'controllers' => ['factories' => [
                 $controllerService => $className . 'Factory',
-            )),
-        );
+            ]],
+        ];
         $this->assertEquals($expected, $config);
     }
 
@@ -261,31 +261,31 @@ class RpcServiceModelTest extends TestCase
 
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
         $config     = include $configFile;
-        $expected   = array(
-            'router' => array('routes' => array(
-                'foo-conf.rpc.hello-world' => array(
+        $expected   = [
+            'router' => ['routes' => [
+                'foo-conf.rpc.hello-world' => [
                     'type' => 'Segment',
-                    'options' => array(
+                    'options' => [
                         'route' => '/foo_conf/hello_world',
-                        'defaults' => array(
+                        'defaults' => [
                             'controller' => 'FooConf\Rpc\HelloWorld\Controller',
                             'action' => 'helloWorld',
-                        ),
-                    ),
-                ),
-            )),
-            'zf-versioning' => array(
-                'uri' => array(
+                        ],
+                    ],
+                ],
+            ]],
+            'zf-versioning' => [
+                'uri' => [
                     'foo-conf.rpc.hello-world'
-                )
-            )
-        );
+                ]
+            ]
+        ];
         $this->assertEquals($expected, $config);
-        return (object) array(
+        return (object) [
             'config'             => $config,
             'config_file'        => $configFile,
             'controller_service' => 'FooConf\Rpc\HelloWorld\Controller',
-        );
+        ];
     }
 
     public function testCanCreateRpcConfiguration()
@@ -294,36 +294,36 @@ class RpcServiceModelTest extends TestCase
             'HelloWorld',
             'FooConf\Rpc\HelloWorld\Controller',
             'foo-conf.rpc.hello-world',
-            array('GET', 'PATCH')
+            ['GET', 'PATCH']
         );
-        $expected = array(
-            'zf-rpc' => array(
-                'FooConf\Rpc\HelloWorld\Controller' => array(
+        $expected = [
+            'zf-rpc' => [
+                'FooConf\Rpc\HelloWorld\Controller' => [
                     'service_name' => 'HelloWorld',
-                    'http_methods' => array('GET', 'PATCH'),
+                    'http_methods' => ['GET', 'PATCH'],
                     'route_name'   => 'foo-conf.rpc.hello-world',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         $this->assertEquals($expected, $result);
 
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
         $config     = include $configFile;
         $this->assertEquals($expected, $config);
 
-        return (object) array(
+        return (object) [
             'controller_service' => 'FooConf\Rpc\HelloWorld\Controller',
             'config'             => $config,
             'config_file'        => $configFile,
-        );
+        ];
     }
 
     public function contentNegotiationSelectors()
     {
-        return array(
-            'defaults' => array(null, 'Json'),
-            'HalJson' => array('HalJson', 'HalJson'),
-        );
+        return [
+            'defaults' => [null, 'Json'],
+            'HalJson' => ['HalJson', 'HalJson'],
+        ];
     }
 
     /**
@@ -332,96 +332,96 @@ class RpcServiceModelTest extends TestCase
     public function testCanCreateContentNegotiationSelectorConfiguration($selector, $expected)
     {
         $result = $this->codeRpc->createContentNegotiationConfig('FooConf\Rpc\HelloWorld\Controller', $selector);
-        $expected = array(
-            'zf-content-negotiation' => array(
-                'controllers' => array(
+        $expected = [
+            'zf-content-negotiation' => [
+                'controllers' => [
                     'FooConf\Rpc\HelloWorld\Controller' => $expected,
-                ),
-                'accept_whitelist' => array(
-                    'FooConf\Rpc\HelloWorld\Controller' => array(
+                ],
+                'accept_whitelist' => [
+                    'FooConf\Rpc\HelloWorld\Controller' => [
                         'application/vnd.foo-conf.v1+json',
                         'application/json',
                         'application/*+json',
-                    ),
-                ),
-                'content_type_whitelist' => array(
-                    'FooConf\Rpc\HelloWorld\Controller' => array(
+                    ],
+                ],
+                'content_type_whitelist' => [
+                    'FooConf\Rpc\HelloWorld\Controller' => [
                         'application/vnd.foo-conf.v1+json',
                         'application/json',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->assertEquals($expected, $result);
 
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
         $config     = include $configFile;
         $this->assertEquals($expected, $config);
 
-        return (object) array(
+        return (object) [
             'config'             => $config,
             'config_file'        => $configFile,
             'controller_service' => 'FooConf\Rpc\HelloWorld\Controller',
-        );
+        ];
     }
 
     public function testCanGenerateAllArtifactsAtOnceViaCreateService()
     {
         $serviceName = 'HelloWorld';
         $route       = '/foo_conf/hello/world';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
 
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
-        $expected   = array(
-            'controllers' => array('factories' => array(
+        $expected   = [
+            'controllers' => ['factories' => [
                 'FooConf\V1\Rpc\HelloWorld\Controller' => 'FooConf\V1\Rpc\HelloWorld\HelloWorldControllerFactory',
-            )),
-            'router' => array('routes' => array(
-                'foo-conf.rpc.hello-world' => array(
+            ]],
+            'router' => ['routes' => [
+                'foo-conf.rpc.hello-world' => [
                     'type' => 'Segment',
-                    'options' => array(
+                    'options' => [
                         'route' => '/foo_conf/hello/world',
-                        'defaults' => array(
+                        'defaults' => [
                             'controller' => 'FooConf\V1\Rpc\HelloWorld\Controller',
                             'action' => 'helloWorld',
-                        ),
-                    ),
-                ),
-            )),
-            'zf-rpc' => array(
-                'FooConf\V1\Rpc\HelloWorld\Controller' => array(
+                        ],
+                    ],
+                ],
+            ]],
+            'zf-rpc' => [
+                'FooConf\V1\Rpc\HelloWorld\Controller' => [
                     'service_name' => 'HelloWorld',
-                    'http_methods' => array('GET', 'PATCH'),
+                    'http_methods' => ['GET', 'PATCH'],
                     'route_name'   => 'foo-conf.rpc.hello-world',
-                ),
-            ),
-            'zf-content-negotiation' => array(
-                'controllers' => array(
+                ],
+            ],
+            'zf-content-negotiation' => [
+                'controllers' => [
                     'FooConf\V1\Rpc\HelloWorld\Controller' => $selector,
-                ),
-                'accept_whitelist' => array(
-                    'FooConf\V1\Rpc\HelloWorld\Controller' => array(
+                ],
+                'accept_whitelist' => [
+                    'FooConf\V1\Rpc\HelloWorld\Controller' => [
                         'application/vnd.foo-conf.v1+json',
                         'application/json',
                         'application/*+json',
-                    ),
-                ),
-                'content_type_whitelist' => array(
-                    'FooConf\V1\Rpc\HelloWorld\Controller' => array(
+                    ],
+                ],
+                'content_type_whitelist' => [
+                    'FooConf\V1\Rpc\HelloWorld\Controller' => [
                         'application/vnd.foo-conf.v1+json',
                         'application/json',
-                    ),
-                ),
-            ),
-            'zf-versioning' => array(
-                'uri' => array(
+                    ],
+                ],
+            ],
+            'zf-versioning' => [
+                'uri' => [
                     'foo-conf.rpc.hello-world'
-                )
-            )
-        );
+                ]
+            ]
+        ];
         $config = include $configFile;
         $this->assertEquals($expected, $config);
 
@@ -448,11 +448,11 @@ class RpcServiceModelTest extends TestCase
             'Expected ' . $actionMethodName . "; class:\n" . file_get_contents($classFile)
         );
 
-        return (object) array(
+        return (object) [
             'rpc_service' => $result->getArrayCopy(),
             'config_file'  => $configFile,
             'config'       => $config,
-        );
+        ];
     }
 
     /**
@@ -463,7 +463,7 @@ class RpcServiceModelTest extends TestCase
         // State is lost in between tests; re-seed the service
         $serviceName = 'HelloWorld';
         $route       = '/foo_conf/hello/world';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $service    = $result->getArrayCopy();
@@ -483,7 +483,7 @@ class RpcServiceModelTest extends TestCase
      */
     public function testCanUpdateHttpMethods($configData)
     {
-        $methods = array('GET', 'PUT', 'DELETE');
+        $methods = ['GET', 'PUT', 'DELETE'];
         $this->writer->toFile($configData->config_file, $configData->config);
         $this->assertTrue($this->codeRpc->updateHttpMethods($configData->controller_service, $methods));
         $config = include $configData->config_file;
@@ -493,13 +493,13 @@ class RpcServiceModelTest extends TestCase
     public function testCanUpdateContentNegotiationSelector()
     {
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
-        $this->writer->toFile($configFile, array(
-            'zf-content-negotiation' => array(
-                'controllers' => array(
+        $this->writer->toFile($configFile, [
+            'zf-content-negotiation' => [
+                'controllers' => [
                     'FooConf\Rpc\HelloWorld\Controller' => 'Json',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
         $this->assertTrue($this->codeRpc->updateSelector('FooConf\Rpc\HelloWorld\Controller', 'MyCustomSelector'));
         $config = include $configFile;
         $this->assertEquals(
@@ -511,43 +511,43 @@ class RpcServiceModelTest extends TestCase
     public function testCanUpdateContentNegotiationWhitelists()
     {
         $configFile = $this->modulePathSpec->getModuleConfigFilePath($this->module);
-        $this->writer->toFile($configFile, array(
-            'zf-content-negotiation' => array(
-                'accept_whitelist' => array(
-                    'FooConf\Rpc\HelloWorld\Controller' => array(
+        $this->writer->toFile($configFile, [
+            'zf-content-negotiation' => [
+                'accept_whitelist' => [
+                    'FooConf\Rpc\HelloWorld\Controller' => [
                         'application/json',
                         'application/*+json',
-                    ),
-                ),
-                'content_type_whitelist' => array(
-                    'FooConf\Rpc\HelloWorld\Controller' => array(
+                    ],
+                ],
+                'content_type_whitelist' => [
+                    'FooConf\Rpc\HelloWorld\Controller' => [
                         'application/json',
-                    ),
-                ),
-            ),
-        ));
+                    ],
+                ],
+            ],
+        ]);
         $this->assertTrue(
             $this->codeRpc->updateContentNegotiationWhitelist(
                 'FooConf\Rpc\HelloWorld\Controller',
                 'accept',
-                array('application/xml', 'application/*+xml')
+                ['application/xml', 'application/*+xml']
             )
         );
         $this->assertTrue(
             $this->codeRpc->updateContentNegotiationWhitelist(
                 'FooConf\Rpc\HelloWorld\Controller',
                 'content_type',
-                array('application/xml')
+                ['application/xml']
             )
         );
         $config = include $configFile;
-        $this->assertEquals(array(
+        $this->assertEquals([
             'application/xml',
             'application/*+xml',
-        ), $config['zf-content-negotiation']['accept_whitelist']['FooConf\Rpc\HelloWorld\Controller']);
-        $this->assertEquals(array(
+        ], $config['zf-content-negotiation']['accept_whitelist']['FooConf\Rpc\HelloWorld\Controller']);
+        $this->assertEquals([
             'application/xml',
-        ), $config['zf-content-negotiation']['content_type_whitelist']['FooConf\Rpc\HelloWorld\Controller']);
+        ], $config['zf-content-negotiation']['content_type_whitelist']['FooConf\Rpc\HelloWorld\Controller']);
     }
 
     public function testDeleteServiceRemovesExpectedConfigurationElements()
@@ -555,7 +555,7 @@ class RpcServiceModelTest extends TestCase
         // State is lost in between tests; re-seed the service
         $serviceName = 'HelloWorld';
         $route       = '/foo_conf/hello/world';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
@@ -600,7 +600,7 @@ class RpcServiceModelTest extends TestCase
     {
         $serviceName = 'HelloWorld';
         $route       = '/foo_conf/hello/world';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
@@ -629,7 +629,7 @@ class RpcServiceModelTest extends TestCase
 
         $serviceName = 'HelloWorld';
         $route       = '/foo_conf/hello/world';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
@@ -654,7 +654,7 @@ class RpcServiceModelTest extends TestCase
     {
         $serviceName = 'HelloWorld';
         $route       = '/foo_conf/hello/world';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
@@ -684,7 +684,7 @@ class RpcServiceModelTest extends TestCase
      */
     public function testCanRemoveAllHttpVerbsWhenUpdating($configData)
     {
-        $methods = array();
+        $methods = [];
         $this->writer->toFile($configData->config_file, $configData->config);
         $this->assertTrue($this->codeRpc->updateHttpMethods($configData->controller_service, $methods));
         $config = include $configData->config_file;
@@ -698,7 +698,7 @@ class RpcServiceModelTest extends TestCase
     {
         $serviceName = 'Foo';
         $route       = '/foo';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
@@ -715,7 +715,7 @@ class RpcServiceModelTest extends TestCase
     {
         $serviceName = 'Foo';
         $route       = '/foo';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);
@@ -733,7 +733,7 @@ class RpcServiceModelTest extends TestCase
     {
         $serviceName = 'Foo';
         $route       = '/foo';
-        $httpMethods = array('GET', 'PATCH');
+        $httpMethods = ['GET', 'PATCH'];
         $selector    = 'HalJson';
         $result      = $this->codeRpc->createService($serviceName, $route, $httpMethods, $selector);
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\RpcServiceEntity', $result);

--- a/test/Model/TestAsset/module/AuthConf/Module.php
+++ b/test/Model/TestAsset/module/AuthConf/Module.php
@@ -10,13 +10,13 @@ class Module
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()

--- a/test/Model/TestAsset/module/AuthConfDefaults/Module.php
+++ b/test/Model/TestAsset/module/AuthConfDefaults/Module.php
@@ -10,13 +10,13 @@ class Module
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()

--- a/test/Model/TestAsset/module/AuthConfWithConfig/Module.php
+++ b/test/Model/TestAsset/module/AuthConfWithConfig/Module.php
@@ -10,13 +10,13 @@ class Module
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()

--- a/test/Model/TestAsset/module/BarConf/src/BarConf/Module.php
+++ b/test/Model/TestAsset/module/BarConf/src/BarConf/Module.php
@@ -12,13 +12,13 @@ class Module implements ApigilityProviderInterface
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()

--- a/test/Model/TestAsset/module/BazConf/Module.php
+++ b/test/Model/TestAsset/module/BazConf/Module.php
@@ -10,13 +10,13 @@ class Module
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()

--- a/test/Model/TestAsset/module/Doc/config/documentation.config.php
+++ b/test/Model/TestAsset/module/Doc/config/documentation.config.php
@@ -1,27 +1,27 @@
 <?php
-return array(
-    'Doc\\V1\\Rest\\FooBar\\Controller' => array(
+return [
+    'Doc\\V1\\Rest\\FooBar\\Controller' => [
         'description' => 'per rest controller description',
-        'entity' => array(
-            'GET' => array(
+        'entity' => [
+            'GET' => [
                 'description' => 'General description for GET',
                 'request' => 'Request for GET doc updated',
-            ),
-        ),
-        'collection' => array(
+            ],
+        ],
+        'collection' => [
             'description' => 'General in rest collection',
-            'POST' => array(
+            'POST' => [
                 'request' => 'Request for POST doc in collection',
                 'description' => 'General POST doc in collection',
-            ),
-        ),
-    ),
-    'Doc\\V1\\Rpc\\BazBam\\Controller' => array(
+            ],
+        ],
+    ],
+    'Doc\\V1\\Rpc\\BazBam\\Controller' => [
         'description' => 'General RPC docs',
-        'GET' => array(
+        'GET' => [
             'description' => 'General GET docs',
             'request' => 'General GET docs for request',
             'response' => 'updated description for GET response',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/test/Model/TestAsset/module/Doc/config/module.config.php
+++ b/test/Model/TestAsset/module/Doc/config/module.config.php
@@ -1,4 +1,4 @@
 <?php
-return array(
+return [
 
-);
+];

--- a/test/Model/TestAsset/module/FooConf/src/FooConf/Module.php
+++ b/test/Model/TestAsset/module/FooConf/src/FooConf/Module.php
@@ -10,13 +10,13 @@ class Module
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()

--- a/test/Model/TestAsset/module/InputFilter/config/module.config.php
+++ b/test/Model/TestAsset/module/InputFilter/config/module.config.php
@@ -1,28 +1,28 @@
 <?php
-return array(
-    'input_filter_specs' => array(
-        'InputFilter\V1\Rest\Foo\Validator' => array(
-            'foo' => array(
+return [
+    'input_filter_specs' => [
+        'InputFilter\V1\Rest\Foo\Validator' => [
+            'foo' => [
                 'name' => 'foo',
-                'validators' => array(
-                    array(
+                'validators' => [
+                    [
                         'name' => 'NotEmpty',
-                        'options' => array(
+                        'options' => [
                             'type' => 127,
-                        ),
-                    ),
-                    array('name' => 'Digits'),
-                ),
-            ),
-        ),
-    ),
-    'zf-content-validation' => array(
-        'InputFilter\V1\Rest\Foo\Controller' => array(
+                        ],
+                    ],
+                    ['name' => 'Digits'],
+                ],
+            ],
+        ],
+    ],
+    'zf-content-validation' => [
+        'InputFilter\V1\Rest\Foo\Controller' => [
             'input_filter' => 'InputFilter\V1\Rest\Foo\Validator',
-        ),
-    ),
-    'zf-rest' => array(
-        'InputFilter\V1\Rest\Foo\Controller' => array(),
-        'InputFilter\V1\Rest\Bar\Controller' => array(),
-    ),
-);
+        ],
+    ],
+    'zf-rest' => [
+        'InputFilter\V1\Rest\Foo\Controller' => [],
+        'InputFilter\V1\Rest\Bar\Controller' => [],
+    ],
+];

--- a/test/Model/ValidatorMetadataModelTest.php
+++ b/test/Model/ValidatorMetadataModelTest.php
@@ -47,12 +47,12 @@ class ValidatorMetadataModelTest extends TestCase
 
     public function allPlugins()
     {
-        $return = array();
+        $return = [];
         foreach ($this->getConfig() as $plugin => $data) {
             if ('__all__' == $plugin) {
                 continue;
             }
-            $return[$plugin] = array($plugin);
+            $return[$plugin] = [$plugin];
         }
         return $return;
     }

--- a/test/Model/VersioningModelTest.php
+++ b/test/Model/VersioningModelTest.php
@@ -36,7 +36,7 @@ class VersioningModelTest extends TestCase
 
     public function removeModuleConfig()
     {
-        foreach (array($this->moduleConfigFile, $this->moduleDocsConfigFile) as $file) {
+        foreach ([$this->moduleConfigFile, $this->moduleDocsConfigFile] as $file) {
             if (file_exists($file)) {
                 unlink($file);
             }
@@ -46,7 +46,7 @@ class VersioningModelTest extends TestCase
     public function setUpModuleConfig()
     {
         $this->removeModuleConfig();
-        foreach (array($this->moduleConfigFile, $this->moduleDocsConfigFile) as $file) {
+        foreach ([$this->moduleConfigFile, $this->moduleDocsConfigFile] as $file) {
             copy($file . '.dist', $file);
         }
     }
@@ -62,7 +62,7 @@ class VersioningModelTest extends TestCase
         if (!file_exists($dir)) {
             return false;
         }
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = "$dir/$file";
             if (is_dir($path)) {
@@ -77,7 +77,7 @@ class VersioningModelTest extends TestCase
     public function testGetModuleVersions()
     {
         $versions = $this->model->getModuleVersions('Version', __DIR__ . '/TestAsset/module/Version/src/Version');
-        $this->assertEquals(array(1), $versions);
+        $this->assertEquals([1], $versions);
     }
 
     public function testCreateVersion()

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -41,7 +41,7 @@ class ModuleTest extends TestCase
 
     public function testRouteListenerDoesNothingIfRouteMatchesDoNotContainController()
     {
-        $matches = new RouteMatch(array());
+        $matches = new RouteMatch([]);
         $event = new MvcEvent();
         $event->setRouteMatch($matches);
         $this->assertNull($this->module->onRoute($event));
@@ -49,9 +49,9 @@ class ModuleTest extends TestCase
 
     public function testRouteListenerDoesNothingIfRouteMatchControllerIsNotRelevant()
     {
-        $matches = new RouteMatch(array(
+        $matches = new RouteMatch([
             'controller' => 'Foo\Bar',
-        ));
+        ]);
         $event = new MvcEvent();
         $event->setRouteMatch($matches);
         $this->assertNull($this->module->onRoute($event));
@@ -62,9 +62,9 @@ class ModuleTest extends TestCase
         $this->setupServiceChain();
         $this->hal->setRenderCollections(false);
 
-        $matches = new RouteMatch(array(
+        $matches = new RouteMatch([
             'controller' => 'ZF\Apigility\Admin\Foo\Controller',
-        ));
+        ]);
         $event = new MvcEvent();
         $event->setRouteMatch($matches);
         $event->setTarget($this->application);


### PR DESCRIPTION
Updates minimum PHP version to 5.5, and includes updates to version constraints (we can loosen them and use the various semantic version constraints). phpcs was also updated to add the "DisallowLongArraySyntax" rule, and all code was updated accordingly.