### PR TITLE
More filter signature issues

### DIFF
--- a/src/InputFilter/AuthorizationInputFilter.php
+++ b/src/InputFilter/AuthorizationInputFilter.php
@@ -15,9 +15,10 @@ class AuthorizationInputFilter extends InputFilter
     /**
      * Is the data set valid?
      *
+     * @param  mixed|null $context
      * @return bool
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $this->messages = [];
         $isValid = true;

--- a/src/InputFilter/DocumentationInputFilter.php
+++ b/src/InputFilter/DocumentationInputFilter.php
@@ -38,9 +38,10 @@ class DocumentationInputFilter extends InputFilter
     /**
      * Is the data set valid?
      *
+     * @param  mixed|null $context
      * @return bool
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $this->messages = [];
         $isValid = true;

--- a/src/InputFilter/InputFilterInputFilter.php
+++ b/src/InputFilter/InputFilterInputFilter.php
@@ -32,9 +32,10 @@ class InputFilterInputFilter extends InputFilter
     /**
      * Is the data set valid?
      *
+     * @param  mixed|null $context
      * @return bool
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $this->messages = [];
         try {


### PR DESCRIPTION
I think I got all the filters in this package now and updated the signatures to match.   It appears the compatibility check from interface -> parent -> child got an overhaul in 7.2 and now errors out completely.

with these changes tests for this package now pass in 7.2.