### PR TITLE
Have upgrade script install zend-mvc-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,21 @@ update your application using the following steps:
   - Add:
     - `require.zendframework/zend-cache`, with a constraint of `2.7.1`
     - `require.zendframework/zend-log`, with a constraint of `2.9`
+    - `require.zendframework/zend-mvc-i18n`, with a constraint of `1.0`
     - `require-dev.zfcampus/zf-asset-manager`, with a constraint of `^1.0`
 - Update your `config/modules.config.php`:
   - Remove:
     - `AssetManager`
     - `ZF\DevelopmentMode`
   - Add, at the top of the list:
+    - `Zend\Cache`
     - `Zend\Db`
     - `Zend\Filter`
     - `Zend\Hydrator`
     - `Zend\InputFilter`
+    - `Zend\I18n`
+    - `Zend\Log`
+    - `Zend\Mvc\I18n`
     - `Zend\Paginator`
     - `Zend\Router`
     - `Zend\Validator`

--- a/bin/apigility-upgrade-to-1.5
+++ b/bin/apigility-upgrade-to-1.5
@@ -33,7 +33,9 @@ $modulesToAdd = [
     'Zend\Filter',
     'Zend\Hydrator',
     'Zend\InputFilter',
+    'Zend\I18n',
     'Zend\Log',
+    'Zend\Mvc\I18n',
     'Zend\Paginator',
     'Zend\Router',
     'Zend\Validator',
@@ -140,6 +142,7 @@ function updateComposerJson($path)
 
     // Add entries
     $composer['require']['zendframework/zend-cache'] = '^2.7.1';
+    $composer['require']['zendframework/zend-mvc-i18n'] = '^1.0';
     $composer['require']['zendframework/zend-log'] = '^2.9';
     $composer['require-dev']['zfcampus/zf-asset-manager'] = '^1.0';
 


### PR DESCRIPTION
The default skeleton from previous versions includes translation features in the layout; when development mode is off, these then are executed, and, for those upgrading, lack of i18n causes fatal errors.

This patch makes the following changes to the upgrade script:

- Adds zend-mvc-i18n as an application requirement.
- Injects both `Zend\I18n` and `Zend\Mvc\I18n` as production modules.

Reported by @jackdpeterson in #apigility-dev