### PR TITLE
Added patchList method to rest-resource.phtml template

### DIFF
--- a/view/code-connected/rest-resource.phtml
+++ b/view/code-connected/rest-resource.phtml
@@ -73,6 +73,17 @@ class <?php echo $classname ?> extends AbstractResourceListener
     }
 
     /**
+     * Patch (partial in-place update) a collection or members of a collection
+     *
+     * @param  mixed $data
+     * @return ApiProblem|mixed
+     */
+    public function patchList($data)
+    {
+        return new ApiProblem(405, 'The PATCH method has not been defined for collections');
+    }
+
+    /**
      * Replace a collection or members of a collection
      *
      * @param  mixed $data


### PR DESCRIPTION
patchList method is included in AbstractResourceListener and can be dispatched. Added this method to rest-resource.phtml so it will be included in the boilerplate Resource class when creating a new service.