### PR TITLE
Improved Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,10 @@ Installation
 Run the following `composer` command:
 
 ```console
-$ composer require --dev "zfcampus/zf-apigility-admin:~1.0-dev"
+$ composer require --dev "zfcampus/zf-apigility-admin"
 ```
 
-Alternately, manually add the following to your `composer.json`, in the `require` section:
-
-```javascript
-"require-dev": {
-    "zfcampus/zf-apigility-admin": "~1.0-dev"
-}
-```
-
-And then run `composer update` to ensure the module is installed.
+And then run `composer install` to ensure the module is installed.
 
 Finally, add the module name to your project's `config/application.config.php` under the `modules`
 key:


### PR DESCRIPTION
A few changes that I think are important:
* The package has now stable releases. So we should remove the version constraint on the "composer require" call.
* Removed the part about making the changes to `composer.json` manually: having that section on the README requires unnecessary maintenance (it has to be updated with every stable release).
* Running `composer update` to install the recently-required package is a bad idea because it will update all other packages. `composer install` should be used instead. Or `composer update --lock` at the very least.