### PR TITLE
Move diagnostic to configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ vendor/zfcampus/
 .project
 .buildpath
 .settings
-/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ vendor/zfcampus/
 .project
 .buildpath
 .settings
+/nbproject/private/

--- a/Module.php
+++ b/Module.php
@@ -78,21 +78,6 @@ class Module
         );
     }
 
-    public function getDiagnostics()
-    {
-        return array(
-            'Config File Writable' => function () {
-                if (!defined('APPLICATION_PATH')) {
-                    return false;
-                }
-                if (!is_writable(APPLICATION_PATH . '/config/autoload/development.php')) {
-                    return false;
-                }
-                return true;
-            },
-        );
-    }
-
     public function getConfig()
     {
         return include __DIR__ . '/config/module.config.php';

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "require-dev": {
         "fabpot/php-cs-fixer": "*@dev",
         "phpunit/PHPUnit": "3.7.*",
+        "zendframework/zenddiagnostics" : "^1.0",
         "zendframework/zend-config": "~2.3",
         "zendframework/zend-loader": "~2.3"
     },
@@ -69,5 +70,8 @@
         "classmap": [
             "Module.php"
         ]
+    },
+    "suggest": {
+        "zendframework/zenddiagnostics": "Support for diagnostic check"
     }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,6 +7,7 @@
 return array(
     'service_manager' => array(
         'invokables' => array(
+            'ZF\Apigility\Admin\Diagnostic\ConfigFileWritable' => 'ZF\Apigility\Admin\Diagnostic\ConfigFileWritableFactory',
             'ZF\Apigility\Admin\Listener\CryptFilterListener' => 'ZF\Apigility\Admin\Listener\CryptFilterListener',
         ),
         'factories' => array(
@@ -1342,6 +1343,11 @@ return array(
         'ZF\Apigility\Admin\Controller\Authorization' => array(
             'input_filter' => 'ZF\Apigility\Admin\InputFilter\Authorization',
         ),
-
+    ),
+    'zf-apigility-admin' => array(
+        'config-path' => 'config/autoload/development.php',
+    ),
+    'diagnostics' => array(
+        'ZF\Apigility\Admin\Diagnostic\ConfigFileWritable',
     ),
 );

--- a/src/Diagnostic/ConfigFileWritable.php
+++ b/src/Diagnostic/ConfigFileWritable.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\Apigility\Admin\Diagnostic;
+
+use ZendDiagnostics\Check\CheckInterface;
+use ZendDiagnostics\Result\Failure;
+use ZendDiagnostics\Result\Success;
+
+class ConfigFileWritable implements CheckInterface
+{
+    protected $configPath;
+
+    public function __construct($configPath)
+    {
+        $this->configPath = $configPath;
+    }
+
+    public function check()
+    {
+        $data = ['config-path' => $this->configPath];
+
+        if (!is_writable($this->configPath)) {
+            return new Failure('Config is not writable', $data);
+        }
+        return new Success('Config is writable', $data);
+    }
+
+    public function getLabel()
+    {
+        return 'Config File Writable';
+    }
+}

--- a/src/Diagnostic/ConfigFileWritableFactory.php
+++ b/src/Diagnostic/ConfigFileWritableFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+namespace ZF\Apigility\Admin\Diagnostic;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ConfigFileWritableFactory
+{
+    public function __invoke(ServiceLocatorInterface $services)
+    {
+        $config = $services->get('Config');
+
+        $configPath = $config['zf-apigility-admin']['config-path'];
+
+        return new ConfigFileWritable($configPath);
+    }
+}


### PR DESCRIPTION
Move diagnostic to configuration and classes. Why?
* before it's not possible to disable diagnostic if needed,
* path to config it's hardcoded

#306 