### PR TITLE
Added code to migrate legacy development mode commands

### DIFF
--- a/bin/apigility-upgrade-to-1.5
+++ b/bin/apigility-upgrade-to-1.5
@@ -107,6 +107,13 @@ if (! $result->status) {
     exit(1);
 }
 
+echo "Updating public/index.php for legacy development mode tooling...\n";
+$result = updateIndexFile($path);
+if (! $result->status) {
+    fwrite(STDERR, sprintf("%s\n", $result->message));
+    exit(1);
+}
+
 echo "\nUpgrade complete!\n";
 exit(0);
 
@@ -356,6 +363,47 @@ function installDependencies($composer)
             'composer install did not complete successfully; run manually to debug'
         );
     }
+
+    return new Result(true);
+}
+
+/**
+ * @var string $path
+ * @return Result
+ */
+function updateIndexFile($path)
+{
+    $indexPath = sprintf('%s/public/index.php', $path);
+
+    if (! file_exists($indexPath)) {
+        return new Result(
+            false,
+            'Could not locate public/index.php; are you running this from an Apigility project?'
+        );
+    }
+
+    $indexFile = file_get_contents($indexPath);
+
+    $template =<<<'EOT'
+
+
+// Redirect legacy requests to enable/disable development mode to new tool
+if (php_sapi_name() === 'cli'
+    && $argc > 2
+    && 'development' == $argv[1]
+    && in_array($argv[2], ['disable', 'enable'])
+) {
+    system('./vendor/bin/zf-development-mode ' . $argv[2], $return);
+    exit($return);
+}
+EOT;
+    $indexFile = preg_replace(
+        '#(chdir\(dirname\(__DIR__\)\\);)#s',
+        '$1' . $template,
+        $indexFile
+    );
+
+    file_put_contents($indexPath, $indexFile);
 
     return new Result(true);
 }


### PR DESCRIPTION
Now also updates the `public/index.php` to allow using the old style of invoking development mode:

- `php public/index.php development enable`
- `php public/index.php development disable`

These now proxy to the `vendor/bin/zf-development-mode` tooling.

This is done primarily to ensure that invoking the admin in Zend Studio continues to work, as Studio invokes development mode prior to and following launching the admin.