### PR TITLE
Use realpath to get modules. Fixes packaging on IBM i.

### DIFF
--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -194,9 +194,9 @@ class PackageController extends AbstractActionController
 
         $modules = array_map(
             function ($entry) {
-                return substr($entry, 7);
+                return basename($entry);
             },
-            glob('module/*', GLOB_ONLYDIR)
+            glob(realpath('module') . '/*', GLOB_ONLYDIR)
         );
 
         $toInclude = [];


### PR DESCRIPTION
When trying to package APIs on IBM i, there is an issue with the `glob()` method. `glob()` on IBM i needs the full path and not a relative one. To fix this, I use `realpath()` and `basename()`.