### PR TITLE
Support PSR-4 autoloading and namespaced module names

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -11,6 +11,8 @@ use Zend\Http\Header\GenericMultiHeader;
 use Zend\ModuleManager\ModuleManagerInterface;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Apigility\Admin\Model\ModuleVersioningModelFactory;
 use ZF\Configuration\ConfigResource;
 use ZF\Hal\Link\Link;
 use ZF\Hal\Link\LinkCollection;
@@ -407,6 +409,9 @@ class Module
                     $documentationModel
                 );
             },
+            /**
+             * @DEPRECATED use \ZF\Apigility\Admin\Model\ModuleVersioningModelFactory instead
+             */
             'ZF\Apigility\Admin\Model\VersioningModelFactory' => function ($services) {
                 if (!$services->has('ZF\Configuration\ConfigResourceFactory')
                     || !$services->has('ZF\Apigility\Admin\Model\ModulePathSpec')
@@ -419,6 +424,11 @@ class Module
                 $configFactory = $services->get('ZF\Configuration\ConfigResourceFactory');
                 $modulePathSpec = $services->get('ZF\Apigility\Admin\Model\ModulePathSpec');
                 return new Model\VersioningModelFactory($configFactory, $modulePathSpec);
+            },
+            ModuleVersioningModelFactory::class => function ($services) {
+                $configFactory = $services->get('ZF\Configuration\ConfigResourceFactory');
+                $modulePathSpec = $services->get('ZF\Apigility\Admin\Model\ModulePathSpec');
+                return new ModuleVersioningModelFactory($configFactory, $modulePathSpec);
             },
         ));
     }
@@ -462,7 +472,7 @@ class Module
             },
             'ZF\Apigility\Admin\Controller\Versioning' => function ($controllers) {
                 $services = $controllers->getServiceLocator();
-                $factory  = $services->get('ZF\Apigility\Admin\Model\VersioningModelFactory');
+                $factory  = $services->get(ModuleVersioningModelFactory::class);
                 return new Controller\VersioningController($factory);
             },
         ));

--- a/README.md
+++ b/README.md
@@ -877,4 +877,4 @@ modification of PHP code, or the generation and modification of PHP based config
 - `ZF\Apigility\Admin\Model\VersioningModel` - responsible for modeling the workflow and module
   code creation artifacts that are required to provide a new version of a particular Apigility-based
   REST or RPC service.
-- `ZF\Apigility\Admin\Model\VersioningModelFactory` - responsible for createing `VersioningModel`s.
+- `ZF\Apigility\Admin\Model\ModuleVersioningModelFactory` - responsible for creating `ModuleVersioningModel`s.

--- a/src/Controller/VersioningController.php
+++ b/src/Controller/VersioningController.php
@@ -8,7 +8,7 @@ namespace ZF\Apigility\Admin\Controller;
 
 use Zend\Mvc\Controller\AbstractActionController;
 use ZF\Apigility\Admin\Exception;
-use ZF\Apigility\Admin\Model\VersioningModelFactory;
+use ZF\Apigility\Admin\Model\ModuleVersioningModelFactoryInterface;
 use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\View\ApiProblemModel;
 
@@ -16,7 +16,7 @@ class VersioningController extends AbstractActionController
 {
     protected $modelFactory;
 
-    public function __construct(VersioningModelFactory $modelFactory)
+    public function __construct(ModuleVersioningModelFactoryInterface $modelFactory)
     {
         $this->modelFactory = $modelFactory;
     }
@@ -80,7 +80,7 @@ class VersioningController extends AbstractActionController
         $version = $this->bodyParam('version', false);
         if (!$version) {
             try {
-                $versions = $model->getModuleVersions($module);
+                $versions = $model->getModuleVersions();
             } catch (Exception\ExceptionInterface $ex) {
                 return new ApiProblemModel(new ApiProblem(404, 'Module not found'));
             }
@@ -94,7 +94,7 @@ class VersioningController extends AbstractActionController
 
 
         try {
-            $result = $model->createVersion($module, $version);
+            $result = $model->createVersion($version);
         } catch (Exception\InvalidArgumentException $ex) {
             return new ApiProblemModel(
                 new ApiProblem(

--- a/src/InputFilter/Validator/ModuleNameValidator.php
+++ b/src/InputFilter/Validator/ModuleNameValidator.php
@@ -25,9 +25,14 @@ class ModuleNameValidator extends AbstractValidator
     {
         $this->setValue($value);
 
-        if (! $this->isValidWordInPhp($value)) {
-            $this->error(self::API_NAME);
-            return false;
+        // validate each namespace independently
+        $parts = explode('\\', $value);
+
+        foreach ($parts as $part) {
+            if (! $this->isValidWordInPhp($part)) {
+                $this->error(self::API_NAME);
+                return false;
+            }
         }
 
         return true;

--- a/src/Model/AuthenticationEntity.php
+++ b/src/Model/AuthenticationEntity.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
@@ -8,11 +8,11 @@ namespace ZF\Apigility\Admin\Model;
 
 class AuthenticationEntity
 {
-    const TYPE_BASIC  = 'basic';
+    const TYPE_BASIC = 'basic';
     const TYPE_DIGEST = 'digest';
     const TYPE_OAUTH2 = 'oauth2';
 
-    const DSN_PDO   = 'PDO';
+    const DSN_PDO = 'PDO';
     const DSN_MONGO = 'Mongo';
 
     /**
@@ -119,41 +119,49 @@ class AuthenticationEntity
     {
         switch ($this->type) {
             case self::TYPE_BASIC:
-                return [
-                    'type'           => 'http_basic',
+                $array = [
+                    'type' => 'http_basic',
                     'accept_schemes' => [self::TYPE_BASIC],
-                    'realm'          => $this->realm,
-                    'htpasswd'       => $this->htpasswd,
+                    'realm' => $this->realm,
+                    'htpasswd' => $this->htpasswd,
                 ];
-                    case self::TYPE_DIGEST:
-                return [
-                    'type'           => 'http_digest',
+                break;
+
+            case self::TYPE_DIGEST:
+                $array = [
+                    'type' => 'http_digest',
                     'accept_schemes' => [self::TYPE_DIGEST],
-                    'realm'          => $this->realm,
-                    'htdigest'       => $this->htdigest,
+                    'realm' => $this->realm,
+                    'htdigest' => $this->htdigest,
                     'digest_domains' => $this->digestDomains,
-                    'nonce_timeout'  => $this->nonceTimeout,
+                    'nonce_timeout' => $this->nonceTimeout,
                 ];
-                    case self::TYPE_OAUTH2:
-                        $array = [
-                            'type'        => 'oauth2',
-                            'dsn_type'    => $this->dsnType,
-                            'dsn'         => $this->dsn,
-                            'username'    => $this->username,
-                            'password'    => $this->password,
-                            'route_match' => $this->routeMatch,
-                        ];
-                        if ($this->getDsnType() === self::DSN_MONGO) {
-                            $array['database'] = $this->database;
+                break;
 
-                            // Allow server strings that do not include "mongodb://" prefix
-                            if (!empty($this->dsn) && 0 !== strpos($this->dsn, 'mongodb://')) {
-                                $array['dsn'] = 'mongodb://' . $this->dsn;
-                            }
-                        }
+            case self::TYPE_OAUTH2:
+                $array = [
+                    'type' => 'oauth2',
+                    'dsn_type' => $this->dsnType,
+                    'dsn' => $this->dsn,
+                    'username' => $this->username,
+                    'password' => $this->password,
+                    'route_match' => $this->routeMatch,
+                ];
+                if ($this->getDsnType() === self::DSN_MONGO) {
+                    $array['database'] = $this->database;
 
-                return $array;
+                    // Allow server strings that do not include "mongodb://" prefix
+                    if (!empty($this->dsn) && 0 !== strpos($this->dsn, 'mongodb://')) {
+                        $array['dsn'] = 'mongodb://' . $this->dsn;
+                    }
+                }
+                break;
+
+            default:
+                $array = null;
         }
+
+        return $array;
     }
 
     public function exchangeArray(array $array)

--- a/src/Model/AuthenticationEntity.php
+++ b/src/Model/AuthenticationEntity.php
@@ -125,7 +125,7 @@ class AuthenticationEntity
                     'realm'          => $this->realm,
                     'htpasswd'       => $this->htpasswd,
                 ];
-            case self::TYPE_DIGEST:
+                    case self::TYPE_DIGEST:
                 return [
                     'type'           => 'http_digest',
                     'accept_schemes' => [self::TYPE_DIGEST],
@@ -134,23 +134,23 @@ class AuthenticationEntity
                     'digest_domains' => $this->digestDomains,
                     'nonce_timeout'  => $this->nonceTimeout,
                 ];
-            case self::TYPE_OAUTH2:
-                $array = [
-                    'type'        => 'oauth2',
-                    'dsn_type'    => $this->dsnType,
-                    'dsn'         => $this->dsn,
-                    'username'    => $this->username,
-                    'password'    => $this->password,
-                    'route_match' => $this->routeMatch,
-                ];
-                if ($this->getDsnType() === self::DSN_MONGO) {
-                    $array['database'] = $this->database;
+                    case self::TYPE_OAUTH2:
+                        $array = [
+                            'type'        => 'oauth2',
+                            'dsn_type'    => $this->dsnType,
+                            'dsn'         => $this->dsn,
+                            'username'    => $this->username,
+                            'password'    => $this->password,
+                            'route_match' => $this->routeMatch,
+                        ];
+                        if ($this->getDsnType() === self::DSN_MONGO) {
+                            $array['database'] = $this->database;
 
-                    // Allow server strings that do not include "mongodb://" prefix
-                    if (!empty($this->dsn) && 0 !== strpos($this->dsn, 'mongodb://')) {
-                        $array['dsn'] = 'mongodb://' . $this->dsn;
-                    }
-                }
+                            // Allow server strings that do not include "mongodb://" prefix
+                            if (!empty($this->dsn) && 0 !== strpos($this->dsn, 'mongodb://')) {
+                                $array['dsn'] = 'mongodb://' . $this->dsn;
+                            }
+                        }
 
                 return $array;
         }

--- a/src/Model/AuthorizationModelFactory.php
+++ b/src/Model/AuthorizationModelFactory.php
@@ -70,6 +70,6 @@ class AuthorizationModelFactory
      */
     protected function normalizeModuleName($name)
     {
-        return str_replace('.', '\\', $name);
+        return str_replace(['.', '/'], '\\', $name);
     }
 }

--- a/src/Model/AuthorizationModelFactory.php
+++ b/src/Model/AuthorizationModelFactory.php
@@ -55,7 +55,7 @@ class AuthorizationModelFactory
             return $this->models[$module];
         }
 
-        $moduleName   = $this->normalizeModuleName($module);
+        $moduleName   = $this->modules->normalizeModuleName($module);
         $moduleEntity = $this->moduleModel->getModule($moduleName);
         $config       = $this->configFactory->factory($module);
 
@@ -67,9 +67,10 @@ class AuthorizationModelFactory
     /**
      * @param  string $name
      * @return string
+     * @deprecated
      */
     protected function normalizeModuleName($name)
     {
-        return str_replace(['.', '/'], '\\', $name);
+        return $this->modules->normalizeModuleName($name);
     }
 }

--- a/src/Model/DocumentationModel.php
+++ b/src/Model/DocumentationModel.php
@@ -51,7 +51,7 @@ class DocumentationModel
                     ],
                     'description' => null
                 ];
-            case self::TYPE_RPC:
+                    case self::TYPE_RPC:
                 return [
                     'description' => null,
                     'GET'    => ['description' => null, 'request' => null, 'response' => null],

--- a/src/Model/ModuleEntity.php
+++ b/src/Model/ModuleEntity.php
@@ -67,7 +67,7 @@ class ModuleEntity
             ));
         }
 
-        $this->name         = $this->normalizeName($namespace);
+        $this->name         = $namespace;
         $this->namespace    = $namespace;
         $this->restServices = $restServices;
         $this->rpcServices  = $rpcServices;
@@ -235,16 +235,5 @@ class ModuleEntity
             return;
         }
         $this->isVendor = false;
-    }
-
-    /**
-     * normalizeName
-     *
-     * @param mixed $namespace
-     * @return void
-     */
-    protected function normalizeName($namespace)
-    {
-        return str_replace('\\', '.', $namespace);
     }
 }

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -162,7 +162,7 @@ class ModuleModel
         $renderer = new PhpRenderer();
         $renderer->setResolver($resolver);
 
-        if ($pathSpec->getPathSpec() === 'psr-0') {
+        if ($pathSpec->getPathSpec() === ModulePathSpec::PSR_0) {
             $view->setTemplate('module/skeleton');
             $moduleRelClassPath = "$moduleSourceRelativePath/Module.php";
 

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -101,7 +101,6 @@ class ModuleModel
      */
     public function getModule($moduleName)
     {
-        $moduleName = $this->normalizeModuleName($moduleName);
         $modules = $this->getEnabledModules();
         if (!array_key_exists($moduleName, $modules)) {
             return null;
@@ -434,15 +433,6 @@ class ModuleModel
             }
         }
         return $services;
-    }
-
-    /**
-     * @param  string $name
-     * @return string
-     */
-    protected function normalizeModuleName($name)
-    {
-        return str_replace('\\', '.', $name);
     }
 
     /**

--- a/src/Model/ModulePathSpec.php
+++ b/src/Model/ModulePathSpec.php
@@ -19,6 +19,16 @@ use ZF\Configuration\ModuleUtils;
 class ModulePathSpec
 {
     /**
+     * PSR-4 path spec key
+     */
+    const PSR_4 = 'psr-4';
+
+    /**
+     * PSR-0 path spec key
+     */
+    const PSR_0 = 'psr-0';
+
+    /**
      * @var ModuleUtils
      */
     protected $modules;
@@ -32,14 +42,14 @@ class ModulePathSpec
      * @var array
      */
     protected $psrSpecs = [
-        'psr-0' => '%modulePath%/src/%moduleName%',
-        'psr-4' => '%modulePath%/src'
+        self::PSR_0 => '%modulePath%/src/%moduleName%',
+        self::PSR_4 => '%modulePath%/src'
     ];
 
     /**
      * @var string
      */
-    protected $currentSpec = 'psr-0';
+    protected $currentSpec = self::PSR_0;
 
     /**
      * @var string  PSR-0
@@ -64,19 +74,23 @@ class ModulePathSpec
     /**
      * @param ModuleUtils $modules
      * @param string $sourcePathSpec
-     * @param string $modulePath
+     * @param string $applicationPath
      */
-    public function __construct(ModuleUtils $modules, $sourcePathSpec = 'psr-0', $applicationPath = ".")
+    public function __construct(ModuleUtils $modules, $sourcePathSpec = self::PSR_0, $applicationPath = ".")
     {
         $sourcePathSpec = strtolower($sourcePathSpec);
 
         if (!array_key_exists($sourcePathSpec, $this->psrSpecs)) {
-            throw new InvalidArgumentException("Invalid sourcePathSpec valid values are psr-0, psr-4");
+            throw new InvalidArgumentException(sprintf(
+                "Invalid sourcePathSpec. Valid values are %s and %s",
+                self::PSR_0,
+                self::PSR_4
+            ));
         }
 
         $this->modules              = $modules;
         $this->moduleSourcePathSpec = $this->psrSpecs[$sourcePathSpec];
-        $this->applicationPath      = $applicationPath;
+        $this->applicationPath      = $this->normalizePath($applicationPath);
         $this->currentSpec          = $sourcePathSpec;
     }
 
@@ -98,7 +112,7 @@ class ModulePathSpec
      */
     public function setApplicationPath($path)
     {
-        $this->applicationPath = $path;
+        $this->applicationPath = $this->normalizePath($path);
 
         return $this;
     }
@@ -128,7 +142,7 @@ class ModulePathSpec
             $modulePath = sprintf($this->modulePathSpec, $this->applicationPath, $moduleName);
         }
 
-        return $modulePath;
+        return $this->normalizePath($modulePath);
     }
 
     /**
@@ -140,9 +154,7 @@ class ModulePathSpec
      */
     public function getModuleSourcePath($moduleName, $fullPath = true)
     {
-        $find    = ["%modulePath%", "%moduleName%"];
-
-        $moduleName = str_replace('\\', '/', $moduleName);
+        $find = ["%modulePath%", "%moduleName%"];
 
         if (true === $fullPath) {
             $replace = [$this->getModulePath($moduleName), $moduleName];
@@ -150,7 +162,9 @@ class ModulePathSpec
             $replace = ['', $moduleName];
         }
 
-        return str_replace($find, $replace, $this->moduleSourcePathSpec);
+        $moduleSourcePath = str_replace($find, $replace, $this->moduleSourcePathSpec);
+
+        return $this->normalizePath($moduleSourcePath);
     }
 
     /**
@@ -173,9 +187,11 @@ class ModulePathSpec
             $path .= "/";
         }
 
-        $path .= (!empty($serviceName)) ? str_replace("\\", "/", $serviceName) : '';
+        if (!empty($serviceName)) {
+            $path .= $serviceName;
+        }
 
-        return $path;
+        return $this->normalizePath($path);
     }
 
     /**
@@ -196,9 +212,11 @@ class ModulePathSpec
             $path .= "/";
         }
 
-        $path .= (!empty($serviceName)) ? str_replace("\\", "/", $serviceName) : '';
+        if (!empty($serviceName)) {
+            $path .= $serviceName;
+        }
 
-        return $path;
+        return $this->normalizePath($path);
     }
 
     /**
@@ -226,5 +244,30 @@ class ModulePathSpec
     public function getModuleViewPath($moduleName)
     {
         return $this->getModulePath($moduleName) . "/view";
+    }
+
+    /**
+     * Normalizes a path by converting back-slashes into normal slashes. This function should always remain idempotent.
+     *
+     * @param $path
+     *
+     * @return string
+     */
+    public function normalizePath($path)
+    {
+        return str_replace('\\', '/', $path);
+    }
+
+    /**
+     * Normalizes a module name by converting periods and forward slashes into backslashes (for namespaces). This
+     * function should always remain idempotent.
+     *
+     * @param $moduleName
+     *
+     * @return string
+     */
+    public function normalizeModuleName($moduleName)
+    {
+        return str_replace(['.', '/'], '\\', $moduleName);
     }
 }

--- a/src/Model/ModuleResource.php
+++ b/src/Model/ModuleResource.php
@@ -70,8 +70,8 @@ class ModuleResource extends AbstractResourceListener
 
         $version = isset($data['version']) ? $data['version'] : 1;
         $name    = $data['name'];
-        $name    = str_replace('.', '\\', $name);
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_]*(\\\+[a-zA-Z][a-zA-Z0-9_]*)?$/', $name)) {
+        $name    = str_replace(['.', '/'], '\\', $name);
+        if (!preg_match('#^[a-zA-Z][a-zA-Z0-9_]*(\\\\[a-zA-Z][a-zA-Z0-9_]*)*$#', $name)) {
             throw new CreationException('Invalid module name; must be a valid PHP namespace name');
         }
 

--- a/src/Model/ModuleVersioningModel.php
+++ b/src/Model/ModuleVersioningModel.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\Model;
+
+use Zend\Filter\FilterChain;
+use Zend\Stdlib\Glob;
+use ZF\Apigility\Admin\Exception;
+use ZF\Configuration\ConfigResource;
+
+/**
+ * Allows management of module versions
+ *
+ *
+ * @author Gabriel Somoza <gabriel@somoza.me>
+ */
+final class ModuleVersioningModel
+{
+    /** Regex to extract module versions from a module's source path */
+    const REGEX_VERSION_DIR = '#V(?P<version>\d+)$#';
+
+    const PATH_SPEC_PSR_0 = 'psr-0';
+    const PATH_SPEC_PSR_4 = 'psr-4';
+
+    /** @var string */
+    private $moduleName;
+
+    /** @var string */
+    private $configDirPath;
+
+    /** @var string */
+    private $versionsPath;
+
+    /** @var string */
+    private $pathSpecType;
+
+    /** @var ConfigResource */
+    protected $configResource;
+
+    /** @var null|ConfigResource */
+    protected $docsConfigResource;
+
+    /** @var FilterChain */
+    protected $moduleNameFilter;
+
+    /**
+     * @param string $moduleName Name of the module.
+     * @param string $configDirPath Path the the configuration folder, with one or more *.config.php files.
+     * @param string $srcPath Path to the module's source folder for versions, resources & collections.
+     * @param ConfigResource $config
+     * @param null|ConfigResource $docsConfig
+     * @param null|string $pathSpecType Whether the module uses a PSR-0 directory structure or not.
+     *                                  Defaults to VersioningModel::PATH_SPEC_PSR_0.
+     */
+    public function __construct(
+        $moduleName,
+        $configDirPath,
+        $srcPath,
+        ConfigResource $config,
+        ConfigResource $docsConfig = null,
+        $pathSpecType = null
+    ) {
+        $this->moduleName = $this->normalizeModule((string) $moduleName);
+        $this->configResource = $config;
+        $this->docsConfigResource = $docsConfig;
+
+        if (null === $pathSpecType) {
+            $pathSpecType = self::PATH_SPEC_PSR_0;
+        }
+        $this->setPathSpecType($pathSpecType);
+        $this->setConfigDirPath($configDirPath);
+        $this->setVersionsPath($srcPath);
+    }
+
+    /**
+     * Create a new version for a module
+     *
+     * @param  integer $version
+     * @return bool
+     */
+    public function createVersion($version)
+    {
+        $versions = $this->getModuleVersions();
+        if (in_array($version, $versions)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'The API version %d of the module %s already exists',
+                $version,
+                $this->moduleName
+            ));
+        }
+
+        $previous = (int) $version - 1;
+        if (!in_array($previous, $versions)) {
+            throw new Exception\RuntimeException(sprintf(
+                'The previous API version %d doesn\'t exist, I cannot create version %d',
+                $previous,
+                $version
+            ));
+        }
+
+        $this->recursiveCopy(
+            $this->versionsPath . DIRECTORY_SEPARATOR . 'V'. $previous,
+            $this->versionsPath . DIRECTORY_SEPARATOR . 'V' . $version,
+            $previous,
+            $version
+        );
+
+        foreach (Glob::glob($this->configDirPath . DIRECTORY_SEPARATOR . '*.config.php') as $file) {
+            $this->updateConfigVersion($file, $previous, $version);
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the versions of a module
+     *
+     * @return array|bool
+     */
+    public function getModuleVersions()
+    {
+        $versions  = [];
+        foreach (Glob::glob($this->versionsPath . DIRECTORY_SEPARATOR . 'V*') as $dir) {
+            if (preg_match(self::REGEX_VERSION_DIR, $dir, $matches)) {
+                $versions[] = (int) $matches['version'];
+            }
+        }
+        return $versions;
+    }
+
+    /**
+     * Updates the default version of a module that will be used if no version is
+     * specified by the API consumer.
+     *
+     * @param  integer $defaultVersion
+     * @return boolean
+     */
+    public function setDefaultVersion($defaultVersion)
+    {
+        $defaultVersion = (int) $defaultVersion;
+
+        $this->configResource->patch([
+            'zf-versioning' => [
+                'default_version' => $defaultVersion
+            ]
+        ], true);
+
+        $config = $this->configResource->fetch(true);
+
+        return isset($config['zf-versioning']['default_version'])
+        && ($config['zf-versioning']['default_version'] === $defaultVersion);
+    }
+
+    /**
+     * Copy file and folder recursively
+     *
+     * @param string $source
+     * @param string $target
+     * @param int $previous
+     * @param int $version
+     */
+    protected function recursiveCopy($source, $target, $previous, $version)
+    {
+        $dir = opendir($source);
+        @mkdir($target);
+        $nsSep   = preg_quote('\\');
+        $pattern = sprintf(
+            '#%sV%s%s#',
+            $nsSep,
+            $previous,
+            $nsSep
+        );
+        while (false !== ($file = readdir($dir))) {
+            if (($file == '.') || ($file == '..')) {
+                continue;
+            }
+
+            $origin      = sprintf('%s/%s', $source, $file);
+            $destination = sprintf('%s/%s', $target, $file);
+
+            if (is_dir($origin)) {
+                $this->recursiveCopy($origin, $destination, $previous, $version);
+                continue;
+            }
+
+            $contents    = file_get_contents($origin);
+            $newContents = preg_replace($pattern, '\V' . $version . '\\', $contents);
+            file_put_contents($destination, $newContents);
+        }
+        closedir($dir);
+    }
+
+
+    /**
+     * Update a PHP configuration file from $previous to $version version
+     *
+     * @param  string  $file
+     * @param  integer $previous Previous version
+     * @param  integer $version New version
+     * @return boolean
+     */
+    protected function updateConfigVersion($file, $previous, $version)
+    {
+        $module = $this->moduleName;
+        if (preg_match('#[/\\\\]documentation.config.php$#', $file)) {
+            return $this->updateDocumentationVersion($previous, $version);
+        }
+
+        $config = $this->configResource->fetch(true);
+        if (empty($config)) {
+            return false;
+        }
+
+        // update zf-hal.metadata_map
+        if (isset($config['zf-hal']['metadata_map'])) {
+            $newValues = $this->changeVersionArray($config['zf-hal']['metadata_map'], $previous, $version);
+            $this->configResource->patch([
+                'zf-hal' => ['metadata_map' => $newValues]
+            ], true);
+        }
+
+        // update zf-rpc
+        if (isset($config['zf-rpc'])) {
+            $newValues = $this->changeVersionArray($config['zf-rpc'], $previous, $version);
+            $this->configResource->patch([
+                'zf-rpc' => $newValues
+            ], true);
+        }
+
+        // update zf-rest
+        if (isset($config['zf-rest'])) {
+            $newValues = $this->changeVersionArray($config['zf-rest'], $previous, $version);
+            $this->configResource->patch([
+                'zf-rest' => $newValues
+            ], true);
+        }
+
+        // update zf-content-negotiation
+        if (isset($config['zf-content-negotiation'])) {
+            foreach (['controllers', 'accept_whitelist', 'content_type_whitelist'] as $key) {
+                if (isset($config['zf-content-negotiation'][$key])) {
+                    $newValues = $this->changeVersionArray(
+                        $config['zf-content-negotiation'][$key],
+                        $previous,
+                        $version
+                    );
+
+                    // change version in mediatype
+                    if (in_array($key, ['accept_whitelist', 'content_type_whitelist'])) {
+                        foreach ($newValues as $k => $v) {
+                            foreach ($v as $index => $mediatype) {
+                                if (strstr($mediatype, '.v' . $previous . '+')) {
+                                    $newValues[$k][$index] = 'application/vnd.'
+                                        . $this->getModuleNameFilter()->filter($module)
+                                        . '.v'
+                                        . $version
+                                        . '+json';
+                                }
+                            }
+                        }
+                    }
+
+                    $this->configResource->patch([
+                        'zf-content-negotiation' => [$key => $newValues]
+                    ], true);
+                }
+            }
+        }
+
+        // update zf-mvc-auth
+        if (isset($config['zf-mvc-auth']['authorization'])) {
+            $newValues = $this->changeVersionArray($config['zf-mvc-auth']['authorization'], $previous, $version);
+            $this->configResource->patch([
+                'zf-mvc-auth' => ['authorization' => $newValues]
+            ], true);
+        }
+
+        // update zf-content-validation and input_filter_specs
+        if (isset($config['zf-content-validation'])) {
+            $newValues = $this->changeVersionArray($config['zf-content-validation'], $previous, $version);
+            $this->configResource->patch([
+                'zf-content-validation' => $newValues
+            ], true);
+        }
+
+        if (isset($config['input_filter_specs'])) {
+            $newValues = $this->changeVersionArray($config['input_filter_specs'], $previous, $version);
+            $this->configResource->patch([
+                'input_filter_specs' => $newValues
+            ], true);
+        }
+
+        // update zf-apigility
+        if (isset($config['zf-apigility']['db-connected'])) {
+            $newValues = $this->changeVersionArray($config['zf-apigility']['db-connected'], $previous, $version);
+            $this->configResource->patch([
+                'zf-apigility' => ['db-connected' => $newValues]
+            ], true);
+        }
+
+        // update service_manager
+        if (isset($config['service_manager'])) {
+            $newValues = $this->changeVersionArray($config['service_manager'], $previous, $version);
+            $this->configResource->patch([
+                'service_manager' => $newValues
+            ], true);
+        }
+
+        // update controllers
+        if (isset($config['controllers'])) {
+            $newValues = $this->changeVersionArray($config['controllers'], $previous, $version);
+            $this->configResource->patch([
+                'controllers' => $newValues
+            ], true);
+        }
+
+        return true;
+    }
+
+    /**
+     * Change version in a namespace
+     *
+     * @param  string $string
+     * @param  integer $previous
+     * @param  integer $version
+     * @return string
+     */
+    protected function changeVersionNamespace($string, $previous, $version)
+    {
+        return str_replace('\\V' . $previous . '\\', '\\V' . $version . '\\', $string);
+    }
+
+    /**
+     * Change version in an array
+     *
+     * @param  array $data
+     * @param  integer $previous
+     * @param  integer $version
+     * @return array
+     */
+    protected function changeVersionArray($data, $previous, $version)
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $newKey = $this->changeVersionNamespace($key, $previous, $version);
+            if (is_array($value)) {
+                $result[$newKey] = $this->changeVersionArray($value, $previous, $version);
+            } else {
+                $result[$newKey] = $this->changeVersionNamespace($value, $previous, $version);
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Normalize a module name
+     *
+     * Module names come over the wire dot-separated; make them namespaced.
+     *
+     * @param  string $module
+     * @return string
+     */
+    protected function normalizeModule($module)
+    {
+        return str_replace(['.', '/'], '\\', $module);
+    }
+
+    /**
+     * Filter for module names
+     *
+     * @return FilterChain
+     */
+    protected function getModuleNameFilter()
+    {
+        if ($this->moduleNameFilter instanceof FilterChain) {
+            return $this->moduleNameFilter;
+        }
+
+        $this->moduleNameFilter = new FilterChain();
+        $this->moduleNameFilter->attachByName('Word\CamelCaseToDash')
+            ->attachByName('StringToLower');
+        return $this->moduleNameFilter;
+    }
+
+    /**
+     * Update the documentation to add a new $version based on the $previous
+     *
+     * @param  integer $previous Previous version
+     * @param  integer $version New version
+     * @return true
+     */
+    protected function updateDocumentationVersion($previous, $version)
+    {
+        if (!$this->docsConfigResource) {
+            // Nothing to do
+            return true;
+        }
+
+        $originalDocs = $this->docsConfigResource->fetch(true);
+        $newDocs = $this->changeVersionArray($originalDocs, $previous, $version);
+        $this->docsConfigResource->patch($newDocs, true);
+        return true;
+    }
+
+    /**
+     * setPathSpecType
+     * @param $pathSpecType
+     * @return void
+     */
+    private function setPathSpecType($pathSpecType)
+    {
+        $pathSpecType = (string) $pathSpecType;
+        if (!in_array($pathSpecType, [self::PATH_SPEC_PSR_0, self::PATH_SPEC_PSR_4])) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid $setPathSpecType parameter supplied. Please use the PATH_SPEC_PSR_0 or PATH_SPEC_PSR_4 ' .
+                'constants located in the %s class.',
+                __CLASS__
+            ));
+        }
+        $this->pathSpecType = $pathSpecType;
+    }
+
+    /**
+     * Sets the path to the directory that contains each of the module's version. If the current module is a PSR-0
+     * module then it automatically appends the module's namespace.
+     *
+     * @param string $srcPath The path to the root of the module.
+     * @return void
+     */
+    private function setVersionsPath($srcPath)
+    {
+        $srcPath = (string) $srcPath;
+        if ($this->pathSpecType == self::PATH_SPEC_PSR_0) {
+            $srcPath .= DIRECTORY_SEPARATOR . $this->moduleName;
+        }
+
+        if (!file_exists($srcPath) || !is_dir($srcPath) || !is_writable($srcPath)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Could not find source directory at path "%s". Make sure the directory exists and is writable.',
+                $srcPath
+            ));
+        }
+
+        $this->versionsPath = $srcPath;
+    }
+
+    /**
+     * setConfigDirPath
+     * @param $configDirPath
+     * @return void
+     */
+    private function setConfigDirPath($configDirPath)
+    {
+        $configDirPath = (string)$configDirPath;
+        if (!is_readable($configDirPath) || !is_dir($configDirPath)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Could not find config directory at path "%s". Make sure the directory exists.',
+                $configDirPath
+            ));
+        }
+        $this->configDirPath = $configDirPath;
+    }
+}

--- a/src/Model/ModuleVersioningModelFactory.php
+++ b/src/Model/ModuleVersioningModelFactory.php
@@ -42,32 +42,21 @@ final class ModuleVersioningModelFactory implements ModuleVersioningModelFactory
      */
     public function factory($module)
     {
-        $moduleName = $this->normalizeModuleName($module);
+        $moduleName = $this->moduleUtils->normalizeModuleName($module);
 
         if (!isset($this->models[$moduleName])) {
             $config     = $this->configFactory->factory($moduleName);
             $docsConfig = $this->getDocsConfig($moduleName);
 
-            $this->models[$moduleName] = new ModuleVersioningModel(
+            $this->models[$moduleName] = ModuleVersioningModel::createWithPathSpec(
                 $moduleName,
-                $this->moduleUtils->getModuleConfigPath($moduleName),
-                $this->moduleUtils->getModuleSourcePath($moduleName),
+                $this->moduleUtils,
                 $config,
-                $docsConfig,
-                $this->moduleUtils->getPathSpec()
+                $docsConfig
             );
         }
 
         return $this->models[$moduleName];
-    }
-
-    /**
-     * @param  string $name
-     * @return string
-     */
-    protected function normalizeModuleName($name)
-    {
-        return str_replace(['.', '/'], '\\', $name);
     }
 
     /**

--- a/src/Model/ModuleVersioningModelFactory.php
+++ b/src/Model/ModuleVersioningModelFactory.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\Model;
+
+use ZF\Configuration\ResourceFactory;
+
+/**
+ * Class ModuleVersioningModelFactory
+ * @author Gabriel Somoza <gabriel@somoza.me>
+ */
+final class ModuleVersioningModelFactory implements ModuleVersioningModelFactoryInterface
+{
+    /** @var ResourceFactory */
+    private $configFactory;
+
+    /** @var ModulePathSpec */
+    private $moduleUtils;
+
+    /** @var ModuleVersioningModel[] */
+    private $models = [];
+
+    /**
+     * @param ResourceFactory $configFactory
+     * @param ModulePathSpec $moduleUtils
+     */
+    public function __construct(ResourceFactory $configFactory, ModulePathSpec $moduleUtils)
+    {
+        $this->configFactory = $configFactory;
+        $this->moduleUtils   = $moduleUtils;
+    }
+
+    /**
+     * Create service
+     *
+     * @param string $module
+     *
+     * @return ModuleVersioningModel
+     */
+    public function factory($module)
+    {
+        $moduleName = $this->normalizeModuleName($module);
+
+        if (!isset($this->models[$moduleName])) {
+            $config     = $this->configFactory->factory($moduleName);
+            $docsConfig = $this->getDocsConfig($moduleName);
+
+            $this->models[$moduleName] = new ModuleVersioningModel(
+                $moduleName,
+                $this->moduleUtils->getModuleConfigPath($moduleName),
+                $this->moduleUtils->getModuleSourcePath($moduleName),
+                $config,
+                $docsConfig,
+                $this->moduleUtils->getPathSpec()
+            );
+        }
+
+        return $this->models[$moduleName];
+    }
+
+    /**
+     * @param  string $name
+     * @return string
+     */
+    protected function normalizeModuleName($name)
+    {
+        return str_replace(['.', '/'], '\\', $name);
+    }
+
+    /**
+     * getDocsConfig
+     * @param $module
+     * @return null|\ZF\Configuration\ConfigResource
+     */
+    protected function getDocsConfig($module)
+    {
+        $moduleConfigPath = $this->moduleUtils->getModuleConfigPath($module);
+        $docConfigPath    = dirname($moduleConfigPath) . '/documentation.config.php';
+        if (!file_exists($docConfigPath)) {
+            return null;
+        }
+        $documentation = include $docConfigPath;
+        return $this->configFactory->createConfigResource($documentation, $docConfigPath);
+    }
+}

--- a/src/Model/ModuleVersioningModelFactoryInterface.php
+++ b/src/Model/ModuleVersioningModelFactoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\Model;
+
+/**
+ * Used primarily to provide backwards-compatibility
+ *
+ * @author Gabriel Somoza <gabriel@somoza.me>
+ */
+interface ModuleVersioningModelFactoryInterface
+{
+    /**
+     * factory
+     *
+     * @param string $module
+     *
+     * @return ModuleVersioningModel
+     */
+    public function factory($module);
+}

--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -243,7 +243,7 @@ class RestServiceModel implements EventManagerAwareInterface
             $namespaceSep = preg_quote('\\');
             $pattern = sprintf(
                 '#%s%sV%s#',
-                $this->module,
+                $this->moduleNameToRegex(),
                 $namespaceSep,
                 $version
             );
@@ -1417,5 +1417,20 @@ class RestServiceModel implements EventManagerAwareInterface
         } while (count($keys));
 
         return $config;
+    }
+
+    /**
+     * Converts a module name (which could include namespace separators) into a string that can be used in regex
+     * matches. Use-cases:
+     *      - Acme\Account => Acme\\Account
+     *      - Acme\\Account (ideally it should never happen) => Acme\\Account
+     *      - Acme => Acme
+     *
+     * @return string
+     */
+    private function moduleNameToRegex()
+    {
+        // find all backslashes (\) that are NOT followed by another \ and replace them with \\ (two of them)
+        return preg_replace('#\\\\(?!\\\\)#', '\\\\\\\\', $this->module);
     }
 }

--- a/src/Model/RestServiceModelFactory.php
+++ b/src/Model/RestServiceModelFactory.php
@@ -14,7 +14,8 @@ class RestServiceModelFactory extends RpcServiceModelFactory
     const TYPE_DB_CONNECTED = 'ZF\Apigility\Admin\Model\DbConnectedRestServiceModel';
 
     /**
-     * @param  string $module
+     * @param string $module
+     * @param string $type
      * @return RestServiceModel
      */
     public function factory($module, $type = self::TYPE_DEFAULT)
@@ -25,7 +26,7 @@ class RestServiceModelFactory extends RpcServiceModelFactory
             return $this->models[$type][$module];
         }
 
-        $moduleName   = $this->normalizeModuleName($module);
+        $moduleName   = $this->modules->normalizeModuleName($module);
         $config       = $this->configFactory->factory($module);
         $moduleEntity = $this->moduleModel->getModule($moduleName);
 

--- a/src/Model/RpcServiceModelFactory.php
+++ b/src/Model/RpcServiceModelFactory.php
@@ -82,6 +82,6 @@ class RpcServiceModelFactory
      */
     protected function normalizeModuleName($name)
     {
-        return str_replace('.', '\\', $name);
+        return str_replace(['.', '/'], '\\', $name);
     }
 }

--- a/src/Model/RpcServiceModelFactory.php
+++ b/src/Model/RpcServiceModelFactory.php
@@ -67,7 +67,7 @@ class RpcServiceModelFactory
             return $this->models[$module];
         }
 
-        $moduleName   = $this->normalizeModuleName($module);
+        $moduleName   = $this->modules->normalizeModuleName($module);
         $moduleEntity = $this->moduleModel->getModule($moduleName);
         $config       = $this->configFactory->factory($module);
 
@@ -79,9 +79,10 @@ class RpcServiceModelFactory
     /**
      * @param  string $name
      * @return string
+     * @deprecated
      */
     protected function normalizeModuleName($name)
     {
-        return str_replace(['.', '/'], '\\', $name);
+        return $this->modules->normalizeModuleName($name);
     }
 }

--- a/src/Model/VersioningModel.php
+++ b/src/Model/VersioningModel.php
@@ -61,7 +61,7 @@ class VersioningModel
             }
             $configDirPath = $this->pathSpec->getModuleConfigPath($name);
         } else {
-            $pathSpecType = ModuleVersioningModel::PATH_SPEC_PSR_0;
+            $pathSpecType = ModulePathSpec::PSR_0;
             // second parameter is false because PSR-0 path will be appended inside ModuleVersioningModel
             $srcPath = $this->getModuleSourcePath($name, false);
             $configDirPath = $this->locateConfigPath($srcPath);
@@ -82,8 +82,8 @@ class VersioningModel
      *
      * @param  string $module
      * @param  integer $version
-     * @param  string $path
-     * @return boolean
+     * @param  bool|string $path
+     * @return bool
      * @deprecated
      */
     public function createVersion($module, $version, $path = false)
@@ -96,8 +96,8 @@ class VersioningModel
      * Get the versions of a module
      *
      * @param  string $module
-     * @param  string $path
-     * @return array|boolean
+     * @param  bool|string $path
+     * @return array|bool
      * @deprecated
      */
     public function getModuleVersions($module, $path = false)
@@ -132,7 +132,11 @@ class VersioningModel
      */
     protected function normalizeModule($module)
     {
-        return str_replace(['.', '/'], '\\', $module);
+        if ($this->pathSpec) {
+            return $this->pathSpec->normalizeModuleName($module);
+        } else {
+            return str_replace(['.', '/'], '\\', $module);
+        }
     }
 
     /**

--- a/src/Model/VersioningModel.php
+++ b/src/Model/VersioningModel.php
@@ -8,10 +8,14 @@ namespace ZF\Apigility\Admin\Model;
 
 use ReflectionClass;
 use Zend\Filter\FilterChain;
-use Zend\Stdlib\Glob;
 use ZF\Apigility\Admin\Exception;
 use ZF\Configuration\ConfigResource;
 
+/**
+ * Class VersioningModel
+ *
+ * @deprecated use \ZF\Apigility\Admin\Model\ModuleVersioningModel instead
+ */
 class VersioningModel
 {
     protected $configResource;
@@ -20,14 +24,57 @@ class VersioningModel
 
     protected $moduleNameFilter;
 
+    private $pathSpec;
+
     /**
      * @param  ConfigResource $config
      * @param  null|ConfigResource $docsConfig
+     * @param  ModulePathSpec $pathSpec
+     * @deprecated
      */
-    public function __construct(ConfigResource $config, ConfigResource $docsConfig = null)
-    {
+    public function __construct(
+        ConfigResource $config,
+        ConfigResource $docsConfig = null,
+        ModulePathSpec $pathSpec = null
+    ) {
         $this->configResource = $config;
         $this->docsConfigResource = $docsConfig;
+        $this->pathSpec = $pathSpec;
+    }
+
+    /**
+     * getModuleVersioningModel
+     * @param $name
+     * @param null|string $srcPath Do not use this parameter unless you're providing for a transition to the new class
+     *                          (see deprecation notice on this class)
+     * @return ModuleVersioningModel
+     */
+    private function getModuleVersioningModel($name, $srcPath = null)
+    {
+        $name  = $this->normalizeModule($name);
+        $hasPathSpec = null !== $this->pathSpec;
+
+        if ($hasPathSpec) {
+            $pathSpecType = $this->pathSpec->getPathSpec();
+            if (!$srcPath) {
+                $srcPath = $this->pathSpec->getModuleSourcePath($name);
+            }
+            $configDirPath = $this->pathSpec->getModuleConfigPath($name);
+        } else {
+            $pathSpecType = ModuleVersioningModel::PATH_SPEC_PSR_0;
+            // second parameter is false because PSR-0 path will be appended inside ModuleVersioningModel
+            $srcPath = $this->getModuleSourcePath($name, false);
+            $configDirPath = $this->locateConfigPath($srcPath);
+        }
+
+        return new ModuleVersioningModel(
+            $name,
+            $configDirPath,
+            $srcPath,
+            $this->configResource,
+            $this->docsConfigResource,
+            $pathSpecType
+        );
     }
 
     /**
@@ -37,42 +84,12 @@ class VersioningModel
      * @param  integer $version
      * @param  string $path
      * @return boolean
+     * @deprecated
      */
     public function createVersion($module, $version, $path = false)
     {
-        $module  = $this->normalizeModule($module);
-        if (!$path) {
-            $path = $this->getModuleSourcePath($module);
-        }
-
-        $versions = $this->getModuleVersions($module, $path);
-        if (in_array($version, $versions)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'The API version %d of the module %s already exists',
-                $version,
-                $module
-            ));
-        }
-
-        $previous = (int) $version - 1;
-        if (!in_array($previous, $versions)) {
-            throw new Exception\RuntimeException(sprintf(
-                'The previous API version %d doesn\'t exist, I cannot create version %d',
-                $previous,
-                $version
-            ));
-        }
-
-        $this->recursiveCopy($path . '/V'. $previous, $path . '/V' . $version, $previous, $version);
-
-        $configPath = $this->locateConfigPath($path);
-        if ($configPath !== false) {
-            foreach (Glob::glob($configPath . '/*.config.php') as $file) {
-                $this->updateConfigVersion($module, $file, $previous, $version);
-            }
-        }
-
-        return true;
+        return $this->getModuleVersioningModel($module, $path)
+            ->createVersion($version);
     }
 
     /**
@@ -81,22 +98,12 @@ class VersioningModel
      * @param  string $module
      * @param  string $path
      * @return array|boolean
+     * @deprecated
      */
     public function getModuleVersions($module, $path = false)
     {
-        $module       = $this->normalizeModule($module);
-
-        if (!$path) {
-            $path = $this->getModuleSourcePath($module);
-        }
-
-        $versions  = [];
-        foreach (Glob::glob($path . DIRECTORY_SEPARATOR . 'V*') as $dir) {
-            if (preg_match('/\\V(?P<version>\d+)$/', $dir, $matches)) {
-                $versions[] = (int) $matches['version'];
-            }
-        }
-        return $versions;
+        return $this->getModuleVersioningModel($module, $path)
+            ->getModuleVersions();
     }
 
     /**
@@ -105,222 +112,13 @@ class VersioningModel
      *
      * @param  integer $defaultVersion
      * @return boolean
+     * @deprecated
      */
     public function setDefaultVersion($defaultVersion)
     {
-        $defaultVersion = (int) $defaultVersion;
-
-        $this->configResource->patch([
-            'zf-versioning' => [
-                'default_version' => $defaultVersion
-            ]
-        ], true);
-
-        $config = $this->configResource->fetch(true);
-
-        return isset($config['zf-versioning']['default_version'])
-            && ($config['zf-versioning']['default_version'] === $defaultVersion);
-    }
-
-    /**
-     * Copy file and folder recursively
-     *
-     * @param string $source
-     * @param string $target
-     * @param int $previous
-     * @param int $version
-     */
-    protected function recursiveCopy($source, $target, $previous, $version)
-    {
-        $dir = opendir($source);
-        @mkdir($target);
-        $nsSep   = preg_quote('\\');
-        $pattern = sprintf(
-            '#%sV%s%s#',
-            $nsSep,
-            $previous,
-            $nsSep
-        );
-        while (false !== ($file = readdir($dir))) {
-            if (($file == '.') || ($file == '..')) {
-                continue;
-            }
-
-            $origin      = sprintf('%s/%s', $source, $file);
-            $destination = sprintf('%s/%s', $target, $file);
-
-            if (is_dir($origin)) {
-                $this->recursiveCopy($origin, $destination, $previous, $version);
-                continue;
-            }
-
-            $contents    = file_get_contents($origin);
-            $newContents = preg_replace($pattern, '\V' . $version . '\\', $contents);
-            file_put_contents($destination, $newContents);
-        }
-        closedir($dir);
-    }
-
-
-    /**
-     * Update a PHP configuration file from $previous to $version version
-     *
-     * @param  string  $module
-     * @param  string  $file
-     * @param  integer $previous Previous version
-     * @param  integer $version New version
-     * @return boolean
-     */
-    protected function updateConfigVersion($module, $file, $previous, $version)
-    {
-        if (preg_match('#[/\\\\]documentation.config.php$#', $file)) {
-            return $this->updateDocumentationVersion($module, $previous, $version);
-        }
-
-        $config = $this->configResource->fetch(true);
-        if (empty($config)) {
-            return false;
-        }
-
-        // update zf-hal.metadata_map
-        if (isset($config['zf-hal']['metadata_map'])) {
-            $newValues = $this->changeVersionArray($config['zf-hal']['metadata_map'], $previous, $version);
-            $this->configResource->patch([
-                'zf-hal' => ['metadata_map' => $newValues]
-            ], true);
-        }
-
-        // update zf-rpc
-        if (isset($config['zf-rpc'])) {
-            $newValues = $this->changeVersionArray($config['zf-rpc'], $previous, $version);
-            $this->configResource->patch([
-                'zf-rpc' => $newValues
-            ], true);
-        }
-
-        // update zf-rest
-        if (isset($config['zf-rest'])) {
-            $newValues = $this->changeVersionArray($config['zf-rest'], $previous, $version);
-            $this->configResource->patch([
-                'zf-rest' => $newValues
-            ], true);
-        }
-
-        // update zf-content-negotiation
-        if (isset($config['zf-content-negotiation'])) {
-            foreach (['controllers', 'accept_whitelist', 'content_type_whitelist'] as $key) {
-                if (isset($config['zf-content-negotiation'][$key])) {
-                    $newValues = $this->changeVersionArray(
-                        $config['zf-content-negotiation'][$key],
-                        $previous,
-                        $version
-                    );
-
-                    // change version in mediatype
-                    if (in_array($key, ['accept_whitelist', 'content_type_whitelist'])) {
-                        foreach ($newValues as $k => $v) {
-                            foreach ($v as $index => $mediatype) {
-                                if (strstr($mediatype, '.v' . $previous . '+')) {
-                                    $newValues[$k][$index] = 'application/vnd.'
-                                        . $this->getModuleNameFilter()->filter($module)
-                                        . '.v'
-                                        . $version
-                                        . '+json';
-                                }
-                            }
-                        }
-                    }
-
-                    $this->configResource->patch([
-                        'zf-content-negotiation' => [$key => $newValues]
-                    ], true);
-                }
-            }
-        }
-
-        // update zf-mvc-auth
-        if (isset($config['zf-mvc-auth']['authorization'])) {
-            $newValues = $this->changeVersionArray($config['zf-mvc-auth']['authorization'], $previous, $version);
-            $this->configResource->patch([
-                'zf-mvc-auth' => ['authorization' => $newValues]
-            ], true);
-        }
-
-        // update zf-content-validation and input_filter_specs
-        if (isset($config['zf-content-validation'])) {
-            $newValues = $this->changeVersionArray($config['zf-content-validation'], $previous, $version);
-            $this->configResource->patch([
-                'zf-content-validation' => $newValues
-            ], true);
-        }
-
-        if (isset($config['input_filter_specs'])) {
-            $newValues = $this->changeVersionArray($config['input_filter_specs'], $previous, $version);
-            $this->configResource->patch([
-                'input_filter_specs' => $newValues
-            ], true);
-        }
-
-        // update zf-apigility
-        if (isset($config['zf-apigility']['db-connected'])) {
-            $newValues = $this->changeVersionArray($config['zf-apigility']['db-connected'], $previous, $version);
-            $this->configResource->patch([
-                'zf-apigility' => ['db-connected' => $newValues]
-            ], true);
-        }
-
-        // update service_manager
-        if (isset($config['service_manager'])) {
-            $newValues = $this->changeVersionArray($config['service_manager'], $previous, $version);
-            $this->configResource->patch([
-                'service_manager' => $newValues
-            ], true);
-        }
-
-        // update controllers
-        if (isset($config['controllers'])) {
-            $newValues = $this->changeVersionArray($config['controllers'], $previous, $version);
-            $this->configResource->patch([
-                'controllers' => $newValues
-            ], true);
-        }
-
-        return true;
-    }
-
-    /**
-     * Change version in a namespace
-     *
-     * @param  string $string
-     * @param  integer $previous
-     * @param  integer $version
-     * @return string
-     */
-    protected function changeVersionNamespace($string, $previous, $version)
-    {
-        return str_replace('\\V' . $previous . '\\', '\\V' . $version . '\\', $string);
-    }
-
-    /**
-     * Change version in an array
-     *
-     * @param  array $data
-     * @param  integer $previous
-     * @param  integer $version
-     * @return array
-     */
-    protected function changeVersionArray($data, $previous, $version)
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            $newKey = $this->changeVersionNamespace($key, $previous, $version);
-            if (is_array($value)) {
-                $result[$newKey] = $this->changeVersionArray($value, $previous, $version);
-            } else {
-                $result[$newKey] = $this->changeVersionNamespace($value, $previous, $version);
-            }
-        }
-        return $result;
+        // here we don't care about module name or path because the operation doesn't need it
+        return (new ModuleVersioningModel('', __DIR__, __DIR__, $this->configResource))
+            ->setDefaultVersion($defaultVersion);
     }
 
     /**
@@ -330,10 +128,11 @@ class VersioningModel
      *
      * @param  string $module
      * @return string
+     * @deprecated
      */
     protected function normalizeModule($module)
     {
-        return str_replace('.', '\\', $module);
+        return str_replace(['.', '/'], '\\', $module);
     }
 
     /**
@@ -343,10 +142,22 @@ class VersioningModel
      * module.
      *
      * @param  string $module
+     * @param bool $appendNamespace If true, it will append the module's namespace to the path - for PSR0 compatibility
      * @return string
+     * @deprecated
      */
-    protected function getModuleSourcePath($module)
+    protected function getModuleSourcePath($module, $appendNamespace = true)
     {
+        // for clients that know how to instantiate this class with a ModulePathSpec
+        if (null !== $this->pathSpec) {
+            $path = $this->pathSpec->getModuleSourcePath($module);
+            if ($this->pathSpec->getPathSpec() === 'psr-0') {
+                $path .= DIRECTORY_SEPARATOR . $module;
+            }
+            return $path;
+        }
+
+        // .. or fall back to the old method, which only supports PSR-0
         $moduleClass = sprintf('%s\\Module', $module);
 
         if (!class_exists($moduleClass)) {
@@ -359,7 +170,15 @@ class VersioningModel
         $r       = new ReflectionClass($moduleClass);
         $srcPath = dirname($r->getFileName());
         if (file_exists($srcPath . '/src') && is_dir($srcPath . '/src')) {
-            $srcPath = sprintf('%s/src/%s', $srcPath, str_replace('\\', '/', $moduleClass));
+            $parts = [$srcPath, 'src'];
+            if ($appendNamespace) {
+                $parts[] = str_replace('\\', '/', $moduleClass);
+            }
+            $srcPath = implode(DIRECTORY_SEPARATOR, $parts);
+        } else {
+            if (!$appendNamespace && substr($srcPath, - strlen($module)) == $module) {
+                $srcPath = substr($srcPath, 0, strlen($srcPath) - strlen($module) - 1);
+            }
         }
 
         if (!file_exists($srcPath) && !is_dir($srcPath)) {
@@ -377,6 +196,7 @@ class VersioningModel
      *
      * @param  string $srcPath
      * @return string|false
+     * @deprecated
      */
     protected function locateConfigPath($srcPath)
     {
@@ -396,6 +216,7 @@ class VersioningModel
      * Filter for module names
      *
      * @return FilterChain
+     * @deprecated
      */
     protected function getModuleNameFilter()
     {
@@ -407,26 +228,5 @@ class VersioningModel
         $this->moduleNameFilter->attachByName('Word\CamelCaseToDash')
             ->attachByName('StringToLower');
         return $this->moduleNameFilter;
-    }
-
-    /**
-     * Update the documentation to add a new $version based on the $previous
-     *
-     * @param  string $module
-     * @param  integer $previous Previous version
-     * @param  integer $version New version
-     * @return true
-     */
-    protected function updateDocumentationVersion($module, $previous, $version)
-    {
-        if (!$this->docsConfigResource) {
-            // Nothing to do
-            return true;
-        }
-
-        $originalDocs = $this->docsConfigResource->fetch(true);
-        $newDocs = $this->changeVersionArray($originalDocs, $previous, $version);
-        $this->docsConfigResource->patch($newDocs, true);
-        return true;
     }
 }

--- a/src/Model/VersioningModelFactory.php
+++ b/src/Model/VersioningModelFactory.php
@@ -55,7 +55,7 @@ class VersioningModelFactory implements ModuleVersioningModelFactoryInterface
             return $this->models[$module];
         }
 
-        $moduleName = $this->normalizeModuleName($module);
+        $moduleName = $this->moduleUtils->normalizeModuleName($module);
         $config     = $this->configFactory->factory($moduleName);
         $docsConfig = $this->getDocsConfig($module);
 
@@ -75,7 +75,7 @@ class VersioningModelFactory implements ModuleVersioningModelFactoryInterface
      */
     protected function normalizeModuleName($name)
     {
-        return str_replace(['.', '/'], '\\', $name);
+        return $this->moduleUtils->normalizeModuleName($name);
     }
 
     /**

--- a/src/Model/VersioningModelFactory.php
+++ b/src/Model/VersioningModelFactory.php
@@ -9,7 +9,12 @@ namespace ZF\Apigility\Admin\Model;
 use ZF\Configuration\ModuleUtils;
 use ZF\Configuration\ResourceFactory as ConfigResourceFactory;
 
-class VersioningModelFactory
+/**
+ * Class VersioningModelFactory
+ *
+ * @deprecated use \ZF\Apigility\Admin\Model\ModuleVersioningModelFactory instead
+ */
+class VersioningModelFactory implements ModuleVersioningModelFactoryInterface
 {
     /**
      * @var ConfigResourceFactory
@@ -29,7 +34,9 @@ class VersioningModelFactory
     protected $moduleUtils;
 
     /**
-     * @param  ConfigResourceFactory $configFactory
+     * @param ConfigResourceFactory $configFactory
+     * @param ModulePathSpec $moduleUtils
+     * @deprecated
      */
     public function __construct(ConfigResourceFactory $configFactory, ModulePathSpec $moduleUtils)
     {
@@ -39,7 +46,8 @@ class VersioningModelFactory
 
     /**
      * @param  string $module
-     * @return RpcServiceModel
+     * @return VersioningModel
+     * @deprecated
      */
     public function factory($module)
     {
@@ -47,10 +55,15 @@ class VersioningModelFactory
             return $this->models[$module];
         }
 
-        $config     = $this->configFactory->factory($this->normalizeModuleName($module));
+        $moduleName = $this->normalizeModuleName($module);
+        $config     = $this->configFactory->factory($moduleName);
         $docsConfig = $this->getDocsConfig($module);
 
-        $this->models[$module] = new VersioningModel($config, $docsConfig);
+        $this->models[$module] = new VersioningModel(
+            $config,
+            $docsConfig,
+            $this->moduleUtils
+        );
 
         return $this->models[$module];
     }
@@ -58,12 +71,19 @@ class VersioningModelFactory
     /**
      * @param  string $name
      * @return string
+     * @deprecated
      */
     protected function normalizeModuleName($name)
     {
-        return str_replace('.', '\\', $name);
+        return str_replace(['.', '/'], '\\', $name);
     }
 
+    /**
+     * getDocsConfig
+     * @param $module
+     * @return null|\ZF\Configuration\ConfigResource
+     * @deprecated
+     */
     protected function getDocsConfig($module)
     {
         $moduleConfigPath = $this->moduleUtils->getModuleConfigPath($module);

--- a/test/InputFilter/ModuleInputFilterTest.php
+++ b/test/InputFilter/ModuleInputFilterTest.php
@@ -46,10 +46,6 @@ class ModuleInputFilterTest extends TestCase
                 ['name' => '_'],
                 ['name'],
             ],
-            'namespace-separator' => [
-                ['name' => 'My\Status'],
-                ['name'],
-            ],
         ];
     }
 


### PR DESCRIPTION
This PR makes changes necessary for Apigility Admin to support API modules that use PSR-4 autoloading and have namespaces in their names.

* New classes were added in order to avoid changing the public interface of existing classes. This will hopefully simplify the transition.
  * Class `ModuleVersioningModel` was added to replace `VersioningModel`. The latter was deprecated and now pretty much just proxies to the new class.
  * Similar thing with `ModuleVersioningModelFactory` only that the old version will still create a `VersioningModel` instance because that's a proxy to the new class anyway.
  * A new interface `ModuleVersioningModelFactoryInterface` (long name, yes) was created and implemented in both factories in order to allow `VersioningController` to transparently be injected with either the old or the new factory. This doesn't break backwards-compatibility with the public interface of `VersioningController` because the new interface is a sub-type of `VersioningModelFactory`.
* The new `ModuleVersioningModel` was simplified significantly over its predecessor. Each instance now represents a single API module, which scopes down its responsibilities and simplified the internal logic. The only exception is the `setDefaultVersion()` method, which seems mostly idempotent anyway, but could be moved somewhere else in the future.
* `ModuleVersioningModelFactory` is now used to inject module data into the factoried class. This allows us to use data from `ModulePathSpec` within `ModuleVersioningModel` to get info about each API module without having to resort to other mechanisms (e.g. reflection) like what was previously being done.

EDIT: removed a section that's no longer relevant.

#### Namespaced API Names
By "namespaced API names" I refer to API modules powered by Apigility that have namespaces in their name, for example "Acme\Account". Previous to this PR support for this was very limited and slightly awkward: backslashes (\\) were being converted to periods (.) and there didn't seem to be much of a reason behind that because namespaced API names just weren't properly supported except for "read" operations (or at least that was my experience).

#### Tests
Right now there are no tests for the new classes. But the old tests for `VersioningModel` will consume the new class and therefore the public-facing business logic will be properly tested. It would be of course better to have direct tests though, and I'll happily add those if this PR is accepted to be merged :)

#### BC Breaks
There are no backwards-incompatible changes when considering the public API of any of the classes.

There are, however BC-breaks at an inheritance level on the `VersioningModel` class (and a few other as well) because some protected methods were removed. I think this had to be done because any classes extending the deprecated classes in order to override one of those protected methods WILL result in unexpected behavior due to the "proxy" nature of the deprecated `VersioningModel` class. All newly added classes are declared as final to prevent issues like this in the future.

Since namespaced API names are a new feature and nothing changed for APIs that do not use them, this PR doesn't break BC from a business-logic point of view. In other words it should be an easy upgrade-path for most Apigility users, as long as they're not subclassing from `VersioningModel` to override behaviour. 

Finally, to make proper use of this feature within Apigility's Admin UI project, zfcampus/zf-apigility-admin-ui#97 would have to be merged as well.