### PR TITLE
zfcampus/zf-configuration 1.3.1 - breaks apigility admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ services:
 cache:
   directories:
     - $HOME/.composer/cache
-    - vendor
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - COMPOSER_ARGS="--no-interaction"
+    - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
   fast_finish: true
@@ -53,24 +53,23 @@ matrix:
     - php: hhvm
   
 notifications:
-  irc: "irc.freenode.org#apigility-dev"
   email: false
 
 before_install:
-  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == '7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
-  - travis_retry composer self-update
 
 install:
-  - if [[ $EXT_MONGODB == 'true' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $EXT_MONGODB == 'true' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
-  - composer show
+  - stty cols 120 && composer show
 
 script:
   - composer test

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "zfcampus/zf-apigility-admin-ui": "^1.3.7",
         "zfcampus/zf-apigility-provider": "^1.2",
         "zfcampus/zf-api-problem": "^1.2.1",
-        "zfcampus/zf-configuration": "^1.2.1",
+        "zfcampus/zf-configuration": "1.2.1 - 1.3.0 || >1.3.1 <2.0",
         "zfcampus/zf-content-negotiation": "^1.2.2",
         "zfcampus/zf-content-validation": "^1.3.4",
         "zfcampus/zf-hal": "^1.4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5d864bde2eea1925a20710f08e3b466",
+    "content-hash": "87bbe1578ed4504fe9ae3184577137fb",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
@@ -2362,12 +2362,12 @@
             "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/kherge-php/json.git",
+                "url": "https://github.com/kherge-abandoned/php-json.git",
                 "reference": "60c696c9370a1e5136816ca557c17f82a6fa83f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kherge-php/json/zipball/60c696c9370a1e5136816ca557c17f82a6fa83f1",
+                "url": "https://api.github.com/repos/kherge-abandoned/php-json/zipball/60c696c9370a1e5136816ca557c17f82a6fa83f1",
                 "reference": "60c696c9370a1e5136816ca557c17f82a6fa83f1",
                 "shasum": ""
             },
@@ -2415,7 +2415,6 @@
                 "schema",
                 "validate"
             ],
-            "abandoned": "kherge/json",
             "time": "2013-10-30T16:51:34+00:00"
         },
         {
@@ -2473,7 +2472,6 @@
                 "phar",
                 "update"
             ],
-            "abandoned": true,
             "time": "2013-10-30T17:23:01+00:00"
         },
         {
@@ -2582,7 +2580,6 @@
             ],
             "description": "A parsing and comparison library for semantic versioning.",
             "homepage": "http://github.com/kherge/Version",
-            "abandoned": true,
             "time": "2012-08-16T17:13:03+00:00"
         },
         {


### PR DESCRIPTION
As noted in https://github.com/zfcampus/zf-configuration/issues/28 seems that [`zfcampus/zf-configuration 1.3.1`](https://github.com/zfcampus/zf-configuration/releases/tag/1.3.1) break Apigility admin.

This PR should prove this - I've updated composer.lock to zf-configuration 1.3.0 so tests will run with the following version of zf-configuration:
- 1.2.1 - lowest :white_check_mark:
- 1.3.0 - locked :white_check_mark:
- 1.3.1 - latest :x:

The change which break Apigility admin at this point was made be me in https://github.com/zfcampus/zf-configuration/pull/25

I think the behaviour of zf-configuration was wrong, the method was not tested and documented, but unfortunately this wrong behaviour has been used in other components.
The simplest solution will be revert change introduced in zf-configuration 1.3.1 and fix it in 2.0.0.

See also:
https://github.com/zfcampus/zf-apigility-doctrine/issues/295
https://github.com/zfcampus/zf-apigility-doctrine/pull/296
https://github.com/zfcampus/zf-configuration/issues/21

/cc @weierophinney @samsonasik @developer-devPHP