### PR TITLE
add operation id to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#393](https://github.com/zfcampus/zf-apigility-admin/pull/393) adds the documentation key "identifier" to the `DocumentationModel` and allowed documentation keys; the key is used in conjunction with the API Blueprint "identifier" and Swagger "operationId" fields.
 
 ### Changed
 

--- a/src/InputFilter/DocumentationInputFilter.php
+++ b/src/InputFilter/DocumentationInputFilter.php
@@ -19,7 +19,7 @@ class DocumentationInputFilter extends InputFilter
      * @var array
      */
     protected $validHttpMethodDocumentationKeys = [
-        'operationId',
+        'identifier',
         'description',
         'request',
         'response',

--- a/src/InputFilter/DocumentationInputFilter.php
+++ b/src/InputFilter/DocumentationInputFilter.php
@@ -19,6 +19,7 @@ class DocumentationInputFilter extends InputFilter
      * @var array
      */
     protected $validHttpMethodDocumentationKeys = [
+        'operationId',
         'description',
         'request',
         'response',

--- a/src/Model/DocumentationModel.php
+++ b/src/Model/DocumentationModel.php
@@ -38,30 +38,30 @@ class DocumentationModel
                 return [
                     'collection' => [
                         'description' => null,
-                        'GET'    => ['description' => null, 'request' => null, 'response' => null],
-                        'POST'   => ['description' => null, 'request' => null, 'response' => null],
-                        'PUT'    => ['description' => null, 'request' => null, 'response' => null],
-                        'PATCH'  => ['description' => null, 'request' => null, 'response' => null],
-                        'DELETE' => ['description' => null, 'request' => null, 'response' => null],
+                        'GET'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'POST'   => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PUT'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PATCH'  => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'DELETE' => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
                     ],
                     'entity' => [
                         'description' => null,
-                        'GET'    => ['description' => null, 'request' => null, 'response' => null],
-                        'POST'   => ['description' => null, 'request' => null, 'response' => null],
-                        'PUT'    => ['description' => null, 'request' => null, 'response' => null],
-                        'PATCH'  => ['description' => null, 'request' => null, 'response' => null],
-                        'DELETE' => ['description' => null, 'request' => null, 'response' => null],
+                        'GET'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'POST'   => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PUT'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PATCH'  => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'DELETE' => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
                     ],
                     'description' => null,
                 ];
             case self::TYPE_RPC:
                 return [
                     'description' => null,
-                    'GET'    => ['description' => null, 'request' => null, 'response' => null],
-                    'POST'   => ['description' => null, 'request' => null, 'response' => null],
-                    'PUT'    => ['description' => null, 'request' => null, 'response' => null],
-                    'PATCH'  => ['description' => null, 'request' => null, 'response' => null],
-                    'DELETE' => ['description' => null, 'request' => null, 'response' => null],
+                    'GET'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'POST'   => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'PUT'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'PATCH'  => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'DELETE' => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
                 ];
         }
     }

--- a/src/Model/DocumentationModel.php
+++ b/src/Model/DocumentationModel.php
@@ -38,30 +38,30 @@ class DocumentationModel
                 return [
                     'collection' => [
                         'description' => null,
-                        'GET'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'POST'   => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'PUT'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'PATCH'  => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'DELETE' => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'GET'    => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'POST'   => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PUT'    => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PATCH'  => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'DELETE' => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
                     ],
                     'entity' => [
                         'description' => null,
-                        'GET'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'POST'   => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'PUT'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'PATCH'  => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                        'DELETE' => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'GET'    => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'POST'   => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PUT'    => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'PATCH'  => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                        'DELETE' => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
                     ],
                     'description' => null,
                 ];
             case self::TYPE_RPC:
                 return [
                     'description' => null,
-                    'GET'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                    'POST'   => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                    'PUT'    => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                    'PATCH'  => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
-                    'DELETE' => ['operationId' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'GET'    => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'POST'   => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'PUT'    => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'PATCH'  => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
+                    'DELETE' => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
                 ];
         }
     }

--- a/src/Model/DocumentationModel.php
+++ b/src/Model/DocumentationModel.php
@@ -33,6 +33,8 @@ class DocumentationModel
 
     public function getSchemaTemplate($type = self::TYPE_REST)
     {
+        // phpcs:disable
+        // @codingStandardsIgnoreStart
         switch ($type) {
             case self::TYPE_REST:
                 return [
@@ -64,6 +66,8 @@ class DocumentationModel
                     'DELETE' => ['identifier' => null, 'description' => null, 'request' => null, 'response' => null],
                 ];
         }
+        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     public function fetchDocumentation($module, $controllerServiceName)


### PR DESCRIPTION
I added this field to be able to personalized methods of the sdks generated with swagger-codegen and zf-apigility-documentation-swagger.