### PR TITLE
Apigility admin fields filter list not fully showing

### DIFF
--- a/src/Model/FiltersModel.php
+++ b/src/Model/FiltersModel.php
@@ -54,6 +54,7 @@ class FiltersModel extends AbstractPluginManagerModel
         $plugins  = parent::getPlugins();
         $plugins  = array_flip($plugins);
         $metadata = $this->metadata;
+        $plugins = array_merge($plugins, $metadata);
 
         array_walk($plugins, function (& $value, $key) use ($metadata) {
             if (! array_key_exists($key, $metadata)) {


### PR DESCRIPTION
In apigility UI, when you want to fetch list of Filters, it is not showing full list. Now that bug fixed.
