### PR TITLE
[wip] zf-configuration patchKey fix

### DIFF
--- a/src/Model/ContentNegotiationModel.php
+++ b/src/Model/ContentNegotiationModel.php
@@ -33,7 +33,7 @@ class ContentNegotiationModel
     public function create($name, array $contentConfig)
     {
         $key = 'zf-content-negotiation.selectors.' . $name;
-        $this->globalConfig->patchKey($key, $contentConfig);
+        $this->globalConfig->replaceKey($key, $contentConfig);
         return new ContentNegotiationEntity($name, $contentConfig);
     }
 

--- a/src/Model/RestServiceModel.php
+++ b/src/Model/RestServiceModel.php
@@ -830,7 +830,7 @@ class RestServiceModel implements EventManagerAwareInterface
 
         foreach ($this->restArrayUpdateOptions as $property => $configKey) {
             $key = sprintf('zf-rest.%s.%s', $original->controllerServiceName, $configKey);
-            $this->configResource->patchKey($key, $update->$property);
+            $this->configResource->replaceKey($key, $update->$property);
         }
     }
 
@@ -847,7 +847,7 @@ class RestServiceModel implements EventManagerAwareInterface
 
         if ($update->selector) {
             $key = $baseKey . 'controllers.' . $service;
-            $this->configResource->patchKey($key, $update->selector);
+            $this->configResource->replaceKey($key, $update->selector);
         }
 
         // Array dereferencing is a PITA
@@ -856,7 +856,7 @@ class RestServiceModel implements EventManagerAwareInterface
             && ! empty($acceptWhitelist)
         ) {
             $key = $baseKey . 'accept_whitelist.' . $service;
-            $this->configResource->patchKey($key, $acceptWhitelist);
+            $this->configResource->replaceKey($key, $acceptWhitelist);
         }
 
         $contentTypeWhitelist = $update->contentTypeWhitelist;
@@ -864,7 +864,7 @@ class RestServiceModel implements EventManagerAwareInterface
             && ! empty($contentTypeWhitelist)
         ) {
             $key = $baseKey . 'content_type_whitelist.' . $service;
-            $this->configResource->patchKey($key, $contentTypeWhitelist);
+            $this->configResource->replaceKey($key, $contentTypeWhitelist);
         }
     }
 
@@ -1086,7 +1086,7 @@ class RestServiceModel implements EventManagerAwareInterface
         });
 
         $key = ['zf-versioning', 'uri'];
-        $this->configResource->patchKey($key, $versioning);
+        $this->configResource->replaceKey($key, $versioning);
     }
 
     /**

--- a/src/Model/RpcServiceModel.php
+++ b/src/Model/RpcServiceModel.php
@@ -623,7 +623,7 @@ class RpcServiceModel
         });
 
         $key = ['zf-versioning', 'uri'];
-        $this->configResource->patchKey($key, $versioning);
+        $this->configResource->replaceKey($key, $versioning);
     }
 
     /**

--- a/test/Model/DbAdapterModelTest.php
+++ b/test/Model/DbAdapterModelTest.php
@@ -151,7 +151,7 @@ class DbAdapterModelTest extends TestCase
         $model->create('Db\New', ['driver' => 'Pdo_Sqlite', 'database' => __FILE__]);
 
         $global = include $this->globalConfigPath;
-        $this->assertDbConfigEquals([], 'Db\Old', $global);
+        $this->assertDbConfigEquals($localSeedConfig['db']['adapters']['Db\Old'], 'Db\Old', $global);
         $this->assertDbConfigEquals([], 'Db\New', $global);
 
         $local  = include $this->localConfigPath;


### PR DESCRIPTION
This PR will require https://github.com/zfcampus/zf-configuration/pull/30
This is a fix for the incorrect, and now corrected, zf-configuration.  

The fix strategy is to change patchKey calls to replaceKey, but only where necessary.