### PR TITLE
Document zf-apigility-admin.path_spec configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,25 @@ update your application using the following steps:
 Configuration
 -------------
 
-There is no custom user level configuration for this module.
-
 Since this particular module is responsible for providing APIs and the Apigility Admin UI, it has a
 significant amount of configuration that it requires in order to function in a development
 environment. Since it is highly unlikely that developers would need to modify the system-level
 configuration, it is omitted in this README, but can be found [within the
 repository](https://github.com/zfcampus/zf-apigility-admin/tree/master/config/module.config.php).
+
+Additionally, the module defines the following module-specific configuration,
+under the top-level key `zf-apigility-admin`:
+
+### Key: path_spec
+
+By default, zf-apigility-admin will create new Apigility modules using
+[PSR-0](http://www.php-fig.org/psr/psr-0/) directory structure. You can switch
+to [PSR-4](http://www.php-fig.org/psr/psr-4/) using the
+`zf-apigility-admin.path_spec` configuration, which accepts one of the following
+values:
+
+- `ZF\Apigility\Admin\Model\ModulePathSpec::PSR_0` ('psr-0')
+- `ZF\Apigility\Admin\Model\ModulePathSpec::PSR_4` ('psr-4')
 
 Routes
 ------

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -9,6 +9,15 @@ namespace ZF\Apigility\Admin;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
+    'zf-apigility-admin' => [
+        // path_spec defines whether modules should be created using PSR-0
+        //     or PSR-4 module structure; the default is to use PSR-0.
+        //     Valid values are:
+        //     - ZF\Apigility\Admin\Model\ModulePathSpec::PSR_0 ("psr-0")
+        //     - ZF\Apigility\Admin\Model\ModulePathSpec::PSR_4 ("psr-4")
+        // 'path_spec' => 'psr-0',
+    ],
+
     'service_manager' => [
         'factories' => [
             // @codingStandardsIgnoreStart


### PR DESCRIPTION
In prepping the Apigility 1.4 skeleton, I discovered that we were not yet documenting the `zf-apigility-admin.path_spec` configuration, which has been available since 1.1.0. This patch adds documentation in the README, as well as the module configuration.