### PR TITLE
Remove ZF\Apigility\Provider from module list

### DIFF
--- a/bin/apigility-upgrade-to-1.5
+++ b/bin/apigility-upgrade-to-1.5
@@ -25,6 +25,7 @@ $path = realpath(getcwd());
 $composer = 'composer';
 $modulesToRemove = [
     'AssetManager',
+    'ZF\Apigility\Provider',
     'ZF\DevelopmentMode',
 ];
 $modulesToAdd = [


### PR DESCRIPTION
As of zf-apigility-provider 1.2.0, that package no longer needs to be registered as a module, as all interfaces it defines can and are autoloaded by Composer already.