### PR TITLE
Create modules.config.php using short array notation

### DIFF
--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -21,6 +21,16 @@ use ZF\Apigility\Provider\ApigilityProviderInterface;
 class ModuleModel
 {
     /**
+     * @var bool
+     */
+    protected static $useShortArrayNotation = false;
+
+    /**
+     * @var ValueGenerator
+     */
+    protected static $valueGenerator;
+
+    /**
      * Services for each module
      * @var array
      */
@@ -30,6 +40,11 @@ class ModuleModel
      * @var ModuleManager
      */
     protected $moduleManager;
+
+    /**
+     * @var string
+     */
+    protected $modulePathSpec;
 
     /**
      * @var array
@@ -45,13 +60,6 @@ class ModuleModel
      * @var array
      */
     protected $rpcConfig;
-
-    /**
-     * @var ValueGenerator
-     */
-    protected static $valueGenerator;
-
-    protected $modulePathSpec;
 
     /**
      * @param  ModuleManager $moduleManager
@@ -79,10 +87,26 @@ class ModuleModel
             static::$valueGenerator = new ValueGenerator();
         }
         static::$valueGenerator->setValue($config);
-        static::$valueGenerator->setType(ValueGenerator::TYPE_ARRAY_SHORT);
+        static::$valueGenerator->setType(
+            static::$useShortArrayNotation
+            ? ValueGenerator::TYPE_ARRAY_SHORT
+            : ValueGenerator::TYPE_ARRAY_LONG
+        );
         static::$valueGenerator->setArrayDepth($indent);
 
         return static::$valueGenerator;
+    }
+
+    /**
+     * Set the flag indicating whether or not generated config files should use
+     * short array notation.
+     *
+     * @var bool $flag
+     * @return void
+     */
+    public function setUseShortArrayNotation($flag = true)
+    {
+        static::$useShortArrayNotation = (bool) $flag;
     }
 
     /**

--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -79,6 +79,7 @@ class ModuleModel
             static::$valueGenerator = new ValueGenerator();
         }
         static::$valueGenerator->setValue($config);
+        static::$valueGenerator->setType(ValueGenerator::TYPE_ARRAY_SHORT);
         static::$valueGenerator->setArrayDepth($indent);
 
         return static::$valueGenerator;

--- a/src/Model/ModuleModelFactory.php
+++ b/src/Model/ModuleModelFactory.php
@@ -27,11 +27,15 @@ class ModuleModelFactory
 
         $config = $this->getConfig($container);
 
-        return new ModuleModel(
+        $model = new ModuleModel(
             $container->get('ModuleManager'),
             $this->getNamedConfigArray('zf-rest', $config),
             $this->getNamedConfigArray('zf-rpc', $config)
         );
+
+        $model->setUseShortArrayNotation($this->useShortArrayNotation($config));
+
+        return $model;
     }
 
     /**
@@ -53,5 +57,23 @@ class ModuleModelFactory
         return (isset($config[$name]) && is_array($config[$name]))
             ? $config[$name]
             : [];
+    }
+
+    /**
+     * Determine whether or not to enable generation of short array notation
+     *
+     * @param array $config
+     * @return bool
+     */
+    private function useShortArrayNotation(array $config)
+    {
+        $config = $this->getNamedConfigArray('zf-configuration', $config);
+        if (! isset($config['enable_short_array'])
+            || false === $config['enable_short_array']
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/test/Model/ModuleModelFactoryTest.php
+++ b/test/Model/ModuleModelFactoryTest.php
@@ -8,6 +8,7 @@ namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\ModuleModel;
@@ -18,6 +19,11 @@ class ModuleModelFactoryTest extends TestCase
     public function setUp()
     {
         $this->container = $this->prophesize(ContainerInterface::class);
+
+        // Ensure we start with the default short array notation flag value
+        $r = new ReflectionProperty(ModuleModel::class, 'useShortArrayNotation');
+        $r->setAccessible(true);
+        $r->setValue(false);
     }
 
     public function testFactoryRaisesExceptionForMissingModuleManagerInContainer()
@@ -50,5 +56,29 @@ class ModuleModelFactoryTest extends TestCase
         $this->assertAttributeSame($moduleManager, 'moduleManager', $model);
         $this->assertAttributeEquals(array_keys($config['zf-rest']), 'restConfig', $model);
         $this->assertAttributeEquals(array_keys($config['zf-rpc']), 'rpcConfig', $model);
+    }
+
+    public function testFactoryCanConfigureShortArrayNotationFlag()
+    {
+        $factory = new ModuleModelFactory();
+        $config  = [
+            'zf-configuration' => ['enable_short_array' => true],
+            'zf-rest' => ['rest configuration' => true],
+            'zf-rpc'  => ['rpc configuration' => true],
+        ];
+        $moduleManager = $this->prophesize(ModuleManager::class)->reveal();
+
+        $this->container->has('ModuleManager')->willReturn(true);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->get('ModuleManager')->willReturn($moduleManager);
+
+        $model = $factory($this->container->reveal());
+        $this->assertInstanceOf(ModuleModel::class, $model);
+
+        $r = new ReflectionProperty(ModuleModel::class, 'useShortArrayNotation');
+        $r->setAccessible(true);
+        $flag = $r->getValue();
+        $this->assertTrue($flag, 'useShortArrayNotation flag was not enabled');
     }
 }

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -513,7 +513,19 @@ class ModuleModelTest extends TestCase
         $this->assertInternalType('array', $modules);
         $this->assertContains('Foo', $modules);
 
+        $contents = file_get_contents("$modulePath/config/modules.config.php");
+
         $this->removeDir($modulePath);
-        return true;
+
+        return $contents;
+    }
+
+    /**
+     * @depends testWritesToModuleConfigFileOnModuleCreationWhenModuleConfigFileExists
+     */
+    public function testWritesShortArrayNotationByDefault($contents)
+    {
+        $this->assertNotContains('array(', $contents);
+        $this->assertContains('return [', $contents);
     }
 }

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -54,11 +54,12 @@ class ModuleModelTest extends TestCase
             'ZFTest\Apigility\Admin\Model\TestAsset\Bob\Controller\Do'  => null,
         ];
 
-        $this->model         = new ModuleModel(
+        $this->model = new ModuleModel(
             $this->moduleManager,
             $restConfig,
             $rpcConfig
         );
+        $this->model->setUseShortArrayNotation(false);
     }
 
     public function tearDown()
@@ -513,18 +514,29 @@ class ModuleModelTest extends TestCase
         $this->assertInternalType('array', $modules);
         $this->assertContains('Foo', $modules);
 
-        $contents = file_get_contents("$modulePath/config/modules.config.php");
-
         $this->removeDir($modulePath);
-
-        return $contents;
     }
 
-    /**
-     * @depends testWritesToModuleConfigFileOnModuleCreationWhenModuleConfigFileExists
-     */
-    public function testWritesShortArrayNotationByDefault($contents)
+    public function testWritesShortArrayNotationWhenRequested()
     {
+        $this->model->setUseShortArrayNotation(true);
+
+        $module     = 'Foo';
+        $modulePath = sys_get_temp_dir() . "/" . uniqid(str_replace('\\', '_', __NAMESPACE__) . '_');
+
+        mkdir("$modulePath/module", 0775, true);
+        mkdir("$modulePath/config", 0775, true);
+        file_put_contents(
+            "$modulePath/config/application.config.php",
+            '<' . '?php return array(\'modules\' => include __DIR__ . \'/modules.config.php\');'
+        );
+        file_put_contents("$modulePath/config/modules.config.php", '<' . '?php return array();');
+
+        $pathSpec = $this->getPathSpec($modulePath);
+
+        $this->assertTrue($this->model->createModule($module, $pathSpec));
+
+        $contents = file_get_contents("$modulePath/config/modules.config.php");
         $this->assertNotContains('array(', $contents);
         $this->assertContains('return [', $contents);
     }


### PR DESCRIPTION
Updates generation of the config/modules.config.php file to use short array notation instead of long array notation.

Alternative to #359, as it presents fewer changes.