### PR TITLE
Fixed the db autodiscover for metadata exception

### DIFF
--- a/src/Model/DbAutodiscoveryModel.php
+++ b/src/Model/DbAutodiscoveryModel.php
@@ -32,7 +32,11 @@ class DbAutodiscoveryModel extends AbstractAutodiscoveryModel
 
         $adapter = new Adapter($config[$adapter_name]);
 
-        $metadata = new Metadata($adapter);
+        try {
+            $metadata = new Metadata($adapter);
+        } catch (\Exception $e) {
+            return [];
+        }
 
         $tableNames = $metadata->getTableNames();
 


### PR DESCRIPTION
This PR fixes the issue #304 returning an empty array if the metadata is not supported by the db adapter for the autodiscovering feature.