### PR TITLE
Hotfix/service locator aware interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ install:
 
 script:
   - ./vendor/bin/phpunit
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs ; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs --standard=PSR2 src/ test/ config/ Module.php ; fi

--- a/Module.php
+++ b/Module.php
@@ -169,7 +169,10 @@ class Module
                 }
                 $config = $services->get('Config');
 
-                return new Model\DbAutodiscoveryModel($config);
+                $instance = new Model\DbAutodiscoveryModel($config);
+                $instance->setServiceLocator($services);
+
+                return $instance;
             },
             'ZF\Apigility\Admin\Model\ContentNegotiationModel' => function ($services) {
                 if (!$services->has('Config')) {

--- a/Module.php
+++ b/Module.php
@@ -244,8 +244,13 @@ class Module
                         . 'because ZF\Apigility\Admin\Model\DoctrineAdapterModel service is not present'
                     );
                 }
+
                 $model = $services->get('ZF\Apigility\Admin\Model\DoctrineAdapterModel');
-                return new Model\DoctrineAdapterResource($model);
+
+                $modules = $services->get('ModuleManager');
+                $loadedModules = $modules->getLoadedModules(false);
+
+                return new Model\DoctrineAdapterResource($model, $loadedModules);
             },
             'ZF\Apigility\Admin\Model\ModulePathSpec' => function ($services) {
                 if (!$services->has('ZF\Configuration\ModuleUtils')) {

--- a/src/Model/AbstractAutodiscoveryModel.php
+++ b/src/Model/AbstractAutodiscoveryModel.php
@@ -3,10 +3,15 @@
 namespace ZF\Apigility\Admin\Model;
 
 use Zend\Filter\StaticFilter;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Exception;
 
-abstract class AbstractAutodiscoveryModel implements ServiceLocatorAwareInterface
+/**
+ * This class is instantiated with a $config in some implementations (DbAutodiscoveryModel)
+ * but this is dependent on the root service locator for the moduleHasService call below
+ * and that must be injected into any class extending this abstract.
+ */
+abstract class AbstractAutodiscoveryModel
 {
     /**
      * @var ServiceLocatorInterface
@@ -60,6 +65,10 @@ abstract class AbstractAutodiscoveryModel implements ServiceLocatorAwareInterfac
      */
     public function getServiceLocator()
     {
+        if (! $this->serviceLocator) {
+            throw new Exception('The AbstractAutodiscoveryModel must be composed with a service locator');
+        }
+
         return $this->serviceLocator;
     }
 
@@ -72,6 +81,7 @@ abstract class AbstractAutodiscoveryModel implements ServiceLocatorAwareInterfac
     public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
+
         return $this;
     }
 

--- a/src/Model/AbstractPluginManagerModel.php
+++ b/src/Model/AbstractPluginManagerModel.php
@@ -58,6 +58,7 @@ class AbstractPluginManagerModel
         $invokables = array_flip($reflProp->getValue($this->pluginManager));
         $plugins    = array_merge($invokables, $this->pluginManager->getCanonicalNames());
 
+        $this->plugins = array();
         foreach ($plugins as $name => $canonical) {
             $this->plugins[] = $name;
         }

--- a/src/Model/AuthenticationModel.php
+++ b/src/Model/AuthenticationModel.php
@@ -904,7 +904,6 @@ class AuthenticationModel
                     $result['type'] = 'custom';
                     $result['route'] = isset($adapter['storage']['route']) ? $adapter['storage']['route'] : null;
             }
-
         }
         return $result;
     }

--- a/src/Model/DoctrineAdapterResource.php
+++ b/src/Model/DoctrineAdapterResource.php
@@ -7,19 +7,12 @@
 namespace ZF\Apigility\Admin\Model;
 
 use Zend\Http\Response;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\ApiProblem\ApiProblem;
 use ZF\Rest\Exception\CreationException;
 use ZF\Rest\AbstractResourceListener;
 
-class DoctrineAdapterResource extends AbstractResourceListener implements ServiceLocatorAwareInterface
+class DoctrineAdapterResource extends AbstractResourceListener
 {
-    /**
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
-
     /**
      * @var DbAdapterModel
      */
@@ -34,29 +27,6 @@ class DoctrineAdapterResource extends AbstractResourceListener implements Servic
     {
         $this->model = $model;
     }
-
-    /**
-     * Set service locator
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return DoctrineAdapterResource
-     */
-    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
-    {
-        $this->serviceLocator = $serviceLocator;
-        return $this;
-    }
-
-    /**
-     * Get service locator
-     *
-     * @return ServiceLocatorInterface
-     */
-    public function getServiceLocator()
-    {
-        return $this->serviceLocator;
-    }
-
 
     /**
      * @param $id
@@ -77,10 +47,8 @@ class DoctrineAdapterResource extends AbstractResourceListener implements Servic
      */
     public function fetchAll($params = [])
     {
-        $modules = $this->getServiceLocator()->get('ModuleManager');
-        $loaded = $modules->getLoadedModules(false);
-
-        if (!isset($loaded['ZF\Apigility\Doctrine\Admin']) || !isset($loaded['ZF\Apigility\Doctrine\Server'])) {
+        if (! class_exists('ZF\Apigility\Doctrine\Admin\Module')
+            || ! class_exists('ZF\Apigility\Doctrine\Server\Module')) {
             $response = new Response();
             $response->setStatusCode(204);
             return $response;

--- a/src/Model/DoctrineAdapterResource.php
+++ b/src/Model/DoctrineAdapterResource.php
@@ -19,13 +19,19 @@ class DoctrineAdapterResource extends AbstractResourceListener
     protected $model;
 
     /**
+     * @var array
+     */
+    protected $loadedModules;
+
+    /**
      * Constructor
      *
      * @param DoctrineAdapterModel $model
      */
-    public function __construct(DoctrineAdapterModel $model)
+    public function __construct(DoctrineAdapterModel $model, array $loadedModules)
     {
         $this->model = $model;
+        $this->loadedModules = $loadedModules;
     }
 
     /**
@@ -47,10 +53,11 @@ class DoctrineAdapterResource extends AbstractResourceListener
      */
     public function fetchAll($params = [])
     {
-        if (! class_exists('ZF\Apigility\Doctrine\Admin\Module')
-            || ! class_exists('ZF\Apigility\Doctrine\Server\Module')) {
+        if (! isset($this->loadedModules['ZF\Apigility\Doctrine\Admin'])
+            || ! isset($this->loadedModules['ZF\Apigility\Doctrine\Server'])) {
             $response = new Response();
             $response->setStatusCode(204);
+
             return $response;
         }
 

--- a/src/Model/DocumentationModel.php
+++ b/src/Model/DocumentationModel.php
@@ -51,7 +51,7 @@ class DocumentationModel
                     ],
                     'description' => null
                 ];
-                    case self::TYPE_RPC:
+            case self::TYPE_RPC:
                 return [
                     'description' => null,
                     'GET'    => ['description' => null, 'request' => null, 'response' => null],

--- a/test/Model/HydratorsModelTest.php
+++ b/test/Model/HydratorsModelTest.php
@@ -17,4 +17,13 @@ class HydratorsModelTest extends AbstractPluginManagerModelTest
         $this->plugins = new HydratorPluginManager();
         $this->model = new HydratorsModel($this->plugins);
     }
+
+    public function testFetchAllReturnsListOfAvailablePlugins()
+    {
+        $services = $this->model->fetchAll();
+        $this->assertGreaterThan(-1, count($services));
+        foreach ($services as $service) {
+            $this->assertContains($this->namespace, $service);
+        }
+    }
 }


### PR DESCRIPTION
This removes the ServiceLocatorAwareInterface requirement of this module.  It also corrects a unit test where invokable classes are expected to exist on the zend-hydrator HydratorPluginManager but this plugin manager has none.

https://github.com/zfcampus/zf-apigility-admin/issues/341#issuecomment-224826598
https://github.com/zfcampus/zf-apigility-admin/issues/339
https://github.com/zfcampus/zf-apigility-admin/issues/332
