### PR TITLE
Add Zend\Validator\Uuid

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1441,6 +1441,7 @@ return [
             'allowAbsolute' => 'bool',
             'allowRelative' => 'bool',
         ],
+        'Zend\Validator\Uuid' => [],
         'Zend\I18n\Validator\Alnum' => [
             'allowwhitespace' => 'bool',
         ],


### PR DESCRIPTION
The `Zend\Validator\Uuid` was introduced in zend-validator 2.8.0, but not yet added.