### PR TITLE
Update stdlib version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "zendframework/zend-modulemanager": "~2.3",
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-servicemanager": "~2.3",
-        "zendframework/zend-stdlib": "~2.3",
+        "zendframework/zend-stdlib": ">=2.3.0,<2.7.0",
         "zendframework/zend-validator": "~2.3",
         "zendframework/zend-view": ">2.3",
         "zfcampus/zf-apigility": "~1.0",

--- a/src/InputFilter/Authentication/OAuth2InputFilter.php
+++ b/src/InputFilter/Authentication/OAuth2InputFilter.php
@@ -7,6 +7,7 @@
 namespace ZF\Apigility\Admin\InputFilter\Authentication;
 
 use Zend\InputFilter\InputFilter;
+use Traversable;
 
 /**
  * @todo DSN validation
@@ -107,5 +108,33 @@ class OAuth2InputFilter extends InputFilter
             'name' => 'route_match',
             'error_message' => 'Please provide a valid URI path for where OAuth2 will respond',
         ]);
+    }
+
+    public function isValid($context = null)
+    {
+        $data = $this->data;
+        if (null === $data) {
+            return parent::isValid($context);
+        }
+
+        if ($data instanceof Traversable) {
+            $data = iterator_to_array($data);
+        }
+        if (is_object($data)) {
+            $data = (array) $data;
+        }
+
+        if (! isset($data['dsn'])) {
+            $data['dsn'] = null;
+        }
+
+        if (isset($data['dsn_type']) && 'Mongo' === $data['dsn_type']) {
+            if (! isset($data['database'])) {
+                $data['database'] = null;
+            }
+        }
+        $this->setData($data);
+
+        return parent::isValid($context);
     }
 }

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -41,7 +41,7 @@ class CreateContentNegotiationInputFilterTest extends TestCase
                 ],
                 [
                     'content_name' => [
-                        'Value is required'
+                        'isEmpty' => 'Value is required and can\'t be empty',
                     ],
                 ],
             ],


### PR DESCRIPTION
To < 2.7.0, to ensure only hydrators implementing the stdlib hydrator interfaces will work.

This patch also fixes failing tests due to changes in zend-inputfilter.