### PR TITLE
Make module version dynamic

### DIFF
--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -134,10 +134,11 @@ class ModuleModel
      *
      * @param  string $module
      * @param  ModulePathSpec $pathSpec
+     * @param  int $version
      * @return bool
      * @throws \Exception
      */
-    public function createModule($module, ModulePathSpec $pathSpec)
+    public function createModule($module, ModulePathSpec $pathSpec, $version = 1)
     {
         $path = $pathSpec->getApplicationPath();
         $application = require sprintf('%s/config/application.config.php', $path);
@@ -163,8 +164,8 @@ class ModuleModel
 
         mkdir($moduleConfigPath, 0775, true);
         mkdir($pathSpec->getModuleViewPath($module), 0775, true);
-        mkdir($pathSpec->getRestPath($module, 1), 0775, true);
-        mkdir($pathSpec->getRpcPath($module, 1), 0775, true);
+        mkdir($pathSpec->getRestPath($module, $version), 0775, true);
+        mkdir($pathSpec->getRpcPath($module, $version), 0775, true);
 
         $payload = static::$useShortArrayNotation
             ? "[\n]"

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -222,7 +222,11 @@ class ModuleModelTest extends TestCase
         }
     }
 
-    public function testCreateModule()
+    /**
+     * @dataProvider getModuleVersionDataProvider
+     * @return bool
+     */
+    public function testCreateModule($version)
     {
         $module     = 'Foo';
         $modulePath = sys_get_temp_dir() . "/" . uniqid(str_replace('\\', '_', __NAMESPACE__) . '_');
@@ -233,10 +237,10 @@ class ModuleModelTest extends TestCase
 
         $pathSpec = $this->getPathSpec($modulePath);
 
-        $this->assertTrue($this->model->createModule($module, $pathSpec));
+        $this->assertTrue($this->model->createModule($module, $pathSpec, $version));
         $this->assertTrue(file_exists("$modulePath/module/$module"));
-        $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/V1/Rpc"));
-        $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/V1/Rest"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/V$version/Rpc"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/V$version/Rest"));
         $this->assertTrue(file_exists("$modulePath/module/$module/view"));
         $this->assertTrue(file_exists("$modulePath/module/$module/Module.php"));
         $this->assertTrue(file_exists("$modulePath/module/$module/src/$module/Module.php"));
@@ -246,11 +250,11 @@ class ModuleModelTest extends TestCase
         return true;
     }
 
-
     /**
+     * @dataProvider getModuleVersionDataProvider
      * @group feature/psr4
      */
-    public function testCreateModulePSR4()
+    public function testCreateModulePSR4($version)
     {
         $module     = 'Foo';
         $modulePath = sys_get_temp_dir() . "/" . uniqid(str_replace('\\', '_', __NAMESPACE__) . '_');
@@ -261,16 +265,26 @@ class ModuleModelTest extends TestCase
 
         $pathSpec = $this->getPathSpec($modulePath, 'psr-4');
 
-        $this->assertTrue($this->model->createModule($module, $pathSpec));
+        $this->assertTrue($this->model->createModule($module, $pathSpec, $version));
         $this->assertTrue(file_exists("$modulePath/module/$module"));
-        $this->assertTrue(file_exists("$modulePath/module/$module/src/V1/Rpc"));
-        $this->assertTrue(file_exists("$modulePath/module/$module/src/V1/Rest"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/src/V$version/Rpc"));
+        $this->assertTrue(file_exists("$modulePath/module/$module/src/V$version/Rest"));
         $this->assertTrue(file_exists("$modulePath/module/$module/view"));
         $this->assertTrue(file_exists("$modulePath/module/$module/Module.php"));
         $this->assertTrue(file_exists("$modulePath/module/$module/config/module.config.php"));
 
         $this->removeDir($modulePath);
         return true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getModuleVersionDataProvider()
+    {
+        return array_map(function ($item) {
+            return [$item];
+        }, range(1, 10));
     }
 
     protected function getPathSpec($modulePath, $spec = 'psr-0')


### PR DESCRIPTION
Hello,

I am currently using the `zf-apigility-admin` classes to create an Apigility skeleton programmatically with this project https://github.com/robertboloc/raml2apigility. 

What I noticed, is that `createModule` creates the initial directories on version 1 and that value can't be changed on invocation. In real life usages there might already be an existing API and a new version is being worked on with Apigility, so ideally we should be able to create an API starting from a +1 version.

This PR allows to specify the initial version when creating the module, defaulting to 1.

If the PR is accepted a similar one should probably be created for the UI project to allow defining this initial version on creation.

Thank you.

Regards,
Rob

