### PR TITLE
Ensure we test against PHP 7.1 and PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_install:
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $ALTERNATE_DEPS ~= '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $ALTERNATE_DEPS ; fi
+  - if [[ $ALTERNATE_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $ALTERNATE_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $EXT_MONGODB == 'true' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - ALTERNATE_DEPS="phpunit/phpunit"
+        - ALTERNATE_DEPS="phpunit/phpunit zendframework/zend-code"
     - php: 5.6
       env:
         - DEPS=latest
@@ -34,7 +34,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - ALTERNATE_DEPS="phpunit/phpunit"
+        - ALTERNATE_DEPS="phpunit/phpunit zendframework/zend-code"
         - EXT_MONGODB=true
         - CS_CHECK=true
     - php: 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
-    - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
   fast_finish: true
@@ -82,11 +81,12 @@ notifications:
   email: false
 
 before_install:
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION =~ '^7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
-  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
-  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
-  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION =~ '^7' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
@@ -94,7 +94,6 @@ install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $EXT_MONGODB == 'true' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
   - stty cols 120 && composer show
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,61 +19,66 @@ matrix:
     - php: 5.6
       env:
         - DEPS=lowest
+        - ENABLE_EXT_MONGO=true
     - php: 5.6
       env:
         - DEPS=locked
+        - ENABLE_EXT_MONGO=true
         - ALTERNATE_DEPS="phpunit/phpunit zendframework/zend-code"
     - php: 5.6
       env:
         - DEPS=latest
+        - ENABLE_EXT_MONGO=true
     - php: 7
       env:
         - DEPS=lowest
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7
       env:
         - DEPS=locked
         - ALTERNATE_DEPS="phpunit/phpunit zendframework/zend-code"
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
         - CS_CHECK=true
     - php: 7
       env:
         - DEPS=latest
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7.1
       env:
         - DEPS=lowest
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7.1
       env:
         - DEPS=locked
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7.1
       env:
         - DEPS=latest
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7.2
       env:
         - DEPS=lowest
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7.2
       env:
         - DEPS=locked
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: 7.2
       env:
         - DEPS=latest
-        - EXT_MONGODB=true
+        - ENABLE_EXT_MONGODB=true
     - php: hhvm
       env:
         - DEPS=lowest
+        - ENABLE_HHVM_MONGO=true
     - php: hhvm
       env:
         - DEPS=locked
+        - ENABLE_HHVM_MONGO=true
     - php: hhvm
       env:
         - DEPS=latest
-        - EXT_MONGODB=true
+        - ENABLE_HHVM_MONGODB=true
   allow_failures:
     - php: hhvm
   
@@ -83,10 +88,10 @@ notifications:
 before_install:
   - echo "TRAVIS_PHP_VERSION is '$TRAVIS_PHP_VERSION'"
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION =~ '^7' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
-  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
-  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
-  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $ENABLE_EXT_MONGO == 'true' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $ENABLE_EXT_MONGODB == 'true' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $ENABLE_HHVM_MONGO == 'true' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $ENABLE_HHVM_MONGODB == 'true' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,18 @@ matrix:
       env:
         - DEPS=latest
         - EXT_MONGODB=true
+    - php: 7.2
+      env:
+        - DEPS=lowest
+        - EXT_MONGODB=true
+    - php: 7.2
+      env:
+        - DEPS=locked
+        - EXT_MONGODB=true
+    - php: 7.2
+      env:
+        - DEPS=latest
+        - EXT_MONGODB=true
     - php: hhvm
       env:
         - DEPS=lowest
@@ -71,7 +83,7 @@ notifications:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == '7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION ~= '^7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ notifications:
   email: false
 
 before_install:
+  - echo "TRAVIS_PHP_VERSION is '$TRAVIS_PHP_VERSION'"
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION =~ '^7' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,12 +81,12 @@ notifications:
   email: false
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION =~ '^7' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongodb extension"; echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "Enabling mongo extension"; echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
+        - ALTERNATE_DEPS="phpunit/phpunit"
         - EXT_MONGODB=true
         - CS_CHECK=true
     - php: 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ notifications:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION ~= '^7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION =~ '^7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
+        - ALTERNATE_DEPS="phpunit/phpunit"
     - php: 5.6
       env:
         - DEPS=latest
@@ -36,6 +37,18 @@ matrix:
         - EXT_MONGODB=true
         - CS_CHECK=true
     - php: 7
+      env:
+        - DEPS=latest
+        - EXT_MONGODB=true
+    - php: 7.1
+      env:
+        - DEPS=lowest
+        - EXT_MONGODB=true
+    - php: 7.1
+      env:
+        - DEPS=locked
+        - EXT_MONGODB=true
+    - php: 7.1
       env:
         - DEPS=latest
         - EXT_MONGODB=true
@@ -64,7 +77,7 @@ before_install:
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - if [[ $ALTERNATE_DEPS ~= '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $ALTERNATE_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $EXT_MONGODB == 'true' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
         "zendframework/zend-inputfilter": "^2.7.2",
         "zendframework/zend-modulemanager": "^2.7.2",
-        "zendframework/zend-mvc": "^2.7.10 || ^3.0.2",
+        "zendframework/zend-mvc": "^2.7.13 || ^3.0.2",
         "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1",
         "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
         "zendframework/zend-validator": "^2.8.1",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "zfcampus/zf-versioning": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.7.25 || ^6.5.4",
         "squizlabs/php_codesniffer": "^2.6.2",
         "zendframework/zend-config": "^2.6",
         "zendframework/zend-loader": "^2.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "587fd344e8b37233ed77075f20e20264",
+    "content-hash": "0e68dd1fb7f60face3d1b50689b51dcd",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "87bbe1578ed4504fe9ae3184577137fb",
+    "content-hash": "587fd344e8b37233ed77075f20e20264",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
-            "version": "v1.8.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bshaffer/oauth2-server-php.git",
-                "reference": "058c98f73209f9c49495e1799d32c035196fe8b8"
+                "reference": "d158878425392fe5a0cc34f15dbaf46315ae0ed9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/058c98f73209f9c49495e1799d32c035196fe8b8",
-                "reference": "058c98f73209f9c49495e1799d32c035196fe8b8",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/d158878425392fe5a0cc34f15dbaf46315ae0ed9",
+                "reference": "d158878425392fe5a0cc34f15dbaf46315ae0ed9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
+            "require-dev": {
+                "aws/aws-sdk-php": "~2.8",
+                "firebase/php-jwt": "~2.2",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^4.0",
+                "predis/predis": "dev-master",
+                "thobbs/phpcassa": "dev-master"
+            },
             "suggest": {
-                "aws/aws-sdk-php": "~2.8 is required to use the DynamoDB storage engine",
+                "aws/aws-sdk-php": "~2.8 is required to use DynamoDB storage",
                 "firebase/php-jwt": "~2.2 is required to use JWT features",
-                "predis/predis": "Required to use the Redis storage engine",
-                "thobbs/phpcassa": "Required to use the Cassandra storage engine"
+                "mongodb/mongodb": "^1.1 is required to use MongoDB storage",
+                "predis/predis": "Required to use Redis storage",
+                "thobbs/phpcassa": "Required to use Cassandra storage"
             },
             "type": "library",
             "autoload": {
@@ -53,21 +62,24 @@
                 "oauth",
                 "oauth2"
             ],
-            "time": "2015-09-18T18:05:10+00:00"
+            "time": "2017-11-15T01:41:02+00:00"
         },
         {
             "name": "container-interop/container-interop",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
                 "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -80,20 +92,21 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30T15:22:37+00:00"
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.2",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -128,7 +141,56 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03T06:00:07+00:00"
+            "time": "2017-09-27T21:40:39+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "zendframework/zend-authentication",
@@ -194,27 +256,27 @@
         },
         {
             "name": "zendframework/zend-code",
-            "version": "3.0.4",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "c5272131d3acb0f470a2462ed088fca3b6ba61c2"
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/c5272131d3acb0f470a2462ed088fca3b6ba61c2",
-                "reference": "c5272131d3acb0f470a2462ed088fca3b6ba61c2",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "php": "^7.1",
                 "zendframework/zend-eventmanager": "^2.6 || ^3.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^4.8.21",
-                "squizlabs/php_codesniffer": "^2.5",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
@@ -224,8 +286,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -243,7 +305,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-06-30T22:35:27+00:00"
+            "time": "2017-10-20T15:21:32+00:00"
         },
         {
             "name": "zendframework/zend-config",
@@ -303,16 +365,16 @@
         },
         {
             "name": "zendframework/zend-crypt",
-            "version": "3.0.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-crypt.git",
-                "reference": "ed348e3e87c945759d11edae5316125c3582bc72"
+                "reference": "514cef5556bac069e36c2cbded40e529b86bb3f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-crypt/zipball/ed348e3e87c945759d11edae5316125c3582bc72",
-                "reference": "ed348e3e87c945759d11edae5316125c3582bc72",
+                "url": "https://api.github.com/repos/zendframework/zend-crypt/zipball/514cef5556bac069e36c2cbded40e529b86bb3f2",
+                "reference": "514cef5556bac069e36c2cbded40e529b86bb3f2",
                 "shasum": ""
             },
             "require": {
@@ -323,7 +385,7 @@
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8",
+                "phpunit/phpunit": "^5.6.7",
                 "squizlabs/php_codesniffer": "^2.3.1"
             },
             "suggest": {
@@ -332,8 +394,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -350,29 +412,29 @@
                 "crypt",
                 "zf2"
             ],
-            "time": "2016-06-21T18:15:32+00:00"
+            "time": "2017-07-17T15:46:00+00:00"
         },
         {
             "name": "zendframework/zend-db",
-            "version": "2.8.2",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-db.git",
-                "reference": "5926a1a2e7e035546b690cb7d4c11a3c47db2c98"
+                "reference": "1651abb1b33fc8fbd2d78ff9e2abb526cc2cf666"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-db/zipball/5926a1a2e7e035546b690cb7d4c11a3c47db2c98",
-                "reference": "5926a1a2e7e035546b690cb7d4c11a3c47db2c98",
+                "url": "https://api.github.com/repos/zendframework/zend-db/zipball/1651abb1b33fc8fbd2d78ff9e2abb526cc2cf666",
+                "reference": "1651abb1b33fc8fbd2d78ff9e2abb526cc2cf666",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
                 "zendframework/zend-hydrator": "^1.1 || ^2.1",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
@@ -385,8 +447,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev",
-                    "dev-develop": "2.9-dev"
+                    "dev-master": "2.9-dev",
+                    "dev-develop": "2.10-dev"
                 },
                 "zf": {
                     "component": "Zend\\Db",
@@ -402,12 +464,13 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-db",
+            "description": "Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations",
             "keywords": [
+                "ZendFramework",
                 "db",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-08-09T19:28:55+00:00"
+            "time": "2017-12-11T14:57:52+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -455,26 +518,26 @@
         },
         {
             "name": "zendframework/zend-eventmanager",
-            "version": "3.0.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-eventmanager.git",
-                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e"
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/5c80bdee0e952be112dcec0968bad770082c3a6e",
-                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "athletic/athletic": "^0.1",
                 "container-interop/container-interop": "^1.1.0",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "^2.0",
+                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
             },
             "suggest": {
@@ -484,8 +547,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -505,20 +568,20 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18T20:53:00+00:00"
+            "time": "2017-07-11T19:17:22+00:00"
         },
         {
             "name": "zendframework/zend-filter",
-            "version": "2.7.1",
+            "version": "2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-filter.git",
-                "reference": "84c50246428efb0a1e52868e162dab3e149d5b80"
+                "reference": "b8d0ff872f126631bf63a932e33aa2d22d467175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-filter/zipball/84c50246428efb0a1e52868e162dab3e149d5b80",
-                "reference": "84c50246428efb0a1e52868e162dab3e149d5b80",
+                "url": "https://api.github.com/repos/zendframework/zend-filter/zipball/b8d0ff872f126631bf63a932e33aa2d22d467175",
+                "reference": "b8d0ff872f126631bf63a932e33aa2d22d467175",
                 "shasum": ""
             },
             "require": {
@@ -526,10 +589,10 @@
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
                 "pear/archive_tar": "^1.4",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-crypt": "^2.6",
+                "phpunit/phpunit": "^6.0.10 || ^5.7.17",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-crypt": "^2.6 || ^3.0",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
                 "zendframework/zend-uri": "^2.5"
             },
@@ -565,39 +628,39 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2016-04-18T18:32:43+00:00"
+            "time": "2017-05-17T20:56:17+00:00"
         },
         {
             "name": "zendframework/zend-http",
-            "version": "2.5.5",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-http.git",
-                "reference": "98b1cac0bc7a91497c5898184281abcd0e24c8d6"
+                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/98b1cac0bc7a91497c5898184281abcd0e24c8d6",
-                "reference": "98b1cac0bc7a91497c5898184281abcd0e24c8d6",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
+                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-loader": "^2.5",
-                "zendframework/zend-stdlib": "^2.5 || ^3.0",
-                "zendframework/zend-uri": "^2.5",
-                "zendframework/zend-validator": "^2.5"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-loader": "^2.5.1",
+                "zendframework/zend-stdlib": "^3.1 || ^2.7.7",
+                "zendframework/zend-uri": "^2.5.2",
+                "zendframework/zend-validator": "^2.10.1"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "^4.0",
-                "zendframework/zend-config": "^2.5"
+                "phpunit/phpunit": "^6.4.1 || ^5.7.15",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^3.1 || ^2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
                 }
             },
             "autoload": {
@@ -612,32 +675,35 @@
             "description": "provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
             "homepage": "https://github.com/zendframework/zend-http",
             "keywords": [
+                "ZendFramework",
                 "http",
-                "zf2"
+                "http client",
+                "zend",
+                "zf"
             ],
-            "time": "2016-08-08T15:01:54+00:00"
+            "time": "2017-10-13T12:06:24+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
-            "version": "2.2.1",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-hydrator.git",
-                "reference": "0ac0d3e569781f1895670b0c8d0dc7f25b8a3182"
+                "reference": "de0d6465fbc4b7ca345fddc148834c321c4b361f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/0ac0d3e569781f1895670b0c8d0dc7f25b8a3182",
-                "reference": "0ac0d3e569781f1895670b0c8d0dc7f25b8a3182",
+                "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/de0d6465fbc4b7ca345fddc148834c321c4b361f",
+                "reference": "de0d6465fbc4b7ca345fddc148834c321c4b361f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-stdlib": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5",
-                "squizlabs/php_codesniffer": "^2.3.1",
+                "phpunit/phpunit": "^5.7.21 || ^6.3",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-eventmanager": "^3.0",
                 "zendframework/zend-filter": "^2.6",
                 "zendframework/zend-inputfilter": "^2.6",
@@ -655,8 +721,8 @@
                 "branch-alias": {
                     "dev-release-1.0": "1.0-dev",
                     "dev-release-1.1": "1.1-dev",
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.3-dev",
+                    "dev-develop": "2.4-dev"
                 },
                 "zf": {
                     "component": "Zend\\Hydrator",
@@ -677,31 +743,31 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-04-18T17:59:29+00:00"
+            "time": "2017-10-02T15:01:27+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
-            "version": "2.7.2",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-inputfilter.git",
-                "reference": "5630ef49e8c16a6fe0c2bd0d2a519869b14d5b12"
+                "reference": "e7edd625f2fcdd72a719a7023114c5f4b4f38488"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-inputfilter/zipball/5630ef49e8c16a6fe0c2bd0d2a519869b14d5b12",
-                "reference": "5630ef49e8c16a6fe0c2bd0d2a519869b14d5b12",
+                "url": "https://api.github.com/repos/zendframework/zend-inputfilter/zipball/e7edd625f2fcdd72a719a7023114c5f4b4f38488",
+                "reference": "e7edd625f2fcdd72a719a7023114c5f4b4f38488",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-filter": "^2.6",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0",
-                "zendframework/zend-validator": "^2.6"
+                "zendframework/zend-validator": "^2.10.1"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "^4.5",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
             },
             "suggest": {
@@ -710,8 +776,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8-dev",
+                    "dev-develop": "2.9-dev"
                 },
                 "zf": {
                     "component": "Zend\\InputFilter",
@@ -727,12 +793,13 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-inputfilter",
+            "description": "Normalize and validate input sets from the web, APIs, the CLI, and more, including files",
             "keywords": [
+                "ZendFramework",
                 "inputfilter",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-06-11T19:35:33+00:00"
+            "time": "2017-12-04T21:24:25+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -880,37 +947,36 @@
         },
         {
             "name": "zendframework/zend-modulemanager",
-            "version": "2.7.2",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-modulemanager.git",
-                "reference": "2a59ab9a0dd7699a55050dff659ab0f28272b46e"
+                "reference": "394df6e12248ac430a312d4693f793ee7120baa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-modulemanager/zipball/2a59ab9a0dd7699a55050dff659ab0f28272b46e",
-                "reference": "2a59ab9a0dd7699a55050dff659ab0f28272b46e",
+                "url": "https://api.github.com/repos/zendframework/zend-modulemanager/zipball/394df6e12248ac430a312d4693f793ee7120baa6",
+                "reference": "394df6e12248ac430a312d4693f793ee7120baa6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-config": "^2.6",
-                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-config": "^3.1 || ^2.6",
+                "zendframework/zend-eventmanager": "^3.2 || ^2.6.3",
+                "zendframework/zend-stdlib": "^3.1 || ^2.7"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-console": "^2.6",
                 "zendframework/zend-di": "^2.6",
                 "zendframework/zend-loader": "^2.5",
-                "zendframework/zend-mvc": "^2.7",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+                "zendframework/zend-mvc": "^3.0 || ^2.7",
+                "zendframework/zend-servicemanager": "^3.0.3 || ^2.7.5"
             },
             "suggest": {
-                "zendframework/zend-config": "Zend\\Config component",
                 "zendframework/zend-console": "Zend\\Console component",
-                "zendframework/zend-loader": "Zend\\Loader component",
+                "zendframework/zend-loader": "Zend\\Loader component if you are not using Composer autoloading for your modules",
                 "zendframework/zend-mvc": "Zend\\Mvc component",
                 "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
             },
@@ -930,60 +996,68 @@
             "license": [
                 "BSD-3-Clause"
             ],
+            "description": "Modular application system for zend-mvc applications",
             "homepage": "https://github.com/zendframework/zend-modulemanager",
             "keywords": [
+                "ZendFramework",
                 "modulemanager",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-05-16T21:21:11+00:00"
+            "time": "2017-12-02T06:11:18+00:00"
         },
         {
             "name": "zendframework/zend-mvc",
-            "version": "3.0.2",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-mvc.git",
-                "reference": "3c6c9e570e01a8b8fcb0605d2f8eb25812c0c273"
+                "reference": "236e7e1e3757e988fa06530c0a3f96a148858ae8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-mvc/zipball/3c6c9e570e01a8b8fcb0605d2f8eb25812c0c273",
-                "reference": "3c6c9e570e01a8b8fcb0605d2f8eb25812c0c273",
+                "url": "https://api.github.com/repos/zendframework/zend-mvc/zipball/236e7e1e3757e988fa06530c0a3f96a148858ae8",
+                "reference": "236e7e1e3757e988fa06530c0a3f96a148858ae8",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
+                "container-interop/container-interop": "^1.2",
                 "php": "^5.6 || ^7.0",
-                "zendframework/zend-eventmanager": "^3.0",
-                "zendframework/zend-http": "^2.5.4",
-                "zendframework/zend-modulemanager": "^2.7.1",
-                "zendframework/zend-router": "^3.0.1",
-                "zendframework/zend-servicemanager": "^3.0.3",
-                "zendframework/zend-stdlib": "^3.0",
-                "zendframework/zend-view": "^2.6.7"
+                "zendframework/zend-eventmanager": "^3.2",
+                "zendframework/zend-http": "^2.7",
+                "zendframework/zend-modulemanager": "^2.8",
+                "zendframework/zend-router": "^3.0.2",
+                "zendframework/zend-servicemanager": "^3.3",
+                "zendframework/zend-stdlib": "^3.1",
+                "zendframework/zend-view": "^2.9"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "^4.5",
+                "http-interop/http-middleware": "^0.4.1",
+                "phpunit/phpunit": "^6.4.4 || ^5.7.14",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-json": "^2.6.1 || ^3.0",
-                "zendframework/zend-psr7bridge": "^0.2"
+                "zendframework/zend-psr7bridge": "^1.0",
+                "zendframework/zend-stratigility": "^2.0.1"
             },
             "suggest": {
+                "http-interop/http-middleware": "^0.4.1 to be used together with zend-stratigility",
                 "zendframework/zend-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
+                "zendframework/zend-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
                 "zendframework/zend-mvc-console": "zend-mvc-console provides the ability to expose zend-mvc as a console application",
                 "zendframework/zend-mvc-i18n": "zend-mvc-i18n provides integration with zend-i18n, including a translation bridge and translatable route segments",
                 "zendframework/zend-mvc-plugin-fileprg": "To provide Post/Redirect/Get functionality around forms that container file uploads",
                 "zendframework/zend-mvc-plugin-flashmessenger": "To provide flash messaging capabilities between requests",
                 "zendframework/zend-mvc-plugin-identity": "To access the authenticated identity (per zend-authentication) in controllers",
                 "zendframework/zend-mvc-plugin-prg": "To provide Post/Redirect/Get functionality within controllers",
+                "zendframework/zend-paginator": "^2.7 To provide pagination functionality via PaginatorPluginManager",
                 "zendframework/zend-psr7bridge": "(^0.2) To consume PSR-7 middleware within the MVC workflow",
-                "zendframework/zend-servicemanager-di": "zend-servicemanager-di provides utilities for integrating zend-di and zend-servicemanager in your zend-mvc application"
+                "zendframework/zend-servicemanager-di": "zend-servicemanager-di provides utilities for integrating zend-di and zend-servicemanager in your zend-mvc application",
+                "zendframework/zend-stratigility": "zend-stratigility is required to use middleware pipes in the MiddlewareListener"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -995,35 +1069,36 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-mvc",
+            "description": "Zend Framework's event-driven MVC layer, including MVC Applications, Controllers, and Plugins",
             "keywords": [
+                "ZendFramework",
                 "mvc",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-06-30T20:30:28+00:00"
+            "time": "2017-11-24T06:32:07+00:00"
         },
         {
             "name": "zendframework/zend-paginator",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-paginator.git",
-                "reference": "42211f3e1e8230953c641e91fec5aa9fe964eb95"
+                "reference": "655b9ef28092b283e10e6c6a4f42c82db992b2ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-paginator/zipball/42211f3e1e8230953c641e91fec5aa9fe964eb95",
-                "reference": "42211f3e1e8230953c641e91fec5aa9fe964eb95",
+                "url": "https://api.github.com/repos/zendframework/zend-paginator/zipball/655b9ef28092b283e10e6c6a4f42c82db992b2ba",
+                "reference": "655b9ef28092b283e10e6c6a4f42c82db992b2ba",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^7.0 || ^5.6",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^6.2.1 || ^5.7.15",
                 "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.6.0",
                 "zendframework/zend-db": "^2.7",
                 "zendframework/zend-filter": "^2.6.1",
@@ -1042,8 +1117,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8-dev",
+                    "dev-develop": "2.9-dev"
                 },
                 "zf": {
                     "component": "Zend\\Paginator",
@@ -1059,12 +1134,13 @@
             "license": [
                 "BSD-3-Clause"
             ],
+            "description": "zend-paginator is a flexible component for paginating collections of data and presenting that data to users.",
             "homepage": "https://github.com/zendframework/zend-paginator",
             "keywords": [
                 "paginator",
                 "zf2"
             ],
-            "time": "2016-04-11T21:18:13+00:00"
+            "time": "2017-11-01T20:49:42+00:00"
         },
         {
             "name": "zendframework/zend-permissions-acl",
@@ -1223,40 +1299,48 @@
         },
         {
             "name": "zendframework/zend-servicemanager",
-            "version": "3.1.1",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "f701b0d322741b0c8d8ca1288f249a49438029cd"
+                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/f701b0d322741b0c8d8ca1288f249a49438029cd",
-                "reference": "f701b0d322741b0c8d8ca1288f249a49438029cd",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
+                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "~1.0",
-                "php": "^5.5 || ^7.0"
+                "container-interop/container-interop": "^1.2",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^3.1"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.1"
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
             },
             "require-dev": {
+                "mikey179/vfsstream": "^1.6",
                 "ocramius/proxy-manager": "^1.0 || ^2.0",
                 "phpbench/phpbench": "^0.10.0",
-                "phpunit/phpunit": "^4.6 || ^5.2.10",
-                "squizlabs/php_codesniffer": "^2.5.1"
+                "phpunit/phpunit": "^5.7 || ^6.0.6",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
                 "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
             },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1274,35 +1358,35 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-07-15T14:59:51+00:00"
+            "time": "2017-11-27T18:11:25+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "8bafa58574204bdff03c275d1d618aaa601588ae"
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/8bafa58574204bdff03c275d1d618aaa601588ae",
-                "reference": "8bafa58574204bdff03c275d1d618aaa601588ae",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1",
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1319,7 +1403,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12T21:19:36+00:00"
+            "time": "2016-09-13T14:38:50+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -1370,27 +1454,27 @@
         },
         {
             "name": "zendframework/zend-validator",
-            "version": "2.8.1",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-validator.git",
-                "reference": "8ec9f57a717dd37340308aa632f148a2c2be1cfc"
+                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/8ec9f57a717dd37340308aa632f148a2c2be1cfc",
-                "reference": "8ec9f57a717dd37340308aa632f148a2c2be1cfc",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
+                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.1",
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7.6 || ^3.1"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
                 "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.6",
                 "zendframework/zend-db": "^2.7",
                 "zendframework/zend-filter": "^2.6",
@@ -1398,24 +1482,24 @@
                 "zendframework/zend-i18n": "^2.6",
                 "zendframework/zend-math": "^2.6",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-session": "^2.8",
                 "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
-                "zendframework/zend-db": "Zend\\Db component",
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
                 "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
-                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
                 "zendframework/zend-i18n-resources": "Translations of validator messages",
-                "zendframework/zend-math": "Zend\\Math component",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
                 "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "zendframework/zend-session": "Zend\\Session component",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
                 "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev",
-                    "dev-develop": "2.9-dev"
+                    "dev-master": "2.10-dev",
+                    "dev-develop": "2.11-dev"
                 },
                 "zf": {
                     "component": "Zend\\Validator",
@@ -1437,33 +1521,33 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2016-06-23T13:44:31+00:00"
+            "time": "2017-08-22T14:19:23+00:00"
         },
         {
             "name": "zendframework/zend-view",
-            "version": "2.8.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-view.git",
-                "reference": "71b4ebd0c4c9a2d0e0438f9d3a435e08dd769ff8"
+                "reference": "3b6342c381c4437a03fc81d0064c0bb8924914d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/71b4ebd0c4c9a2d0e0438f9d3a435e08dd769ff8",
-                "reference": "71b4ebd0c4c9a2d0e0438f9d3a435e08dd769ff8",
+                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/3b6342c381c4437a03fc81d0064c0bb8924914d3",
+                "reference": "3b6342c381c4437a03fc81d0064c0bb8924914d3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
                 "zendframework/zend-loader": "^2.5",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "^4.5",
+                "phpunit/phpunit": "^5.7.15 || ^6.0.8",
                 "zendframework/zend-authentication": "^2.5",
                 "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.6",
                 "zendframework/zend-console": "^2.6",
                 "zendframework/zend-escaper": "^2.5",
@@ -1505,8 +1589,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev",
-                    "dev-develop": "2.9-dev"
+                    "dev-master": "2.9-dev",
+                    "dev-develop": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1524,20 +1608,20 @@
                 "view",
                 "zf2"
             ],
-            "time": "2016-06-30T22:28:07+00:00"
+            "time": "2017-03-21T15:05:56+00:00"
         },
         {
             "name": "zfcampus/zf-api-problem",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-api-problem.git",
-                "reference": "3d2cb9f91aace74d4ca00d865d1ed95b593c6187"
+                "reference": "8227f2116835db3835b9f362806a2a7336f72559"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-api-problem/zipball/3d2cb9f91aace74d4ca00d865d1ed95b593c6187",
-                "reference": "3d2cb9f91aace74d4ca00d865d1ed95b593c6187",
+                "url": "https://api.github.com/repos/zfcampus/zf-api-problem/zipball/8227f2116835db3835b9f362806a2a7336f72559",
+                "reference": "8227f2116835db3835b9f362806a2a7336f72559",
                 "shasum": ""
             },
             "require": {
@@ -1551,7 +1635,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8",
-                "squizlabs/php_codesniffer": "^2.3.1"
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
@@ -1581,7 +1665,7 @@
                 "zend",
                 "zf2"
             ],
-            "time": "2016-07-07T13:52:00+00:00"
+            "time": "2017-07-24T13:48:49+00:00"
         },
         {
             "name": "zfcampus/zf-apigility",
@@ -1658,16 +1742,16 @@
         },
         {
             "name": "zfcampus/zf-apigility-admin-ui",
-            "version": "1.3.7",
+            "version": "1.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-apigility-admin-ui.git",
-                "reference": "13eee0c3906b887f689443a3275873e949203253"
+                "reference": "20f5b79643c00fdc9b8e3ddd33d9700a9240ccd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-apigility-admin-ui/zipball/13eee0c3906b887f689443a3275873e949203253",
-                "reference": "13eee0c3906b887f689443a3275873e949203253",
+                "url": "https://api.github.com/repos/zfcampus/zf-apigility-admin-ui/zipball/20f5b79643c00fdc9b8e3ddd33d9700a9240ccd6",
+                "reference": "20f5b79643c00fdc9b8e3ddd33d9700a9240ccd6",
                 "shasum": ""
             },
             "require": {
@@ -1705,7 +1789,7 @@
                 "framework",
                 "zf2"
             ],
-            "time": "2016-08-14T16:37:00+00:00"
+            "time": "2016-12-19T17:46:02+00:00"
         },
         {
             "name": "zfcampus/zf-apigility-provider",
@@ -1755,16 +1839,16 @@
         },
         {
             "name": "zfcampus/zf-configuration",
-            "version": "1.3.0",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-configuration.git",
-                "reference": "9213c09125bbf27e6c9bc78df73d2598a3f3c97d"
+                "reference": "e6c0ccff74b07390ee53855542e7d7861030daf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-configuration/zipball/9213c09125bbf27e6c9bc78df73d2598a3f3c97d",
-                "reference": "9213c09125bbf27e6c9bc78df73d2598a3f3c97d",
+                "url": "https://api.github.com/repos/zfcampus/zf-configuration/zipball/e6c0ccff74b07390ee53855542e7d7861030daf8",
+                "reference": "e6c0ccff74b07390ee53855542e7d7861030daf8",
                 "shasum": ""
             },
             "require": {
@@ -1806,20 +1890,20 @@
                 "zend",
                 "zf2"
             ],
-            "time": "2017-08-24T14:12:38+00:00"
+            "time": "2017-11-14T23:07:10+00:00"
         },
         {
             "name": "zfcampus/zf-content-negotiation",
-            "version": "1.2.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-content-negotiation.git",
-                "reference": "8543f610b66a78e8d9821fd1425844e7fab26d43"
+                "reference": "6ca3012f3a7f57bd5970dce8394b2c3ea1293371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-content-negotiation/zipball/8543f610b66a78e8d9821fd1425844e7fab26d43",
-                "reference": "8543f610b66a78e8d9821fd1425844e7fab26d43",
+                "url": "https://api.github.com/repos/zfcampus/zf-content-negotiation/zipball/6ca3012f3a7f57bd5970dce8394b2c3ea1293371",
+                "reference": "6ca3012f3a7f57bd5970dce8394b2c3ea1293371",
                 "shasum": ""
             },
             "require": {
@@ -1837,17 +1921,19 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8",
-                "squizlabs/php_codesniffer": "^2.3.1",
+                "squizlabs/php_codesniffer": "^2.7",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-console": "^2.0",
                 "zfcampus/zf-hal": "^1.4"
             },
             "suggest": {
-                "zendframework/zend-console": "^2.3, if you intend to use the RequestFactory"
+                "zendframework/zend-console": "^2.0, if you intend to use the console request of RequestFactory"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev",
-                    "dev-develop": "1.3-dev"
+                    "dev-master": "1.3-dev",
+                    "dev-develop": "1.4-dev"
                 },
                 "zf": {
                     "module": "ZF\\ContentNegotiation"
@@ -1870,20 +1956,20 @@
                 "zend",
                 "zf2"
             ],
-            "time": "2016-07-27T20:13:12+00:00"
+            "time": "2017-11-21T16:19:30+00:00"
         },
         {
             "name": "zfcampus/zf-content-validation",
-            "version": "1.3.4",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-content-validation.git",
-                "reference": "aa9b688d0995bab00a3c94fe629891d3581b0ca5"
+                "reference": "5ee53ef56bb85b90b438c7ac6b1cef98a56fca4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-content-validation/zipball/aa9b688d0995bab00a3c94fe629891d3581b0ca5",
-                "reference": "aa9b688d0995bab00a3c94fe629891d3581b0ca5",
+                "url": "https://api.github.com/repos/zfcampus/zf-content-validation/zipball/5ee53ef56bb85b90b438c7ac6b1cef98a56fca4f",
+                "reference": "5ee53ef56bb85b90b438c7ac6b1cef98a56fca4f",
                 "shasum": ""
             },
             "require": {
@@ -1891,7 +1977,7 @@
                 "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
                 "zendframework/zend-filter": "^2.7.1",
                 "zendframework/zend-http": "^2.5.4",
-                "zendframework/zend-inputfilter": "^2.7.2",
+                "zendframework/zend-inputfilter": "^2.7.3",
                 "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
                 "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
                 "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
@@ -1901,7 +1987,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8 || ^5.0",
-                "squizlabs/php_codesniffer": "^2.6.1",
+                "squizlabs/php_codesniffer": "^2.6.2",
                 "zendframework/zend-db": "^2.8.1"
             },
             "type": "library",
@@ -1931,7 +2017,7 @@
                 "zend",
                 "zf2"
             ],
-            "time": "2016-08-04T22:27:17+00:00"
+            "time": "2017-11-06T17:18:49+00:00"
         },
         {
             "name": "zfcampus/zf-hal",
@@ -1996,16 +2082,16 @@
         },
         {
             "name": "zfcampus/zf-mvc-auth",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-mvc-auth.git",
-                "reference": "3c15ae465ae75d594c939043e44e3ba079ab0fa7"
+                "reference": "cb5ffdd5be60b6e59abf2fb94cf9339b642c66f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-mvc-auth/zipball/3c15ae465ae75d594c939043e44e3ba079ab0fa7",
-                "reference": "3c15ae465ae75d594c939043e44e3ba079ab0fa7",
+                "url": "https://api.github.com/repos/zfcampus/zf-mvc-auth/zipball/cb5ffdd5be60b6e59abf2fb94cf9339b642c66f3",
+                "reference": "cb5ffdd5be60b6e59abf2fb94cf9339b642c66f3",
                 "shasum": ""
             },
             "require": {
@@ -2052,7 +2138,7 @@
                 "zend",
                 "zf2"
             ],
-            "time": "2016-08-03T20:34:18+00:00"
+            "time": "2016-09-30T15:49:02+00:00"
         },
         {
             "name": "zfcampus/zf-oauth2",
@@ -2123,16 +2209,16 @@
         },
         {
             "name": "zfcampus/zf-rest",
-            "version": "1.3.1",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-rest.git",
-                "reference": "8af3606cd2b8cc3a0204cbe5a4bf8f983f742f44"
+                "reference": "1ff0b85c93699958908c90e48e1c2887266d2cd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-rest/zipball/8af3606cd2b8cc3a0204cbe5a4bf8f983f742f44",
-                "reference": "8af3606cd2b8cc3a0204cbe5a4bf8f983f742f44",
+                "url": "https://api.github.com/repos/zfcampus/zf-rest/zipball/1ff0b85c93699958908c90e48e1c2887266d2cd3",
+                "reference": "1ff0b85c93699958908c90e48e1c2887266d2cd3",
                 "shasum": ""
             },
             "require": {
@@ -2141,14 +2227,14 @@
                 "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
                 "zendframework/zend-paginator": "^2.7",
                 "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
-                "zfcampus/zf-api-problem": "^1.2.1",
+                "zfcampus/zf-api-problem": "^1.2.2",
                 "zfcampus/zf-content-negotiation": "^1.2.1",
                 "zfcampus/zf-hal": "^1.4",
                 "zfcampus/zf-mvc-auth": "^1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8 || ^5.0",
-                "squizlabs/php_codesniffer": "^2.3.1",
+                "squizlabs/php_codesniffer": "^2.7",
                 "zendframework/zend-escaper": "^2.5.2",
                 "zendframework/zend-http": "^2.5.4",
                 "zendframework/zend-inputfilter": "^2.7.2",
@@ -2185,20 +2271,20 @@
                 "zf2",
                 "zf3"
             ],
-            "time": "2016-07-12T21:08:39+00:00"
+            "time": "2016-10-11T21:16:15+00:00"
         },
         {
             "name": "zfcampus/zf-rpc",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-rpc.git",
-                "reference": "aec741a2d8aad7e75710e27fd0770e1f7577c796"
+                "reference": "f08db1e50d49eefbe908b50d38d3cf3d0dd181f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-rpc/zipball/aec741a2d8aad7e75710e27fd0770e1f7577c796",
-                "reference": "aec741a2d8aad7e75710e27fd0770e1f7577c796",
+                "url": "https://api.github.com/repos/zfcampus/zf-rpc/zipball/f08db1e50d49eefbe908b50d38d3cf3d0dd181f6",
+                "reference": "f08db1e50d49eefbe908b50d38d3cf3d0dd181f6",
                 "shasum": ""
             },
             "require": {
@@ -2243,7 +2329,7 @@
                 "zend",
                 "zf2"
             ],
-            "time": "2016-07-12T22:18:34+00:00"
+            "time": "2016-10-11T19:47:59+00:00"
         },
         {
             "name": "zfcampus/zf-versioning",
@@ -2305,32 +2391,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -2355,19 +2441,19 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "herrera-io/json",
             "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/kherge-abandoned/php-json.git",
+                "url": "https://github.com/kherge-php/json.git",
                 "reference": "60c696c9370a1e5136816ca557c17f82a6fa83f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kherge-abandoned/php-json/zipball/60c696c9370a1e5136816ca557c17f82a6fa83f1",
+                "url": "https://api.github.com/repos/kherge-php/json/zipball/60c696c9370a1e5136816ca557c17f82a6fa83f1",
                 "reference": "60c696c9370a1e5136816ca557c17f82a6fa83f1",
                 "shasum": ""
             },
@@ -2415,6 +2501,7 @@
                 "schema",
                 "validate"
             ],
+            "abandoned": "kherge/json",
             "time": "2013-10-30T16:51:34+00:00"
         },
         {
@@ -2472,6 +2559,7 @@
                 "phar",
                 "update"
             ],
+            "abandoned": true,
             "time": "2013-10-30T17:23:01+00:00"
         },
         {
@@ -2580,20 +2668,168 @@
             ],
             "description": "A parsing and comparison library for semantic versioning.",
             "homepage": "http://github.com/kherge/Version",
+            "abandoned": true,
             "time": "2012-08-16T17:13:03+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -2634,33 +2870,39 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -2679,24 +2921,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10T09:48:41+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -2726,36 +2968,37 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10T07:14:17+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -2788,43 +3031,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07T08:13:47+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -2839,7 +3083,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2850,20 +3094,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -2897,7 +3141,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21T13:08:43+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2942,25 +3186,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -2982,33 +3231,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3031,45 +3280,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15T10:49:45+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "6.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
+                "reference": "1b2f933d5775f9237369deaa2d2bfbf9d652be4c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -3077,7 +3338,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -3103,30 +3364,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21T06:48:14+00:00"
+            "time": "2017-12-10T08:06:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
+                "reference": "283b9f4f670e3a6fd6c4ff95c51a952eb5c75933",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -3134,7 +3398,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -3149,7 +3413,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -3159,34 +3423,79 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2017-12-10T08:01:53+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -3217,38 +3526,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26T15:48:44+00:00"
+            "time": "2017-11-03T07:16:52+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3275,32 +3584,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -3325,34 +3634,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17T03:18:57+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -3392,27 +3701,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -3420,7 +3729,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3443,32 +3752,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -3496,23 +3897,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11T19:50:13+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -3531,24 +3982,27 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.4.0",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "66834d3e3566bb5798db7294619388786ae99394"
+                "reference": "7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/66834d3e3566bb5798db7294619388786ae99394",
-                "reference": "66834d3e3566bb5798db7294619388786ae99394",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19",
+                "reference": "7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
             },
             "bin": [
                 "bin/jsonlint"
@@ -3577,20 +4031,20 @@
                 "parser",
                 "validator"
             ],
-            "time": "2015-11-21T02:21:41+00:00"
+            "time": "2017-11-30T15:34:22+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.2",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -3655,73 +4109,64 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-07-13T23:29:13+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.1.3",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1819adf2066880c7967df7180f4f662b6f0567ac",
-                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-07-17T14:02:08+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -3730,7 +4175,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -3754,7 +4199,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09T15:02:57+00:00"
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-console",
@@ -3810,39 +4255,38 @@
         },
         {
             "name": "zfcampus/zf-console",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zfcampus/zf-console.git",
-                "reference": "663c19e22240b4ea51b3d01950720f6db8dfd6f0"
+                "reference": "e4dd16760fe219d8b2745865a883b0e0a492a3ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zfcampus/zf-console/zipball/663c19e22240b4ea51b3d01950720f6db8dfd6f0",
-                "reference": "663c19e22240b4ea51b3d01950720f6db8dfd6f0",
+                "url": "https://api.github.com/repos/zfcampus/zf-console/zipball/e4dd16760fe219d8b2745865a883b0e0a492a3ed",
+                "reference": "e4dd16760fe219d8b2745865a883b0e0a492a3ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
                 "zendframework/zend-console": "^2.6"
             },
             "require-dev": {
-                "container-interop/container-interop": "^1.1",
-                "phpunit/phpunit": "~4.8 || ^5.0",
-                "squizlabs/php_codesniffer": "^2.3.1",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-filter": "^2.7.1",
                 "zendframework/zend-validator": "^2.8.1"
             },
             "suggest": {
-                "container-interop/container-interop": "^1.1; For ability to pull dispatched commands from container",
                 "zendframework/zend-filter": "^2.7.1; Useful for filtering/normalizing argument values",
                 "zendframework/zend-validator": "^2.8.1; Useful for providing more thorough argument validation logic"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev",
-                    "dev-develop": "1.4-dev"
+                    "dev-master": "1.4-dev",
+                    "dev-develop": "1.5-dev"
                 }
             },
             "autoload": {
@@ -3855,12 +4299,12 @@
                 "BSD-3-Clause"
             ],
             "description": "Library for creating and dispatching console commands",
-            "homepage": "http://framework.zend.com/",
             "keywords": [
-                "zend",
-                "zf2"
+                "ZendFramework",
+                "console",
+                "zf"
             ],
-            "time": "2016-07-11T20:33:55+00:00"
+            "time": "2017-11-27T17:17:19+00:00"
         },
         {
             "name": "zfcampus/zf-deploy",

--- a/test/Controller/AuthenticationControllerFactoryTest.php
+++ b/test/Controller/AuthenticationControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Apigility\Admin\Model\AuthenticationModel;
 

--- a/test/Controller/AuthenticationControllerTest.php
+++ b/test/Controller/AuthenticationControllerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray as ConfigWriter;
 use Zend\Http\Request;
 use Zend\Mvc\Controller\Plugin\Params;

--- a/test/Controller/AuthenticationTypeControllerFactoryTest.php
+++ b/test/Controller/AuthenticationTypeControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\MvcAuth\Authentication\DefaultAuthenticationListener;
 

--- a/test/Controller/AuthenticationTypeControllerTest.php
+++ b/test/Controller/AuthenticationTypeControllerTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Controller;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Request;
 use Zend\Mvc\MvcEvent;
 use ZF\Apigility\Admin\Controller\AuthenticationTypeController;

--- a/test/Controller/AuthorizationControllerFactoryTest.php
+++ b/test/Controller/AuthorizationControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Apigility\Admin\Model\AuthorizationModelFactory;
 

--- a/test/Controller/ConfigControllerFactoryTest.php
+++ b/test/Controller/ConfigControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Configuration\ConfigResource;
 

--- a/test/Controller/ConfigControllerTest.php
+++ b/test/Controller/ConfigControllerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Request;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\Stdlib\Parameters;

--- a/test/Controller/DashboardControllerFactoryTest.php
+++ b/test/Controller/DashboardControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Apigility\Admin\Model;
 

--- a/test/Controller/FsPermissionsControllerTest.php
+++ b/test/Controller/FsPermissionsControllerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Controller;
 
 use FilesystemIterator;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ZF\Apigility\Admin\Controller\FsPermissionsController;

--- a/test/Controller/InputFilterControllerTest.php
+++ b/test/Controller/InputFilterControllerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray;
 use Zend\Http\Request;
 use Zend\Mvc\Controller\PluginManager;

--- a/test/Controller/ModuleConfigControllerFactoryTest.php
+++ b/test/Controller/ModuleConfigControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Configuration\ConfigResourceFactory;
 use ZF\Configuration\ResourceFactory;

--- a/test/Controller/ModuleCreationControllerFactoryTest.php
+++ b/test/Controller/ModuleCreationControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Apigility\Admin\Model\ModuleModel;
 

--- a/test/Controller/ModuleCreationControllerTest.php
+++ b/test/Controller/ModuleCreationControllerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Request;
 use Zend\ModuleManager\ModuleManager;
 use Zend\Mvc\Controller\PluginManager;

--- a/test/Controller/PackageControllerTest.php
+++ b/test/Controller/PackageControllerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Request;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\Mvc\MvcEvent;

--- a/test/Controller/SourceControllerFactoryTest.php
+++ b/test/Controller/SourceControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Apigility\Admin\Model\ModuleModel;
 

--- a/test/Controller/SourceControllerTest.php
+++ b/test/Controller/SourceControllerTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Controller;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Request;
 use Zend\ModuleManager\ModuleManager;
 use ZF\Apigility\Admin\Controller\SourceController;

--- a/test/Controller/StrategyControllerFactoryTest.php
+++ b/test/Controller/StrategyControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 
 class StrategyControllerFactoryTest extends TestCase

--- a/test/Controller/VersioningControllerFactoryTest.php
+++ b/test/Controller/VersioningControllerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Controller;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Apigility\Admin\Model\ModuleVersioningModelFactory;
 

--- a/test/InputFilter/Authentication/BasicInputFilterTest.php
+++ b/test/InputFilter/Authentication/BasicInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\Authentication;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class BasicInputFilterTest extends TestCase

--- a/test/InputFilter/Authentication/DigestInputFilterTest.php
+++ b/test/InputFilter/Authentication/DigestInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\Authentication;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class DigestInputFilterTest extends TestCase

--- a/test/InputFilter/Authentication/OAuth2InputFilterTest.php
+++ b/test/InputFilter/Authentication/OAuth2InputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\Authentication;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class OAuth2InputFilterTest extends TestCase

--- a/test/InputFilter/AuthorizationInputFilterTest.php
+++ b/test/InputFilter/AuthorizationInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\InputFilter\AuthorizationInputFilter;
 
 class AuthorizationInputFilterTest extends TestCase

--- a/test/InputFilter/ContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/ContentNegotiationInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\InputFilter\ContentNegotiationInputFilter;
 
 class ContentNegotiationInputFilterTest extends TestCase

--- a/test/InputFilter/CreateContentNegotiationInputFilterTest.php
+++ b/test/InputFilter/CreateContentNegotiationInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\InputFilter\CreateContentNegotiationInputFilter;
 
 class CreateContentNegotiationInputFilterTest extends TestCase

--- a/test/InputFilter/DbAdapterInputFilterTest.php
+++ b/test/InputFilter/DbAdapterInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class DbAdapterInputFilterTest extends TestCase

--- a/test/InputFilter/DocumentationInputFilterTest.php
+++ b/test/InputFilter/DocumentationInputFilterTest.php
@@ -2,7 +2,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class DocumentationInputFilterTest extends TestCase

--- a/test/InputFilter/InputFilterInputFilterTest.php
+++ b/test/InputFilter/InputFilterInputFilterTest.php
@@ -2,7 +2,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 use ZF\Apigility\Admin\InputFilter\InputFilterInputFilter;
 

--- a/test/InputFilter/ModuleInputFilterTest.php
+++ b/test/InputFilter/ModuleInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class ModuleInputFilterTest extends TestCase

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\RestService;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class PatchInputFilterTest extends TestCase

--- a/test/InputFilter/RestService/PostInputFilterTest.php
+++ b/test/InputFilter/RestService/PostInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\RestService;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class PostInputFilterTest extends TestCase

--- a/test/InputFilter/RpcService/PatchInputFilterTest.php
+++ b/test/InputFilter/RpcService/PatchInputFilterTest.php
@@ -2,7 +2,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\RpcService;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class PatchInputFilterTest extends TestCase

--- a/test/InputFilter/RpcService/PostInputFilterTest.php
+++ b/test/InputFilter/RpcService/PostInputFilterTest.php
@@ -2,7 +2,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\RpcService;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class PostInputFilterTest extends TestCase

--- a/test/InputFilter/Validator/ModuleNameTest.php
+++ b/test/InputFilter/Validator/ModuleNameTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter\Validator;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\InputFilter\Validator\ModuleNameValidator;
 
 class ModuleNameTest extends TestCase

--- a/test/InputFilter/VersionInputFilterTest.php
+++ b/test/InputFilter/VersionInputFilterTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\InputFilter;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\InputFilter\Factory;
 
 class VersionInputFilterTest extends TestCase

--- a/test/Listener/CryptFilterListenerTest.php
+++ b/test/Listener/CryptFilterListenerTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Listener;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mvc\MvcEvent;
 use ZF\Apigility\Admin\Listener\CryptFilterListener;
 use ZFTest\Apigility\Admin\RouteAssetsTrait;
@@ -19,7 +19,7 @@ class CryptFilterListenerTest extends TestCase
     {
         $this->listener   = new CryptFilterListener();
         $this->event      = new MvcEvent();
-        $this->request    = $this->getMock('Zend\Http\Request');
+        $this->request    = $this->createMock('Zend\Http\Request');
         $this->routeMatch = $this->getMockBuilder($this->getRouteMatchClass())
             ->disableOriginalConstructor(true)
             ->getMock();
@@ -44,7 +44,7 @@ class CryptFilterListenerTest extends TestCase
 
     public function testReturnsNullIfRequestIsNotAnHttpRequest()
     {
-        $request = $this->getMock('Zend\Stdlib\RequestInterface');
+        $request = $this->createMock('Zend\Stdlib\RequestInterface');
         $this->event->setRequest($request);
         $this->assertNull($this->listener->onRoute($this->event));
     }

--- a/test/Listener/DisableHttpCacheListenerTest.php
+++ b/test/Listener/DisableHttpCacheListenerTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Listener;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\Http\Header\GenericHeader;
 use Zend\Http\Header\GenericMultiHeader;

--- a/test/Listener/EnableHalRenderCollectionsListenerTest.php
+++ b/test/Listener/EnableHalRenderCollectionsListenerTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Listener;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mvc\ApplicationInterface;
 use Zend\Mvc\MvcEvent;
 use ZF\Apigility\Admin\Listener\EnableHalRenderCollectionsListener;

--- a/test/Listener/InjectModuleResourceLinksListenerFactoryTest.php
+++ b/test/Listener/InjectModuleResourceLinksListenerFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Listener;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Listener\InjectModuleResourceLinksListener;
 use ZF\Apigility\Admin\Listener\InjectModuleResourceLinksListenerFactory;
 

--- a/test/Listener/InjectModuleResourceLinksListenerTest.php
+++ b/test/Listener/InjectModuleResourceLinksListenerTest.php
@@ -8,7 +8,7 @@ namespace ZFTest\Apigility\Admin\Listener;
 
 use Closure;
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ReflectionProperty;
 use stdClass;

--- a/test/Listener/NormalizeMatchedControllerServiceNameListenerTest.php
+++ b/test/Listener/NormalizeMatchedControllerServiceNameListenerTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Listener;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\Mvc\MvcEvent;
 use ZF\Apigility\Admin\Listener\NormalizeMatchedControllerServiceNameListener;

--- a/test/Listener/NormalizeMatchedInputFilterNameListenerTest.php
+++ b/test/Listener/NormalizeMatchedInputFilterNameListenerTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Listener;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\Mvc\MvcEvent;
 use ZF\Apigility\Admin\Listener\NormalizeMatchedInputFilterNameListener;

--- a/test/Model/AbstractPluginManagerModelTest.php
+++ b/test/Model/AbstractPluginManagerModelTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 abstract class AbstractPluginManagerModelTest extends TestCase
 {

--- a/test/Model/AuthenticationEntityTest.php
+++ b/test/Model/AuthenticationEntityTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\AuthenticationEntity;
 
 class AuthenticationEntityTest extends TestCase

--- a/test/Model/AuthenticationModelFactoryTest.php
+++ b/test/Model/AuthenticationModelFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\Config\Writer\WriterInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -30,7 +30,8 @@ class AuthenticationModelFactoryTest extends TestCase
 
         $this->container->has('config')->willReturn(false);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'config service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('config service is not present');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/AuthenticationModelTest.php
+++ b/test/Model/AuthenticationModelTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use MongoClient;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray as ConfigWriter;
 use Zend\Stdlib\ArrayUtils;
 use ZF\Apigility\Admin\Model\AuthenticationModel;
@@ -372,7 +372,9 @@ class AuthenticationModelTest extends TestCase
         ];
         $model = $this->createModelFromConfigArrays([], []);
 
-        $this->setExpectedException('ZF\Apigility\Admin\Exception\InvalidArgumentException', 'DSN', 422);
+        $this->expectException('ZF\Apigility\Admin\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('DSN');
+        $this->expectExceptionCode(422);
         $model->create($toCreate);
     }
 
@@ -389,7 +391,9 @@ class AuthenticationModelTest extends TestCase
         ];
         $model = $this->createModelFromConfigArrays([], []);
 
-        $this->setExpectedException('ZF\Apigility\Admin\Exception\InvalidArgumentException', 'DSN', 422);
+        $this->expectException('ZF\Apigility\Admin\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('DSN');
+        $this->expectExceptionCode(422);
         $model->create($toCreate);
     }
 
@@ -411,7 +415,9 @@ class AuthenticationModelTest extends TestCase
             'dsn' => 'sqlite:/tmp/' . uniqid() . '/.db',
         ];
 
-        $this->setExpectedException('ZF\Apigility\Admin\Exception\InvalidArgumentException', 'DSN', 422);
+        $this->expectException('ZF\Apigility\Admin\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('DSN');
+        $this->expectExceptionCode(422);
         $entity = $model->update($newConfig);
     }
 

--- a/test/Model/AuthorizationEntityTest.php
+++ b/test/Model/AuthorizationEntityTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\AuthorizationEntity;
 
 class AuthorizationEntityTest extends TestCase

--- a/test/Model/AuthorizationModelFactoryFactoryTest.php
+++ b/test/Model/AuthorizationModelFactoryFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\AuthorizationModelFactory;
 use ZF\Apigility\Admin\Model\AuthorizationModelFactoryFactory;
@@ -75,7 +75,8 @@ class AuthorizationModelFactoryFactoryTest extends TestCase
             $this->container->has($dependency)->willReturn($presence);
         }
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'missing one or more dependencies');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing one or more dependencies');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/AuthorizationModelTest.php
+++ b/test/Model/AuthorizationModelTest.php
@@ -10,7 +10,7 @@ use AuthConf;
 use AuthConfDefaults;
 use AuthConfWithConfig;
 use FooConf;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\AuthorizationEntity;
 use ZF\Apigility\Admin\Model\AuthorizationModel;

--- a/test/Model/ContentNegotiationModelFactoryTest.php
+++ b/test/Model/ContentNegotiationModelFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\Config\Writer\WriterInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -32,7 +32,8 @@ class ContentNegotiationModelFactoryTest extends TestCase
         $this->container->get('config')->shouldNotBeCalled();
         $this->container->get(ConfigWriter::class)->shouldNotBeCalled();
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'config service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('config service is not present');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/ContentNegotiationResourceFactoryTest.php
+++ b/test/Model/ContentNegotiationResourceFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\ContentNegotiationModel;
 use ZF\Apigility\Admin\Model\ContentNegotiationResource;
@@ -25,10 +25,8 @@ class ContentNegotiationResourceFactoryTest extends TestCase
         $factory = new ContentNegotiationResourceFactory();
         $this->container->has(ContentNegotiationModel::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            ContentNegotiationModel::class . ' service is not present'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage(ContentNegotiationModel::class . ' service is not present');
 
         $factory($this->container->reveal());
     }

--- a/test/Model/ContentNegotiationResourceTest.php
+++ b/test/Model/ContentNegotiationResourceTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray as ConfigWriter;
 use ZF\Apigility\Admin\InputFilter\ContentNegotiationInputFilter;
 use ZF\Apigility\Admin\InputFilter\CreateContentNegotiationInputFilter;

--- a/test/Model/ContentNegotiationTest.php
+++ b/test/Model/ContentNegotiationTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray as ConfigWriter;
 use ZF\Apigility\Admin\Model\ContentNegotiationModel;
 use ZF\Configuration\ConfigResource;

--- a/test/Model/DbAdapterModelFactoryTest.php
+++ b/test/Model/DbAdapterModelFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\Config\Writer\WriterInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -29,7 +29,8 @@ class DbAdapterModelFactoryTest extends TestCase
 
         $this->container->has('config')->willReturn(false);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'config service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('config service is not present');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/DbAdapterModelTest.php
+++ b/test/Model/DbAdapterModelTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray as ConfigWriter;
 use Zend\Stdlib\ArrayUtils;
 use ZF\Apigility\Admin\Model\DbAdapterModel;

--- a/test/Model/DbAdapterResourceFactoryTest.php
+++ b/test/Model/DbAdapterResourceFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\DbAdapterModel;
 use ZF\Apigility\Admin\Model\DbAdapterResource;
@@ -25,10 +25,8 @@ class DbAdapterResourceFactoryTest extends TestCase
         $factory = new DbAdapterResourceFactory();
         $this->container->has(DbAdapterModel::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            DbAdapterModel::class . ' service is not present'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage(DbAdapterModel::class . ' service is not present');
 
         $factory($this->container->reveal());
     }

--- a/test/Model/DbAutodiscoveryModelFactoryTest.php
+++ b/test/Model/DbAutodiscoveryModelFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\Apigility\Admin\Model\DbAutodiscoveryModel;
@@ -27,7 +27,8 @@ class DbAutodiscoveryModelFactoryTest extends TestCase
 
         $this->container->has('config')->willReturn(false);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'config service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('config service is not present');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/DbConnectedRestServiceModelTest.php
+++ b/test/Model/DbConnectedRestServiceModelTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use BarConf;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Zend\Config\Writer\PhpArray;
 use Zend\EventManager\Event;

--- a/test/Model/DoctrineAdapterEntityTest.php
+++ b/test/Model/DoctrineAdapterEntityTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\DoctrineAdapterEntity;
 
 class DoctrineAdapterEntityTest extends TestCase

--- a/test/Model/DoctrineAdapterModelFactoryTest.php
+++ b/test/Model/DoctrineAdapterModelFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\Config\Writer\WriterInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -29,7 +29,8 @@ class DoctrineAdapterModelFactoryTest extends TestCase
 
         $this->container->has('config')->willReturn(false);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'config service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('config service is not present');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/DoctrineAdapterModelTest.php
+++ b/test/Model/DoctrineAdapterModelTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\DoctrineAdapterModel;
 use ZF\Configuration\ConfigResource;
 
@@ -14,7 +14,7 @@ class DoctrineAdapterModelTest extends TestCase
 {
     public function getMockWriter()
     {
-        return $this->getMock('Zend\Config\Writer\WriterInterface');
+        return $this->createMock('Zend\Config\Writer\WriterInterface');
     }
 
     public function getGlobalConfig()

--- a/test/Model/DoctrineAdapterResourceFactoryTest.php
+++ b/test/Model/DoctrineAdapterResourceFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -28,10 +28,8 @@ class DoctrineAdapterResourceFactoryTest extends TestCase
         $factory = new DoctrineAdapterResourceFactory();
         $this->container->has(DoctrineAdapterModel::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            DoctrineAdapterModel::class . ' service is not present'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage(DoctrineAdapterModel::class . ' service is not present');
 
         $factory($this->container->reveal());
     }

--- a/test/Model/DocumentationModelTest.php
+++ b/test/Model/DocumentationModelTest.php
@@ -6,11 +6,12 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\WriterInterface;
 use ZF\Apigility\Admin\Model\DocumentationModel;
 use ZF\Configuration\ResourceFactory;
 
-class DocumentationModelTest extends \PHPUnit_Framework_TestCase
+class DocumentationModelTest extends TestCase
 {
     protected $actualDocData;
 
@@ -20,14 +21,11 @@ class DocumentationModelTest extends \PHPUnit_Framework_TestCase
     {
         $this->actualDocData = include __DIR__ . '/TestAsset/module/Doc/config/documentation.config.php';
 
-        $mockModuleUtils = $this->getMock(
-            'ZF\Configuration\ModuleUtils',
-            ['getModuleConfigPath'],
-            [],
-            '',
-            false
-        );
-        $mockModuleUtils->expects($this->any())
+        $mockModuleUtils = $this->getMockBuilder('ZF\Configuration\ModuleUtils')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockModuleUtils
+            ->expects($this->any())
             ->method('getModuleConfigPath')
             ->will($this->returnValue(__DIR__ . '/TestAsset/module/Doc/config/module.config.php'));
 

--- a/test/Model/FiltersModelTest.php
+++ b/test/Model/FiltersModelTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Filter\FilterPluginManager;
 use ZF\Apigility\Admin\Model\FiltersModel;
 

--- a/test/Model/InputFilterModelTest.php
+++ b/test/Model/InputFilterModelTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\InputFilterModel;
 use ZF\Configuration\ModuleUtils;

--- a/test/Model/ModuleEntityTest.php
+++ b/test/Model/ModuleEntityTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\ModuleEntity;
 
 class ModuleEntityTest extends TestCase

--- a/test/Model/ModuleModelFactoryTest.php
+++ b/test/Model/ModuleModelFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -32,7 +32,8 @@ class ModuleModelFactoryTest extends TestCase
 
         $this->container->has('ModuleManager')->willReturn(false);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'ModuleManager service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('ModuleManager service is not present');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/ModuleModelTest.php
+++ b/test/Model/ModuleModelTest.php
@@ -6,9 +6,9 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
-use ZF\Apigility\Admin\Model\ModuleModel;
+use PHPUnit\Framework\TestCase;
 use Test;
+use ZF\Apigility\Admin\Model\ModuleModel;
 use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Configuration\ModuleUtils;
 
@@ -486,7 +486,9 @@ class ModuleModelTest extends TestCase
 
         $this->assertTrue($this->model->createModule($module, $pathSpec));
 
-        $this->setExpectedException('Exception', 'exists', 409);
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('exists');
+        $this->expectExceptionCode(409);
 
         $this->model->createModule($module, $pathSpec);
     }

--- a/test/Model/ModulePathSpecFactoryTest.php
+++ b/test/Model/ModulePathSpecFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Apigility\Admin\Model\ModulePathSpecFactory;
@@ -26,7 +26,8 @@ class ModulePathSpecFactoryTest extends TestCase
 
         $this->container->has(ModuleUtils::class)->willReturn(false);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, ModuleUtils::class . ' service is not present');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage(ModuleUtils::class . ' service is not present');
         $factory($this->container->reveal());
     }
 
@@ -44,7 +45,8 @@ class ModulePathSpecFactoryTest extends TestCase
             ],
         ]);
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'Invalid module path');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('Invalid module path');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/ModulePathSpecTest.php
+++ b/test/Model/ModulePathSpecTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\ModulePathSpec;
 
 class ModulePathSpecTest extends TestCase

--- a/test/Model/ModuleResourceFactoryTest.php
+++ b/test/Model/ModuleResourceFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\ModuleModel;
 use ZF\Apigility\Admin\Model\ModulePathSpec;
 use ZF\Apigility\Admin\Model\ModuleResource;

--- a/test/Model/ModuleResourceTest.php
+++ b/test/Model/ModuleResourceTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ZF\Apigility\Admin\Model\ModuleModel;
 use ZF\Apigility\Admin\Model\ModulePathSpec;

--- a/test/Model/ModuleVersioningModelFactoryFactoryTest.php
+++ b/test/Model/ModuleVersioningModelFactoryFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Configuration\ConfigResourceFactory;
 use ZF\Configuration\ResourceFactory;
@@ -48,7 +48,8 @@ class ModuleVersioningModelFactoryFactoryTest extends TestCase
             $this->container->has($dependency)->willReturn($presence);
         }
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'missing one or more dependencies');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing one or more dependencies');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/RestServiceModelFactoryFactoryTest.php
+++ b/test/Model/RestServiceModelFactoryFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\EventManager\SharedEventManagerInterface;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -81,7 +81,8 @@ class RestServiceModelFactoryFactoryTest extends TestCase
             $this->container->has($dependency)->willReturn($presence);
         }
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'missing one or more dependencies');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing one or more dependencies');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/RestServiceModelTest.php
+++ b/test/Model/RestServiceModelTest.php
@@ -8,7 +8,7 @@ namespace ZFTest\Apigility\Admin\Model;
 
 use BarConf;
 use BazConf;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\ModuleEntity;
@@ -126,7 +126,7 @@ class RestServiceModelTest extends TestCase
 
     public function testRejectInvalidRestServiceName1()
     {
-        $this->setExpectedException('ZF\Rest\Exception\CreationException');
+        $this->expectException('ZF\Rest\Exception\CreationException');
         $restServiceEntity = new NewRestServiceEntity();
         $restServiceEntity->exchangeArray(['servicename' => 'Foo Bar']);
         $this->codeRest->createService($restServiceEntity);
@@ -134,7 +134,7 @@ class RestServiceModelTest extends TestCase
 
     public function testRejectInvalidRestServiceName2()
     {
-        $this->setExpectedException('ZF\Rest\Exception\CreationException');
+        $this->expectException('ZF\Rest\Exception\CreationException');
         $restServiceEntity = new NewRestServiceEntity();
         $restServiceEntity->exchangeArray(['serivcename' => 'Foo:Bar']);
         $this->codeRest->createService($restServiceEntity);
@@ -142,7 +142,7 @@ class RestServiceModelTest extends TestCase
 
     public function testRejectInvalidRestServiceName3()
     {
-        $this->setExpectedException('ZF\Rest\Exception\CreationException');
+        $this->expectException('ZF\Rest\Exception\CreationException');
         $restServiceEntity = new NewRestServiceEntity();
         $restServiceEntity->exchangeArray(['servicename' => 'Foo/Bar']);
         $this->codeRest->createService($restServiceEntity);
@@ -723,7 +723,9 @@ class RestServiceModelTest extends TestCase
         $fooPath = __DIR__ . '/TestAsset/module/BarConf/src/BarConf/V1/Rest/Foo';
         $this->assertTrue(file_exists($fooPath));
 
-        $this->setExpectedException('ZF\Apigility\Admin\Exception\RuntimeException', 'find', 404);
+        $this->expectException('ZF\Apigility\Admin\Exception\RuntimeException');
+        $this->expectExceptionMessage('find');
+        $this->expectExceptionCode(404);
         $this->codeRest->fetch($service->controllerServiceName);
     }
 
@@ -750,7 +752,9 @@ class RestServiceModelTest extends TestCase
         $fooPath = __DIR__ . '/TestAsset/module/BazConf/src/V1/Rest/Foo';
         $this->assertTrue(file_exists($fooPath));
 
-        $this->setExpectedException('ZF\Apigility\Admin\Exception\RuntimeException', 'find', 404);
+        $this->expectException('ZF\Apigility\Admin\Exception\RuntimeException');
+        $this->expectExceptionMessage('find');
+        $this->expectExceptionCode(404);
         $this->codeRest->fetch($service->controllerServiceName);
     }
 

--- a/test/Model/RestServiceResourceFactoryTest.php
+++ b/test/Model/RestServiceResourceFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\DocumentationModel;
 use ZF\Apigility\Admin\Model\InputFilterModel;
@@ -28,10 +28,8 @@ class RestServiceResourceFactoryTest extends TestCase
 
         $this->container->has(RestServiceModelFactory::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            'missing its ' . RestServiceModelFactory::class. ' dependency'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing its ' . RestServiceModelFactory::class. ' dependency');
         $factory($this->container->reveal());
     }
 
@@ -42,10 +40,8 @@ class RestServiceResourceFactoryTest extends TestCase
         $this->container->has(RestServiceModelFactory::class)->willReturn(true);
         $this->container->has(InputFilterModel::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            'missing its ' . InputFilterModel::class. ' dependency'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing its ' . InputFilterModel::class. ' dependency');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/RestServiceResourceTest.php
+++ b/test/Model/RestServiceResourceTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use BarConf;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Zend\Config\Writer\PhpArray;
 use Zend\EventManager\SharedEventManager;

--- a/test/Model/RpcServiceModelFactoryFactoryTest.php
+++ b/test/Model/RpcServiceModelFactoryFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\EventManager\SharedEventManagerInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\ModuleModel;
@@ -71,7 +71,8 @@ class RpcServiceModelFactoryFactoryTest extends TestCase
             $this->container->has($dependency)->willReturn($presence);
         }
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'missing one or more dependencies');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing one or more dependencies');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/RpcServiceModelTest.php
+++ b/test/Model/RpcServiceModelTest.php
@@ -8,7 +8,7 @@ namespace ZFTest\Apigility\Admin\Model;
 
 use BazConf;
 use FooConf;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\ModuleEntity;
@@ -100,7 +100,7 @@ class RpcServiceModelTest extends TestCase
         /**
          * @todo define exception in Rpc namespace
          */
-        $this->setExpectedException('ZF\Rest\Exception\CreationException');
+        $this->expectException('ZF\Rest\Exception\CreationException');
         $this->codeRpc->createService('Foo Bar', 'route', []);
     }
 
@@ -109,7 +109,7 @@ class RpcServiceModelTest extends TestCase
         /**
          * @todo define exception in Rpc namespace
         */
-        $this->setExpectedException('ZF\Rest\Exception\CreationException');
+        $this->expectException('ZF\Rest\Exception\CreationException');
         $this->codeRpc->createService('Foo:Bar', 'route', []);
     }
 
@@ -118,7 +118,7 @@ class RpcServiceModelTest extends TestCase
         /**
          * @todo define exception in Rpc namespace
         */
-        $this->setExpectedException('ZF\Rest\Exception\CreationException');
+        $this->expectException('ZF\Rest\Exception\CreationException');
         $this->codeRpc->createService('Foo/Bar', 'route', []);
     }
 

--- a/test/Model/RpcServiceResourceFactoryTest.php
+++ b/test/Model/RpcServiceResourceFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Controller\ControllerManager;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Apigility\Admin\Model\DocumentationModel;
@@ -29,10 +29,8 @@ class RpcServiceResourceFactoryTest extends TestCase
 
         $this->container->has(RpcServiceModelFactory::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            'missing its ' . RpcServiceModelFactory::class. ' dependency'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing its ' . RpcServiceModelFactory::class. ' dependency');
         $factory($this->container->reveal());
     }
 
@@ -43,10 +41,8 @@ class RpcServiceResourceFactoryTest extends TestCase
         $this->container->has(RpcServiceModelFactory::class)->willReturn(true);
         $this->container->has(InputFilterModel::class)->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            'missing its ' . InputFilterModel::class. ' dependency'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing its ' . InputFilterModel::class. ' dependency');
         $factory($this->container->reveal());
     }
 
@@ -58,10 +54,8 @@ class RpcServiceResourceFactoryTest extends TestCase
         $this->container->has(InputFilterModel::class)->willReturn(true);
         $this->container->has('ControllerManager')->willReturn(false);
 
-        $this->setExpectedException(
-            ServiceNotCreatedException::class,
-            'missing its ControllerManager dependency'
-        );
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing its ControllerManager dependency');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/ValidatorMetadataModelTest.php
+++ b/test/Model/ValidatorMetadataModelTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZF\Apigility\Admin\Model\ValidatorMetadataModel;
 
 class ValidatorMetadataModelTest extends TestCase

--- a/test/Model/ValidatorsModelTest.php
+++ b/test/Model/ValidatorsModelTest.php
@@ -7,7 +7,7 @@
 namespace ZFTest\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Validator\ValidatorPluginManager;
 use ZF\Apigility\Admin\Model\ValidatorMetadataModel;
 use ZF\Apigility\Admin\Model\ValidatorsModel;

--- a/test/Model/VersioningModelFactoryFactoryTest.php
+++ b/test/Model/VersioningModelFactoryFactoryTest.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Admin\Model;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use ZF\Configuration\ConfigResourceFactory;
 use ZF\Configuration\ResourceFactory;
@@ -48,7 +48,8 @@ class VersioningModelFactoryFactoryTest extends TestCase
             $this->container->has($dependency)->willReturn($presence);
         }
 
-        $this->setExpectedException(ServiceNotCreatedException::class, 'missing one or more dependencies');
+        $this->expectException(ServiceNotCreatedException::class);
+        $this->expectExceptionMessage('missing one or more dependencies');
         $factory($this->container->reveal());
     }
 

--- a/test/Model/VersioningModelTest.php
+++ b/test/Model/VersioningModelTest.php
@@ -6,7 +6,7 @@
 
 namespace ZFTest\Apigility\Admin\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Config\Writer\PhpArray;
 use ZF\Apigility\Admin\Model\VersioningModel;
 use ZF\Configuration\ConfigResource;


### PR DESCRIPTION
The last few fixes were for PHP 7.2 support, but we had no 7.2 or 7.1 jobs on Travis.

This patch updates the CI suite to add 7.1 and 7.2 jobs, and upgrades PHPUnit to 5.7/6.5 so that we can actually run it on PHP 7.1 and later. This required minor updates to the test suite to make it compatible:

- Use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`
- Replace `setExpectedException()` calls with combination of `expectException()` and (if needed) `expectExceptionMessage()` and `expectExceptionCode()`.
- Do not use `getMock()` directly; use `createMock()` or `getMockBuilder()` + `getMock()`.