### PR TITLE
Fixes failing unit tests due to input filter changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-eventmanager": "~2.3",
         "zendframework/zend-filter": "~2.3",
         "zendframework/zend-http": "~2.3",
-        "zendframework/zend-inputfilter": "~2.3",
+        "zendframework/zend-inputfilter": "^2.4.6",
         "zendframework/zend-modulemanager": "~2.3",
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-servicemanager": "~2.3",

--- a/src/InputFilter/Authentication/OAuth2InputFilter.php
+++ b/src/InputFilter/Authentication/OAuth2InputFilter.php
@@ -17,6 +17,8 @@ class OAuth2InputFilter extends InputFilter
     {
         $this->add([
             'name' => 'dsn',
+            'required' => false,
+            'allow_empty' => true,
             'continue_if_empty' => true,
             'validators' => [
                 [

--- a/src/InputFilter/Authentication/OAuth2InputFilter.php
+++ b/src/InputFilter/Authentication/OAuth2InputFilter.php
@@ -54,6 +54,8 @@ class OAuth2InputFilter extends InputFilter
         ]);
         $this->add([
             'name' => 'database',
+            'required' => false,
+            'allow_empty' => true,
             'continue_if_empty' => true,
             'validators' => [
                 [

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -41,7 +41,7 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                 ],
                 [
                     'content_name' => [
-                        'isEmpty' => 'Value is required and can\'t be empty'
+                        'Value is required'
                     ],
                 ],
             ],


### PR DESCRIPTION
Updates code to fit with input filter expectations from ZF 2.4.6+ and ZF 2.5.3+. In particular:

- `OAuth2InpuFilter`'s `dsn` input is now marked optional, allow empty, validate when empty.
- `OAuth2InpuFilter`'s `database` input is now marked optional, allow empty, validate when empty.
- The `CreateContentNegotiationInputFilter` test case was updated to reflect actual validation messages returned by a required but missing input.