### PR TITLE
Allow forwards-compatibility with zf-hal 1.4

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -625,7 +625,7 @@ class Module
      */
     protected function injectServiceLinks(Entity $halEntity, HalJsonModel $model, $e)
     {
-        $entity = $halEntity->entity;
+        $entity = method_exists($halEntity, 'getEntity') ? $halEntity->getEntity() : $halEntity->entity;
         $links  = $halEntity->getLinks();
         if ($entity instanceof Model\ModuleEntity) {
             $this->injectModuleResourceRelationalLinks($entity, $links, $model);
@@ -707,7 +707,7 @@ class Module
     public function onRenderEntity($e)
     {
         $halEntity = $e->getParam('entity');
-        $entity    = $halEntity->entity;
+        $entity    = method_exists($halEntity, 'getEntity') ? $halEntity->getEntity() : $halEntity->entity;
         $hal       = $e->getTarget();
 
         if ($entity instanceof Model\RestServiceEntity

--- a/src/Model/AbstractPluginManagerModel.php
+++ b/src/Model/AbstractPluginManagerModel.php
@@ -58,7 +58,7 @@ class AbstractPluginManagerModel
         $invokables = array_flip($reflProp->getValue($this->pluginManager));
         $plugins    = array_merge($invokables, $this->pluginManager->getCanonicalNames());
 
-        $this->plugins = array();
+        $this->plugins = [];
         foreach ($plugins as $name => $canonical) {
             $this->plugins[] = $name;
         }

--- a/test/Controller/AuthenticationControllerTest.php
+++ b/test/Controller/AuthenticationControllerTest.php
@@ -111,7 +111,7 @@ class AuthenticationControllerTest extends TestCase
         $payload = $result->getVariable('payload');
         $this->assertInstanceOf('ZF\Hal\Entity', $payload);
 
-        $metadata = $payload->entity;
+        $metadata = method_exists($payload, 'getEntity') ? $payload->getEntity() : $payload->entity;
         $this->assertEquals('testbasic', $metadata['name']);
     }
 
@@ -246,7 +246,7 @@ class AuthenticationControllerTest extends TestCase
         $params = $self->getRouteParams();
         $this->assertEquals('testbasic', $params['authentication_adapter']);
 
-        $metadata = $payload->entity;
+        $metadata = method_exists($payload, 'getEntity') ? $payload->getEntity() : $payload->entity;
         $this->assertEmpty(array_diff_key($metadata, $postData));
     }
 

--- a/test/Controller/InputFilterControllerTest.php
+++ b/test/Controller/InputFilterControllerTest.php
@@ -115,7 +115,7 @@ class InputFilterControllerTest extends TestCase
         $this->assertInstanceOf('ZF\ContentNegotiation\ViewModel', $result);
         $payload = $result->payload;
         $this->assertInstanceOf('ZF\Hal\Entity', $payload);
-        $entity = $payload->entity;
+        $entity = method_exists($payload, 'getEntity') ? $payload->getEntity() : $payload->entity;
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\InputFilterEntity', $entity);
 
         $expected = $this->config['input_filter_specs'][$validator];
@@ -174,7 +174,7 @@ class InputFilterControllerTest extends TestCase
         $this->assertInstanceOf('ZF\ContentNegotiation\ViewModel', $result);
         $payload = $result->payload;
         $this->assertInstanceOf('ZF\Hal\Entity', $payload);
-        $entity = $payload->entity;
+        $entity = method_exists($payload, 'getEntity') ? $payload->getEntity() : $payload->entity;
         $this->assertInstanceOf('ZF\Apigility\Admin\Model\InputFilterEntity', $entity);
 
         $config    = include $this->basePath . '/module.config.php';

--- a/test/Controller/ModuleCreationControllerTest.php
+++ b/test/Controller/ModuleCreationControllerTest.php
@@ -106,11 +106,11 @@ class ModuleCreationControllerTest extends TestCase
 
         $this->assertInstanceOf('ZF\ContentNegotiation\ViewModel', $result);
         $payload = $result->getVariable('payload');
+        $entity = method_exists($payload, 'getEntity') ? $payload->getEntity() : $payload->entity;
         $this->assertInstanceOf('ZF\Hal\Entity', $payload);
-        $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $payload->entity);
+        $this->assertInstanceOf('ZF\Apigility\Admin\Model\ModuleEntity', $entity);
 
-        $metadata = $payload->entity;
-        $this->assertEquals('Foo', $metadata->getName());
+        $this->assertEquals('Foo', $entity->getName());
 
         $this->removeDir($tmpDir);
         chdir($currentDir);

--- a/test/Model/DocumentationModelTest.php
+++ b/test/Model/DocumentationModelTest.php
@@ -6,10 +6,10 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
+use Zend\Config\Writer\WriterInterface;
 use ZF\Apigility\Admin\Model\DocumentationModel;
 use ZF\Configuration\ModuleUtils;
 use ZF\Configuration\ResourceFactory;
-use ZFTest\Configuration\TestAsset\ConfigWriter;
 
 class DocumentationModelTest extends \PHPUnit_Framework_TestCase
 {
@@ -32,9 +32,11 @@ class DocumentationModelTest extends \PHPUnit_Framework_TestCase
             ->method('getModuleConfigPath')
             ->will($this->returnValue(__DIR__ . '/TestAsset/module/Doc/config/module.config.php'));
 
+        $mockWriter = $this->getMockBuilder(WriterInterface::class)->getMock();
+
         $configResourceFactory = new ResourceFactory(
             $mockModuleUtils,
-            new ConfigWriter()
+            $mockWriter
         );
         $this->docModel = new DocumentationModel($configResourceFactory, $mockModuleUtils);
     }

--- a/test/Model/ModulePathSpecTest.php
+++ b/test/Model/ModulePathSpecTest.php
@@ -66,7 +66,6 @@ class ModulePathSpecTest extends TestCase
 
         $this->assertEquals($basePath . 'Rpc/', $pathSpec->getRpcPath('ModuleName', 2));
         $this->assertEquals($basePath . 'Rpc/ServiceName', $pathSpec->getRpcPath('ModuleName', 2, 'ServiceName'));
-
     }
 
     /**

--- a/test/Model/RpcServiceModelTest.php
+++ b/test/Model/RpcServiceModelTest.php
@@ -89,7 +89,6 @@ class RpcServiceModelTest extends TestCase
 
     protected function setCurrentModule()
     {
-
     }
 
     public function tearDown()


### PR DESCRIPTION
This patch updates `Module` to pull entities from `ZF\Hal\Entity` instances using that class's `getModule()` method if it is present, falling back to direct property access otherwise. This allows it to be used with zf-hal 1.4 without emitting deprecation notices - which often caused admin API calls to fail!

A number of test classes also were pulling the composed entity using property access, and were updated; these include the `AuthenticationControllerTest`, `InputFilterControllerTest`, and `ModuleCreationControllerTest`.

Finally, when running tests and CS checks, I discovered the following:

- `DocumentationModelTest` was relying on a test asset from zf-configuration; however, the test directory is now omitted from distribution packages, which makes tests fail. I updated to use a mock object instead.
- CS checks failed when running phpcs; I ran phpcbf to correct them.