### PR TITLE
Expose the apigility-version API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ update your application using the following steps:
 - Update your `config/development.config.php` and
   `config/development.config.php.dist` files:
   - Remove from the modules list:
-    - 'ZFTool`
+    - `ZFTool`
 - Remove `composer.lock`
 - Remove, recursively, the `vendor/` subdirectory
 - Execute `composer install`
@@ -165,7 +165,6 @@ update your application using the following steps:
 > $ ./vendor/bin/zf-development-mode status
 > ```
 
-
 Configuration
 -------------
 
@@ -186,6 +185,27 @@ API Endpoints
 -------------
 
 All routes are prefixed with `/apigility` by default.
+
+### api/apigility-version
+
+- Since 1.5.1
+
+Returns the current Apigility version if it can be discovered, and the string
+`@dev` otherwise. The payload is in the `version` key:
+
+```json
+{
+    "version": "1.4.0"
+}
+```
+
+- `Accept`: `application/json`
+
+- `Content-Type`: `application/json`
+
+- Methods: `GET`
+
+- Errors: none
 
 ### api/config
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "zendframework/zend-validator": "^2.8.1",
         "zendframework/zend-view": "^2.8.1",
         "zfcampus/zf-apigility": "^1.3",
-        "zfcampus/zf-apigility-admin-ui": "^1.3.2",
+        "zfcampus/zf-apigility-admin-ui": "^1.3.3",
         "zfcampus/zf-apigility-provider": "^1.2",
         "zfcampus/zf-api-problem": "^1.2.1",
         "zfcampus/zf-configuration": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f30d0c644ded96821154a6acfeaee5c6",
-    "content-hash": "fc4f3cca902b7da88d1fb5f231e0109d",
+    "hash": "d9cef99e8107e0f5aaeec1e1d87eca00",
+    "content-hash": "6357981539a352a581f998de931498a1",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
@@ -1659,16 +1659,16 @@
         },
         {
             "name": "zfcampus/zf-apigility-admin-ui",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-apigility-admin-ui.git",
-                "reference": "bc896d2ab41775daef8ba4e8e2f8c982a5ed1fe2"
+                "reference": "a1b7d037f6af48e69331cc7e83df327cec6da91c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-apigility-admin-ui/zipball/bc896d2ab41775daef8ba4e8e2f8c982a5ed1fe2",
-                "reference": "bc896d2ab41775daef8ba4e8e2f8c982a5ed1fe2",
+                "url": "https://api.github.com/repos/zfcampus/zf-apigility-admin-ui/zipball/a1b7d037f6af48e69331cc7e83df327cec6da91c",
+                "reference": "a1b7d037f6af48e69331cc7e83df327cec6da91c",
                 "shasum": ""
             },
             "require": {
@@ -1706,7 +1706,7 @@
                 "framework",
                 "zf2"
             ],
-            "time": "2016-08-09 19:14:03"
+            "time": "2016-08-10 16:34:24"
         },
         {
             "name": "zfcampus/zf-apigility-provider",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -64,6 +64,7 @@ return [
             Controller\Versioning::class               => Controller\VersioningController::class,
         ],
         'factories' => [
+            Controller\ApigilityVersionController::class => InvokableFactory::class,
             Controller\AppController::class            => InvokableFactory::class,
             Controller\AuthenticationController::class => Controller\AuthenticationControllerFactory::class,
             Controller\AuthenticationType::class       => Controller\AuthenticationTypeControllerFactory::class,
@@ -113,6 +114,16 @@ return [
                         ],
                         'may_terminate' => false,
                         'child_routes' => [
+                            'apigility-version' => [
+                                'type' => 'Literal',
+                                'options' => [
+                                    'route' => '/apigility-version',
+                                    'defaults' => [
+                                        'controller' => Controller\ApigilityVersionController::class,
+                                        'action'     => 'index',
+                                    ],
+                                ],
+                            ],
                             'dashboard' => [
                                 'type' => 'Literal',
                                 'options' => [
@@ -459,6 +470,7 @@ return [
 
     'zf-content-negotiation' => [
         'controllers' => [
+            Controller\ApigilityVersionController::class => 'Json',
             Controller\Authentication::class           => 'HalJson',
             Controller\AuthenticationType::class       => 'Json',
             Controller\Authorization::class            => 'HalJson',
@@ -488,6 +500,10 @@ return [
             Controller\Versioning::class               => 'Json',
         ],
         'accept_whitelist' => [
+            Controller\ApigilityVersionController::class => [
+                'application/json',
+                'application/*+json',
+            ],
             Controller\Authentication::class => [
                 'application/json',
                 'application/*+json',
@@ -864,6 +880,10 @@ return [
     ],
 
     'zf-rpc' => [
+        Controller\ApigilityVersionController::class => [
+            'http_methods' => ['GET'],
+            'route_name'   => 'zf-apigility/api/apigility-version',
+        ],
         Controller\Authentication::class => [
             'http_methods' => ['GET', 'POST', 'PUT', 'DELETE'],
             'route_name'   => 'zf-apigility/api/authentication',

--- a/src/Controller/ApigilityVersionController.php
+++ b/src/Controller/ApigilityVersionController.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Admin\Controller;
+
+use Zend\Mvc\Controller\AbstractActionController;
+use Zend\View\Model\JsonModel;
+
+class ApigilityVersionController extends AbstractActionController
+{
+    public function indexAction()
+    {
+        return new JsonModel([
+            'version' => defined('Apigility\VERSION') ? \Apigility\VERSION : '@dev',
+        ]);
+    }
+}


### PR DESCRIPTION
In order to allow separating the skeleton version from the UI version, we need to be able to report the former to the latter.

zfcampus/zf-apigility-skeleton#130 adds a new constant, `Apigility\VERSION`, which reports the current skeleton version. zfcampus/zf-apigility-admin-ui updates the UI's "About" tab to:

- use `@dev` by default for the version
- attempt to query the apigility-version API exposed by the admin
  - if not available, keeps the `@dev` default
  - if it returns something unexpected, keeps the `@dev` default
  - but otherwise, reports that version

This patch exposes the apigility-version API. It will return the value of `Apigility\VERSION`, if defined, but otherwise return `@dev`.